### PR TITLE
Add CSV export support to Fubon statement workflows

### DIFF
--- a/.agents/skills/libretto-download-csv/SKILL.md
+++ b/.agents/skills/libretto-download-csv/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: libretto-download-csv
+description: Add automatic CSV conversion to Libretto browser automation workflows after downloads. Use when creating or editing a workflow that downloads XLS, XLSX, Excel-labeled HTML tables, TXT/CSV-like statement files, bank statements, loan statements, reports, or other tabular exports and the user wants future runs to save CSV output automatically.
+---
+
+# Libretto Download CSV
+
+## Workflow
+
+Use this skill together with the repo's `libretto` skill when editing production workflow files. Keep the browser automation behavior unchanged unless conversion requires a different download format.
+
+1. Identify the download function and output schema.
+2. Preserve the original downloaded file path and byte count unless the user explicitly asks to replace it.
+3. Add CSV output next to the downloaded file, using the same base path with a `.csv` extension.
+4. Return CSV metadata from the workflow result, usually `csvPath` and `csvBytes`.
+5. Run `npm run typecheck`.
+6. If possible, validate the converter with a local sample file without replaying authenticated browser steps.
+
+## Excel Downloads
+
+Prefer an existing spreadsheet parser dependency if one is already installed. In this repo, use `xlsx` for `.xls`, `.xlsx`, and `.xls` files that are actually HTML tables.
+
+Use default import in this ESM/NodeNext project:
+
+```ts
+import XLSX from "xlsx";
+```
+
+Avoid `import * as XLSX from "xlsx"` here because runtime access to `readFile` fails under this project's ESM execution.
+
+Use this helper shape:
+
+```ts
+function csvPathFor(path: string): string {
+  const csvPath = path.replace(/\.[^/.]+$/, ".csv");
+  return csvPath === path ? `${path}.csv` : csvPath;
+}
+
+async function convertXlsToCsv(path: string) {
+  const workbook = XLSX.readFile(path);
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) {
+    throw new Error(`Downloaded Excel file has no worksheets: ${path}`);
+  }
+
+  const worksheet = workbook.Sheets[sheetName];
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const csvPath = csvPathFor(path);
+  await writeFile(csvPath, csv.endsWith("\n") ? csv : `${csv}\n`, "utf8");
+
+  const csvStat = await stat(csvPath);
+  return { csvPath, csvBytes: csvStat.size };
+}
+```
+
+Call it only for Excel download formats unless the user asks for CSV conversion of every format:
+
+```ts
+const fileStat = await stat(path);
+const converted =
+  downloadFormat === "EXCEL" ? await convertXlsToCsv(path) : undefined;
+return { filename, path, bytes: fileStat.size, ...converted };
+```
+
+Update the Zod output schema with optional CSV fields so non-Excel formats remain valid:
+
+```ts
+csvPath: z.string().optional(),
+csvBytes: z.number().int().nonnegative().optional(),
+```
+
+## Plain Text Or CSV-Like Downloads
+
+When the site downloads TXT or CSV-like data instead of Excel, do not add `xlsx` just to rewrite text. Read the file as text, normalize line endings if useful, and write a `.csv` sibling file with explicit UTF-8 encoding. Preserve the original file metadata and add `csvPath/csvBytes`.
+
+## Dependency Notes
+
+If `xlsx` is not installed and Excel parsing is required, add it to `dependencies` and update the lockfile with the repo's package manager. Mention any audit findings in the final response, especially when the parser has no patched npm release.

--- a/.agents/skills/libretto-download-csv/agents/openai.yaml
+++ b/.agents/skills/libretto-download-csv/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Libretto Download CSV"
+  short_description: "Convert workflow downloads to CSV"
+  default_prompt: "Use $libretto-download-csv to add CSV conversion for a Libretto workflow download."

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npm run libretto:close-all
 
 | Bank   | Records                                                                         | Command                                          | Output                                          |
 | ------ | ------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
+| Fubon  | Deposit, credit card, and loan statements in one login session                  | `npm run run:fubon-all-statements`               | `downloads/fubon-*/`                            |
 | Fubon  | Deposit statements                                                              | `npm run run:fubon-statements`                   | `downloads/fubon-statements/`                   |
 | Fubon  | Credit card statements and unbilled details                                     | `npm run run:fubon-credit-card-statements`       | `downloads/fubon-credit-card-statements/`       |
 | Fubon  | Loan statements                                                                 | `npm run run:fubon-loan-statements`              | `downloads/fubon-loan-statements/`              |
@@ -133,13 +134,33 @@ LIBRETTO_CLOUD_CATHAY_PASSWORD=
 
 ## Workflow Details
 
+### Fubon All Statements
+
+```bash
+npm run run:fubon-all-statements
+```
+
+Logs in to Fubon once, then runs the deposit, credit card, and loan workflows in the same browser session. This avoids repeating CAPTCHA/OTP for the three separate Fubon workflows. Output is grouped in the workflow result as `statements`, `creditCards`, and `loans`; files are still written to the same per-workflow folders:
+
+- `downloads/fubon-statements/`
+- `downloads/fubon-credit-card-statements/`
+- `downloads/fubon-loan-statements/`
+
+The nested params match the original workflow params:
+
+```bash
+npx libretto run src/workflows/fubon-all-statements.ts --headed --params '{"statements":{"dateRanges":["180","180_365"],"downloadFormat":"EXCEL"},"creditCards":{"periodOffsets":[1,2,3,4,5,6]},"loans":{"quickMonths":"6","downloadFormat":"EXCEL"}}'
+```
+
+For Fubon deposit and loan `EXCEL` downloads, the workflow keeps the original bank file and also writes a sibling `.csv` file. The result metadata includes the original `path`/`bytes` plus `csvPath`/`csvBytes`.
+
 ### Fubon Deposit Statements
 
 ```bash
 npm run run:fubon-statements
 ```
 
-Downloads the past year by running both bank ranges, `180` and `180_365`, because the bank UI limits each query to roughly six months. The workflow saves one file per account per range and does not print statement rows to stdout.
+Downloads the past year by running both bank ranges, `180` and `180_365`, because the bank UI limits each query to roughly six months. The workflow saves one file per account per range and does not print statement rows to stdout. For `EXCEL` downloads, it also writes a sibling `.csv` file and returns `csvPath`/`csvBytes`.
 
 ### Fubon Credit Card Statements
 
@@ -162,6 +183,10 @@ npm run run:fubon-loan-statements
 ```
 
 Selects every available loan account, runs all discovered loan query items for `近六個月`, downloads `EXCEL`, and returns file metadata only.
+
+Some loan accounts expose only a subset of the query item options. By default, the workflow reads the visible options for each account and runs only the available query items, avoiding long `selectOption` timeouts for unavailable items. If you explicitly pass `queryItem` or `queryItems`, unavailable items are reported in `skippedAccounts`.
+
+For `EXCEL` downloads, the workflow keeps the original bank file and also writes a sibling `.csv` file with `csvPath`/`csvBytes` in the output metadata.
 
 Optional filters and date ranges:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^2.0.0",
         "libretto": "^0.6.31",
+        "xlsx": "^0.18.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -604,6 +605,15 @@
         "node": ">= 20"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/affordance": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/affordance/-/affordance-0.2.1.tgz",
@@ -660,6 +670,40 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -708,6 +752,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -834,6 +887,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tsx": {
@@ -1345,6 +1410,45 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "libretto:close-all": "libretto close --all",
     "run:example": "libretto run src/workflows/scrape-page.ts --headless",
     "run:fubon-statements": "libretto run src/workflows/fubon-statements.ts --headed",
+    "run:fubon-all-statements": "libretto run src/workflows/fubon-all-statements.ts --headed",
     "run:fubon-credit-card-statements": "libretto run src/workflows/fubon-credit-card-statements.ts --headed",
     "run:fubon-loan-statements": "libretto run src/workflows/fubon-loan-statements.ts --headed",
     "run:yuanta-statements": "libretto run src/workflows/yuanta-statements.ts --headed",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^2.0.0",
     "libretto": "^0.6.31",
+    "xlsx": "^0.18.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/workflows/fubon-all-statements.ts
+++ b/src/workflows/fubon-all-statements.ts
@@ -1,0 +1,78 @@
+import { workflow, type LibrettoWorkflowContext } from "libretto";
+import { z } from "zod";
+import {
+  fubonCreditCardStatementsInputSchema,
+  fubonCreditCardStatementsOutputSchema,
+  runFubonCreditCardStatements,
+} from "./fubon-credit-card-statements.js";
+import {
+  fubonLoanStatementsInputSchema,
+  fubonLoanStatementsOutputSchema,
+  runFubonLoanStatements,
+} from "./fubon-loan-statements.js";
+import {
+  type FubonCredentials,
+  fubonStatementsInputSchema,
+  fubonStatementsOutputSchema,
+  runFubonStatements,
+  signInFubon,
+} from "./fubon-statements.js";
+
+const inputSchema = z.object({
+  statements: fubonStatementsInputSchema.default(() =>
+    fubonStatementsInputSchema.parse({}),
+  ),
+  creditCards: fubonCreditCardStatementsInputSchema.default(() =>
+    fubonCreditCardStatementsInputSchema.parse({}),
+  ),
+  loans: fubonLoanStatementsInputSchema.default(() =>
+    fubonLoanStatementsInputSchema.parse({}),
+  ),
+});
+
+const outputSchema = z.object({
+  statements: fubonStatementsOutputSchema,
+  creditCards: fubonCreditCardStatementsOutputSchema,
+  loans: fubonLoanStatementsOutputSchema,
+});
+
+type Input = z.infer<typeof inputSchema> & {
+  credentials: FubonCredentials;
+};
+
+export default workflow("fubonAllStatements", {
+  credentials: ["fubon_user_id", "fubon_account", "fubon_password"],
+  input: inputSchema,
+  output: outputSchema,
+  handler: async (ctx: LibrettoWorkflowContext, rawInput) => {
+    const input = rawInput as Input;
+    const { page, session } = ctx;
+
+    page.on("dialog", async (dialog) => {
+      console.warn("bank-dialog", { type: dialog.type() });
+      await dialog.accept();
+    });
+
+    await signInFubon(page, session, input.credentials);
+
+    console.log("combined-workflow-section-start", { section: "statements" });
+    const statements = await runFubonStatements(page, input.statements);
+
+    console.log("combined-workflow-section-start", {
+      section: "creditCards",
+    });
+    const creditCards = await runFubonCreditCardStatements(
+      page,
+      input.creditCards,
+    );
+
+    console.log("combined-workflow-section-start", { section: "loans" });
+    const loans = await runFubonLoanStatements(page, input.loans);
+
+    return {
+      statements,
+      creditCards,
+      loans,
+    };
+  },
+});

--- a/src/workflows/fubon-credit-card-statements.ts
+++ b/src/workflows/fubon-credit-card-statements.ts
@@ -45,6 +45,14 @@ const outputSchema = z.object({
   }),
 });
 
+export {
+  inputSchema as fubonCreditCardStatementsInputSchema,
+  outputSchema as fubonCreditCardStatementsOutputSchema,
+};
+
+export type FubonCreditCardStatementsInput = z.infer<typeof inputSchema>;
+export type FubonCreditCardStatementsOutput = z.infer<typeof outputSchema>;
+
 const periodTabs = [
   { offset: 1, label: "本期" },
   { offset: 2, label: "前一期" },
@@ -270,6 +278,23 @@ async function clickLinkByClassOrText(
   throw new Error(`Could not find link "${text}".`);
 }
 
+async function openCreditCardFunctionPage(
+  page: Page,
+  classSelector: string,
+  text: string,
+): Promise<void> {
+  try {
+    await clickLinkByClassOrText(page, classSelector, text, 5_000);
+    return;
+  } catch {
+    // The combined workflow may be sitting in another product area after login.
+  }
+
+  const headerFrame = await waitForFrame(page, "frame1");
+  await headerFrame.locator("#menu_CCC").click({ force: true });
+  await clickLinkByClassOrText(page, classSelector, text);
+}
+
 async function fillCreditCardLoginForm(
   page: Page,
   credentials: FubonCredentials,
@@ -323,7 +348,7 @@ async function waitForSignedInState(page: Page): Promise<void> {
 }
 
 async function openStatementDetailsPage(page: Page): Promise<BrowserScope> {
-  await clickLinkByClassOrText(
+  await openCreditCardFunctionPage(
     page,
     "task_CCCQU003.menu_CCC0202",
     "帳單明細查詢",
@@ -342,7 +367,7 @@ async function openStatementDetailsPage(page: Page): Promise<BrowserScope> {
 }
 
 async function openUnbilledDetailsPage(page: Page): Promise<BrowserScope> {
-  await clickLinkByClassOrText(
+  await openCreditCardFunctionPage(
     page,
     "task_CCCQU004.menu_CCC0203",
     "未出帳單消費明細",
@@ -530,6 +555,60 @@ async function readUnbilledRows(
   return details;
 }
 
+export async function runFubonCreditCardStatements(
+  page: Page,
+  input: FubonCreditCardStatementsInput,
+): Promise<FubonCreditCardStatementsOutput> {
+  await openStatementDetailsPage(page);
+
+  const statementRows: CsvRow[] = [];
+  const statementPeriods: string[] = [];
+  for (const periodOffset of input.periodOffsets) {
+    const scope = await selectStatementPeriod(page, periodOffset);
+    const periodLabel = await readStatementPeriodLabel(scope);
+    statementPeriods.push(periodLabel);
+    statementRows.push(
+      ...(await readStatementRows(
+        scope,
+        periodLabel,
+        input.statementCardLabels,
+      )),
+    );
+  }
+
+  const unbilledScope = await openUnbilledDetailsPage(page);
+  const unbilledRows = await readUnbilledRows(
+    unbilledScope,
+    input.unbilledCardNumbers,
+  );
+
+  const statementDetails = await writeCsv(
+    "statement-details.csv",
+    statementRows,
+    statementHeaders,
+  );
+  const unbilledDetails = await writeCsv(
+    "unbilled-details.csv",
+    unbilledRows,
+    unbilledHeaders,
+  );
+
+  return {
+    periodOffsets: input.periodOffsets,
+    statementPeriods,
+    statementCards: unique(
+      statementRows.map((row) => row.card_label).filter(Boolean),
+    ),
+    unbilledCards: unique(
+      unbilledRows.map((row) => row.card_number).filter(Boolean),
+    ),
+    csvFiles: {
+      statementDetails,
+      unbilledDetails,
+    },
+  };
+}
+
 export default workflow("fubonCreditCardStatements", {
   credentials: ["fubon_user_id", "fubon_account", "fubon_password"],
   input: inputSchema,
@@ -571,54 +650,6 @@ export default workflow("fubonCreditCardStatements", {
     }
 
     await waitForSignedInState(page);
-
-    await openStatementDetailsPage(page);
-
-    const statementRows: CsvRow[] = [];
-    const statementPeriods: string[] = [];
-    for (const periodOffset of input.periodOffsets) {
-      const scope = await selectStatementPeriod(page, periodOffset);
-      const periodLabel = await readStatementPeriodLabel(scope);
-      statementPeriods.push(periodLabel);
-      statementRows.push(
-        ...(await readStatementRows(
-          scope,
-          periodLabel,
-          input.statementCardLabels,
-        )),
-      );
-    }
-
-    const unbilledScope = await openUnbilledDetailsPage(page);
-    const unbilledRows = await readUnbilledRows(
-      unbilledScope,
-      input.unbilledCardNumbers,
-    );
-
-    const statementDetails = await writeCsv(
-      "statement-details.csv",
-      statementRows,
-      statementHeaders,
-    );
-    const unbilledDetails = await writeCsv(
-      "unbilled-details.csv",
-      unbilledRows,
-      unbilledHeaders,
-    );
-
-    return {
-      periodOffsets: input.periodOffsets,
-      statementPeriods,
-      statementCards: unique(
-        statementRows.map((row) => row.card_label).filter(Boolean),
-      ),
-      unbilledCards: unique(
-        unbilledRows.map((row) => row.card_number).filter(Boolean),
-      ),
-      csvFiles: {
-        statementDetails,
-        unbilledDetails,
-      },
-    };
+    return await runFubonCreditCardStatements(page, input);
   },
 });

--- a/src/workflows/fubon-loan-statements.ts
+++ b/src/workflows/fubon-loan-statements.ts
@@ -1,7 +1,8 @@
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { pause, workflow, type LibrettoWorkflowContext } from "libretto";
 import type { Frame, Locator, Page } from "playwright";
+import XLSX from "xlsx";
 import { z } from "zod";
 
 const BANK_ENTRY_URL =
@@ -62,6 +63,8 @@ const outputSchema = z.object({
       filename: z.string(),
       path: z.string(),
       bytes: z.number().int().nonnegative(),
+      csvPath: z.string().optional(),
+      csvBytes: z.number().int().nonnegative().optional(),
     }),
   ),
   skippedAccounts: z.array(
@@ -96,6 +99,27 @@ function digitsOnly(value: string): string {
 
 function safeFilename(filename: string): string {
   return filename.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function csvPathFor(path: string): string {
+  const csvPath = path.replace(/\.[^/.]+$/, ".csv");
+  return csvPath === path ? `${path}.csv` : csvPath;
+}
+
+async function convertXlsToCsv(path: string) {
+  const workbook = XLSX.readFile(path);
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) {
+    throw new Error(`Downloaded Excel file has no worksheets: ${path}`);
+  }
+
+  const worksheet = workbook.Sheets[sheetName];
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const csvPath = csvPathFor(path);
+  await writeFile(csvPath, csv.endsWith("\n") ? csv : `${csv}\n`, "utf8");
+
+  const csvStat = await stat(csvPath);
+  return { csvPath, csvBytes: csvStat.size };
 }
 
 function matchesFilter(value: string, filters: string[]): boolean {
@@ -478,7 +502,9 @@ async function downloadLoanStatement(
   await download.saveAs(path);
 
   const fileStat = await stat(path);
-  return { filename, path, bytes: fileStat.size };
+  const converted =
+    downloadFormat === "EXCEL" ? await convertXlsToCsv(path) : undefined;
+  return { filename, path, bytes: fileStat.size, ...converted };
 }
 
 export default workflow("fubonLoanStatements", {

--- a/src/workflows/fubon-loan-statements.ts
+++ b/src/workflows/fubon-loan-statements.ts
@@ -23,7 +23,9 @@ const queryItemSchema = z.enum([
   "DYNAMIC_BRANCH_DETAIL_QUERY",
 ]);
 
-const DEFAULT_QUERY_ITEMS: z.infer<typeof queryItemSchema>[] = [
+type QueryItem = z.infer<typeof queryItemSchema>;
+
+const DEFAULT_QUERY_ITEMS: QueryItem[] = [
   "TRANSACTION_DETAIL_QUERY",
   "PARTLY_PAID_TRANSACTION_DETAIL_QUERY",
   "DATES_DETAIL_QUERY",
@@ -75,6 +77,14 @@ const outputSchema = z.object({
     }),
   ),
 });
+
+export {
+  inputSchema as fubonLoanStatementsInputSchema,
+  outputSchema as fubonLoanStatementsOutputSchema,
+};
+
+export type FubonLoanStatementsInput = z.infer<typeof inputSchema>;
+export type FubonLoanStatementsOutput = z.infer<typeof outputSchema>;
 
 function requireCredential(
   credentials: FubonCredentials,
@@ -396,6 +406,16 @@ type LoanAccountOption = {
   value: string;
 };
 
+function requestedQueryItems(input: FubonLoanStatementsInput): QueryItem[] {
+  if (input.queryItems && input.queryItems.length > 0) return input.queryItems;
+  if (input.queryItem) return [input.queryItem];
+  return DEFAULT_QUERY_ITEMS;
+}
+
+function hasExplicitQueryItems(input: FubonLoanStatementsInput): boolean {
+  return Boolean(input.queryItem || (input.queryItems && input.queryItems.length > 0));
+}
+
 async function readLoanAccountOptions(
   scope: BrowserScope,
   filters: string[],
@@ -426,11 +446,9 @@ async function readLoanAccountOptions(
   return result;
 }
 
-async function configureLoanQuery(
+async function selectLoanAccount(
   page: Page,
   account: LoanAccountOption,
-  input: z.infer<typeof inputSchema>,
-  queryItem: z.infer<typeof queryItemSchema>,
 ): Promise<BrowserScope> {
   let scope = await findScopeWithSelector(page, "#form1\\:loanAccountCombo");
   await waitForNoVisibleBankMask(page);
@@ -440,7 +458,44 @@ async function configureLoanQuery(
     .selectOption(account.value, { force: true });
   await waitForNoVisibleBankMask(page);
 
-  scope = await findScopeWithSelector(page, "#form1\\:queryItemCombo");
+  return await findScopeWithSelector(page, "#form1\\:queryItemCombo");
+}
+
+async function readAvailableLoanQueryItems(
+  scope: BrowserScope,
+): Promise<QueryItem[]> {
+  const combo = scope.locator("#form1\\:queryItemCombo");
+  await combo.locator("option").first().waitFor({
+    state: "attached",
+    timeout: 60_000,
+  });
+
+  const options = combo.locator("option");
+  const count = await options.count();
+  const result: QueryItem[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const value = cleanText(await options.nth(index).getAttribute("value"));
+    const parsed = queryItemSchema.safeParse(value);
+    if (parsed.success && !result.includes(parsed.data)) {
+      result.push(parsed.data);
+    }
+  }
+
+  return result;
+}
+
+async function configureLoanQuery(
+  page: Page,
+  input: FubonLoanStatementsInput,
+  queryItem: QueryItem,
+): Promise<BrowserScope> {
+  const scope = await findScopeWithSelector(page, "#form1\\:queryItemCombo");
+  const availableQueryItems = await readAvailableLoanQueryItems(scope);
+  if (!availableQueryItems.includes(queryItem)) {
+    throw new Error(`Loan query item is not available for this account: ${queryItem}`);
+  }
+
   await scope
     .locator("#form1\\:queryItemCombo")
     .selectOption(queryItem, { force: true });
@@ -507,6 +562,122 @@ async function downloadLoanStatement(
   return { filename, path, bytes: fileStat.size, ...converted };
 }
 
+export async function runFubonLoanStatements(
+  page: Page,
+  input: FubonLoanStatementsInput,
+): Promise<FubonLoanStatementsOutput> {
+  let scope = await openLoanStatementsPage(page);
+  const loanAccounts = await readLoanAccountOptions(
+    scope,
+    input.loanAccountLabels,
+  );
+  const queryItems = requestedQueryItems(input);
+  const explicitQueryItems = hasExplicitQueryItems(input);
+
+  const downloads: FubonLoanStatementsOutput["downloads"] = [];
+  const skippedAccounts: FubonLoanStatementsOutput["skippedAccounts"] = [];
+
+  for (const account of loanAccounts) {
+    scope = await selectLoanAccount(page, account);
+    const availableQueryItems = await readAvailableLoanQueryItems(scope);
+    const accountQueryItems = queryItems.filter((queryItem) =>
+      availableQueryItems.includes(queryItem),
+    );
+    const unavailableQueryItems = queryItems.filter(
+      (queryItem) => !availableQueryItems.includes(queryItem),
+    );
+
+    if (explicitQueryItems) {
+      for (const queryItem of unavailableQueryItems) {
+        const reason = `Loan query item is not available for this account: ${queryItem}`;
+        console.warn("loan-query-skipped", {
+          loanAccount: account.label,
+          queryItem,
+          reason,
+        });
+        skippedAccounts.push({
+          loanAccount: account.label,
+          queryItem,
+          reason,
+        });
+      }
+    }
+
+    if (accountQueryItems.length === 0) {
+      const queryItem = queryItems[0];
+      const reason = "No requested loan query items are available for this account.";
+      console.warn("loan-query-skipped", {
+        loanAccount: account.label,
+        queryItem,
+        reason,
+      });
+      skippedAccounts.push({
+        loanAccount: account.label,
+        queryItem,
+        reason,
+      });
+      continue;
+    }
+
+    for (const queryItem of accountQueryItems) {
+      try {
+        scope = await configureLoanQuery(page, input, queryItem);
+        scope = await runLoanQuery(page);
+        await loanDownloadLink(scope).waitFor({
+          state: "attached",
+          timeout: 60_000,
+        });
+        const download = await downloadLoanStatement(
+          page,
+          account.label,
+          queryItem,
+          input.downloadFormat,
+        );
+        downloads.push({
+          loanAccount: account.label,
+          queryItem,
+          ...download,
+        });
+      } catch (error) {
+        console.warn("loan-query-skipped", {
+          loanAccount: account.label,
+          queryItem,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        skippedAccounts.push({
+          loanAccount: account.label,
+          queryItem,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  if (downloads.length === 0 && skippedAccounts.length > 0) {
+    throw new Error(
+      `No loan statements were downloaded. First skipped account reason: ${skippedAccounts[0].reason}`,
+    );
+  }
+
+  return {
+    queryItems,
+    period: input.dateRange
+      ? {
+          mode: "custom" as const,
+          startDate: input.dateRange.startDate,
+          endDate: input.dateRange.endDate,
+        }
+      : {
+          mode: "quick" as const,
+          quickMonths: input.quickMonths,
+        },
+    downloadFormat: input.downloadFormat,
+    count: downloads.length,
+    downloads,
+    skippedAccounts,
+  };
+}
+
 export default workflow("fubonLoanStatements", {
   credentials: ["fubon_user_id", "fubon_account", "fubon_password"],
   input: inputSchema,
@@ -548,78 +719,6 @@ export default workflow("fubonLoanStatements", {
     }
 
     await waitForSignedInState(page);
-    let scope = await openLoanStatementsPage(page);
-    const loanAccounts = await readLoanAccountOptions(
-      scope,
-      input.loanAccountLabels,
-    );
-    const queryItems =
-      input.queryItems && input.queryItems.length > 0
-        ? input.queryItems
-        : input.queryItem
-          ? [input.queryItem]
-          : DEFAULT_QUERY_ITEMS;
-
-    const downloads = [];
-    const skippedAccounts = [];
-
-    for (const account of loanAccounts) {
-      for (const queryItem of queryItems) {
-        try {
-          scope = await configureLoanQuery(page, account, input, queryItem);
-          scope = await runLoanQuery(page);
-          await loanDownloadLink(scope).waitFor({
-            state: "attached",
-            timeout: 60_000,
-          });
-          const download = await downloadLoanStatement(
-            page,
-            account.label,
-            queryItem,
-            input.downloadFormat,
-          );
-          downloads.push({
-            loanAccount: account.label,
-            queryItem,
-            ...download,
-          });
-        } catch (error) {
-          console.warn("loan-query-skipped", {
-            loanAccount: account.label,
-            queryItem,
-            reason: error instanceof Error ? error.message : String(error),
-          });
-          skippedAccounts.push({
-            loanAccount: account.label,
-            queryItem,
-            reason: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
-    }
-
-    if (downloads.length === 0 && skippedAccounts.length > 0) {
-      throw new Error(
-        `No loan statements were downloaded. First skipped account reason: ${skippedAccounts[0].reason}`,
-      );
-    }
-
-    return {
-      queryItems,
-      period: input.dateRange
-        ? {
-            mode: "custom" as const,
-            startDate: input.dateRange.startDate,
-            endDate: input.dateRange.endDate,
-          }
-        : {
-            mode: "quick" as const,
-            quickMonths: input.quickMonths,
-          },
-      downloadFormat: input.downloadFormat,
-      count: downloads.length,
-      downloads,
-      skippedAccounts,
-    };
+    return await runFubonLoanStatements(page, input);
   },
 });

--- a/src/workflows/fubon-statements.ts
+++ b/src/workflows/fubon-statements.ts
@@ -1,7 +1,8 @@
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { workflow, pause, type LibrettoWorkflowContext } from "libretto";
 import type { Frame, Locator, Page } from "playwright";
+import XLSX from "xlsx";
 import { z } from "zod";
 
 const BANK_ENTRY_URL =
@@ -38,6 +39,8 @@ const outputSchema = z.object({
       filename: z.string(),
       path: z.string(),
       bytes: z.number().int().nonnegative(),
+      csvPath: z.string().optional(),
+      csvBytes: z.number().int().nonnegative().optional(),
     }),
   ),
 });
@@ -75,6 +78,27 @@ function maskAccount(account: string): string {
 
 function safeFilename(filename: string): string {
   return filename.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function csvPathFor(path: string): string {
+  const csvPath = path.replace(/\.[^/.]+$/, ".csv");
+  return csvPath === path ? `${path}.csv` : csvPath;
+}
+
+async function convertXlsToCsv(path: string) {
+  const workbook = XLSX.readFile(path);
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) {
+    throw new Error(`Downloaded Excel file has no worksheets: ${path}`);
+  }
+
+  const worksheet = workbook.Sheets[sheetName];
+  const csv = XLSX.utils.sheet_to_csv(worksheet);
+  const csvPath = csvPathFor(path);
+  await writeFile(csvPath, csv.endsWith("\n") ? csv : `${csv}\n`, "utf8");
+
+  const csvStat = await stat(csvPath);
+  return { csvPath, csvBytes: csvStat.size };
 }
 
 async function waitForFrame(
@@ -299,7 +323,9 @@ async function downloadStatements(
   await download.saveAs(path);
 
   const fileStat = await stat(path);
-  return { filename, path, bytes: fileStat.size };
+  const converted =
+    downloadFormat === "EXCEL" ? await convertXlsToCsv(path) : undefined;
+  return { filename, path, bytes: fileStat.size, ...converted };
 }
 
 export default workflow("fubonStatements", {

--- a/src/workflows/fubon-statements.ts
+++ b/src/workflows/fubon-statements.ts
@@ -10,7 +10,7 @@ const BANK_ENTRY_URL =
 
 type BrowserScope = Page | Frame;
 
-const dateRangeSchema = z.enum([
+export const fubonStatementDateRangeSchema = z.enum([
   "1",
   "3",
   "7",
@@ -23,19 +23,22 @@ const dateRangeSchema = z.enum([
   "180_365",
 ]);
 
-const inputSchema = z.object({
-  dateRanges: z.array(dateRangeSchema).min(1).default(["180", "180_365"]),
+export const fubonStatementsInputSchema = z.object({
+  dateRanges: z
+    .array(fubonStatementDateRangeSchema)
+    .min(1)
+    .default(["180", "180_365"]),
   downloadFormat: z.enum(["TXT", "EXCEL", "PDF"]).default("EXCEL"),
 });
 
-const outputSchema = z.object({
-  dateRanges: z.array(dateRangeSchema),
+export const fubonStatementsOutputSchema = z.object({
+  dateRanges: z.array(fubonStatementDateRangeSchema),
   downloadFormat: z.enum(["TXT", "EXCEL", "PDF"]),
   count: z.number().int().nonnegative(),
   downloads: z.array(
     z.object({
       account: z.string(),
-      dateRange: dateRangeSchema,
+      dateRange: fubonStatementDateRangeSchema,
       filename: z.string(),
       path: z.string(),
       bytes: z.number().int().nonnegative(),
@@ -45,17 +48,22 @@ const outputSchema = z.object({
   ),
 });
 
-type Input = z.infer<typeof inputSchema> & {
-  credentials: {
-    fubon_user_id?: string;
-    fubon_account?: string;
-    fubon_password?: string;
-  };
+export type FubonCredentials = {
+  fubon_user_id?: string;
+  fubon_account?: string;
+  fubon_password?: string;
+};
+
+export type FubonStatementsInput = z.infer<typeof fubonStatementsInputSchema>;
+export type FubonStatementsOutput = z.infer<typeof fubonStatementsOutputSchema>;
+
+type Input = FubonStatementsInput & {
+  credentials: FubonCredentials;
 };
 
 function requireCredential(
-  credentials: Input["credentials"],
-  name: keyof Input["credentials"],
+  credentials: FubonCredentials,
+  name: keyof FubonCredentials,
 ): string {
   const value = credentials[name]?.trim();
   if (!value) {
@@ -115,7 +123,7 @@ async function waitForFrame(
   throw new Error(`Timed out waiting for frame "${name}".`);
 }
 
-async function fillLoginForm(page: Page, credentials: Input["credentials"]) {
+async function fillLoginForm(page: Page, credentials: FubonCredentials) {
   const userId = requireCredential(credentials, "fubon_user_id");
   const account = requireCredential(credentials, "fubon_account");
   const password = requireCredential(credentials, "fubon_password");
@@ -285,7 +293,7 @@ async function openTransactionDetailForAccountIndex(
 
 async function queryStatements(
   page: Page,
-  dateRange: z.infer<typeof dateRangeSchema>,
+  dateRange: z.infer<typeof fubonStatementDateRangeSchema>,
 ) {
   const scope = await findScopeWithSelector(
     page,
@@ -328,10 +336,76 @@ async function downloadStatements(
   return { filename, path, bytes: fileStat.size, ...converted };
 }
 
+export async function signInFubon(
+  page: Page,
+  session: string,
+  credentials: FubonCredentials,
+): Promise<void> {
+  await fillLoginForm(page, credentials);
+
+  console.log(
+    "manual-auth-required: enter the CAPTCHA in the browser, then run `npx libretto resume --session " +
+      session +
+      "`.",
+  );
+  await pause(session);
+
+  const loginFrame = await waitForFrame(page, "txnFrame");
+  await loginFrame.locator("#btnLogin2").click();
+
+  if (
+    await loginFrame
+      .locator("#m1_inputOTP")
+      .isVisible()
+      .catch(() => false)
+  ) {
+    console.log(
+      "manual-otp-required: complete OTP in the browser, then run `npx libretto resume --session " +
+        session +
+        "`.",
+    );
+    await pause(session);
+  }
+
+  await waitForSignedInState(page);
+}
+
+export async function runFubonStatements(
+  page: Page,
+  input: FubonStatementsInput,
+): Promise<FubonStatementsOutput> {
+  const depositScope = await openMyDepositsPage(page);
+  const accountCount = await countDepositRows(depositScope);
+  const downloads: FubonStatementsOutput["downloads"] = [];
+
+  for (let accountIndex = 0; accountIndex < accountCount; accountIndex += 1) {
+    for (const dateRange of input.dateRanges) {
+      const account = await openTransactionDetailForAccountIndex(
+        page,
+        accountIndex,
+      );
+      await queryStatements(page, dateRange);
+      const download = await downloadStatements(page, input.downloadFormat);
+      downloads.push({
+        account,
+        dateRange,
+        ...download,
+      });
+    }
+  }
+
+  return {
+    dateRanges: input.dateRanges,
+    downloadFormat: input.downloadFormat,
+    count: downloads.length,
+    downloads,
+  };
+}
+
 export default workflow("fubonStatements", {
   credentials: ["fubon_user_id", "fubon_account", "fubon_password"],
-  input: inputSchema,
-  output: outputSchema,
+  input: fubonStatementsInputSchema,
+  output: fubonStatementsOutputSchema,
   handler: async (ctx: LibrettoWorkflowContext, rawInput) => {
     const input = rawInput as Input;
     const { page, session } = ctx;
@@ -341,59 +415,7 @@ export default workflow("fubonStatements", {
       await dialog.accept();
     });
 
-    await fillLoginForm(page, input.credentials);
-
-    console.log(
-      "manual-auth-required: enter the CAPTCHA in the browser, then run `npx libretto resume --session " +
-        session +
-        "`.",
-    );
-    await pause(session);
-
-    const loginFrame = await waitForFrame(page, "txnFrame");
-    await loginFrame.locator("#btnLogin2").click();
-
-    if (
-      await loginFrame
-        .locator("#m1_inputOTP")
-        .isVisible()
-        .catch(() => false)
-    ) {
-      console.log(
-        "manual-otp-required: complete OTP in the browser, then run `npx libretto resume --session " +
-          session +
-          "`.",
-      );
-      await pause(session);
-    }
-
-    await waitForSignedInState(page);
-
-    const depositScope = await openMyDepositsPage(page);
-    const accountCount = await countDepositRows(depositScope);
-    const downloads = [];
-
-    for (let accountIndex = 0; accountIndex < accountCount; accountIndex += 1) {
-      for (const dateRange of input.dateRanges) {
-        const account = await openTransactionDetailForAccountIndex(
-          page,
-          accountIndex,
-        );
-        await queryStatements(page, dateRange);
-        const download = await downloadStatements(page, input.downloadFormat);
-        downloads.push({
-          account,
-          dateRange,
-          ...download,
-        });
-      }
-    }
-
-    return {
-      dateRanges: input.dateRanges,
-      downloadFormat: input.downloadFormat,
-      count: downloads.length,
-      downloads,
-    };
+    await signInFubon(page, session, input.credentials);
+    return await runFubonStatements(page, input);
   },
 });


### PR DESCRIPTION
## Summary
- Add and document CSV conversion support for the Fubon statement download workflows.
- Update the relevant Libretto skill metadata and README guidance.
- Adjust dependencies and workflow implementations for all statement variants.

## Testing
- Not run (not requested)