### PR TITLE
Add Yuanta all-statements workflow and normalize CSV downloads to UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm run libretto:close-all
 | Fubon  | Deposit statements                                                              | `npm run run:fubon-statements`                   | `downloads/fubon-statements/`                   |
 | Fubon  | Credit card statements and unbilled details                                     | `npm run run:fubon-credit-card-statements`       | `downloads/fubon-credit-card-statements/`       |
 | Fubon  | Loan statements                                                                 | `npm run run:fubon-loan-statements`              | `downloads/fubon-loan-statements/`              |
+| YuanTa | TWD, foreign-currency, loan, credit card, and fund statements in one session    | `npm run run:yuanta-all-statements`              | Multiple `downloads/yuanta-*/` folders          |
 | YuanTa | TWD account statements                                                          | `npm run run:yuanta-statements`                  | `downloads/yuanta-statements/`                  |
 | YuanTa | Nexus WebTrade statements and holdings                                          | `npm run run:yuanta-trade-statements`            | `downloads/yuanta-trade-statements/`            |
 | YuanTa | Foreign-currency statements                                                     | `npm run run:yuanta-foreign-currency-statements` | `downloads/yuanta-foreign-currency-statements/` |
@@ -185,7 +186,7 @@ npx libretto run src/workflows/fubon-loan-statements.ts --headed --params '{"que
 npm run run:yuanta-statements
 ```
 
-Opens `臺幣交易明細查詢`, uses the `三個月` date range by default, iterates all domestic-currency account options, downloads each `下載CSV檔`, and returns only file metadata and masked account labels.
+Opens `臺幣交易明細查詢`, uses the `三個月` date range by default, iterates all domestic-currency account options, downloads each `下載CSV檔`, re-encodes the bank's Big5 CSV as UTF-8, and returns only file metadata and masked account labels.
 
 Optional params:
 
@@ -213,13 +214,37 @@ npx libretto run src/workflows/yuanta-trade-statements.ts --headed --params '{"s
 
 YuanTa enforces a 90-day custom date range limit in the UI.
 
+### YuanTa All Internet Banking Statements
+
+```bash
+npm run run:yuanta-all-statements
+```
+
+Runs the YuanTa Internet Banking TWD, foreign-currency, loan, credit card, and fund workflows through the same headed browser session. Complete the CAPTCHA once, resume the session, and the wrapper reuses the authenticated page for the remaining workflows. The fund workflow runs last because the existing fund workflow logs out when it finishes.
+
+The wrapper uses the existing individual workflow components and writes each workflow's files to its own existing output folder. YuanTa TWD and foreign-currency CSV downloads are saved as UTF-8 even though the bank serves those downloads as Big5.
+
+Run only selected components:
+
+```bash
+npm run run:yuanta-all-statements -- --params '{"include":{"statements":true,"foreignCurrency":true,"loan":false,"creditCard":false,"fund":false}}'
+```
+
+Pass options through to individual components:
+
+```bash
+npm run run:yuanta-all-statements -- --params '{"statements":{"dateRange":"one_month","accountFilters":["<account-suffix>"]},"foreignCurrency":{"currencyFilters":["USD"]},"creditCard":{"monthIndexes":[0,1,2]},"continueOnError":true}'
+```
+
+By default, every component is enabled, `prepareBetweenComponents` is `true`, and `continueOnError` is `false`. If a run fails between components, keep only the `yuanta-all-*` log lines and the final error when sharing diagnostics; avoid sharing account rows or downloaded file contents.
+
 ### YuanTa Foreign-Currency Statements
 
 ```bash
 npm run run:yuanta-foreign-currency-statements
 ```
 
-Opens `外幣交易明細查詢`, uses the `三個月` date range by default, iterates all available foreign-currency account options, selects `全部` currency when available, downloads each `下載CSV檔`, and returns only file metadata, masked account labels, and currency labels.
+Opens `外幣交易明細查詢`, uses the `三個月` date range by default, iterates all available foreign-currency account options, selects `全部` currency when available, downloads each `下載CSV檔`, re-encodes the bank's Big5 CSV as UTF-8, and returns only file metadata, masked account labels, and currency labels.
 
 Optional params:
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "run:fubon-credit-card-statements": "libretto run src/workflows/fubon-credit-card-statements.ts --headed",
     "run:fubon-loan-statements": "libretto run src/workflows/fubon-loan-statements.ts --headed",
     "run:yuanta-statements": "libretto run src/workflows/yuanta-statements.ts --headed",
+    "run:yuanta-all-statements": "libretto run src/workflows/yuanta-all-statements.ts --headed",
     "run:yuanta-trade-statements": "libretto run src/workflows/yuanta-trade-statements.ts --headed",
     "run:yuanta-foreign-currency-statements": "libretto run src/workflows/yuanta-foreign-currency-statements.ts --headed",
     "run:yuanta-loan-statements": "libretto run src/workflows/yuanta-loan-statements.ts --headed",

--- a/src/workflows/yuanta-all-statements.ts
+++ b/src/workflows/yuanta-all-statements.ts
@@ -1,0 +1,590 @@
+import {
+  workflow,
+  type ExportedLibrettoWorkflow,
+  type LibrettoWorkflowContext,
+} from "libretto";
+import type { Frame, Locator, Page } from "playwright";
+import { z } from "zod";
+
+import yuantaCreditCardStatements from "./yuanta-credit-card-statements.js";
+import yuantaForeignCurrencyStatements from "./yuanta-foreign-currency-statements.js";
+import yuantaFundStatements from "./yuanta-fund-statements.js";
+import yuantaLoanStatements from "./yuanta-loan-statements.js";
+import yuantaStatements from "./yuanta-statements.js";
+
+type YuantaCredentials = {
+  yuanta_user_id?: string;
+  yuanta_account?: string;
+  yuanta_password?: string;
+};
+type BrowserScope = Page | Frame;
+
+const BANK_ORIGIN = "https://ebank.yuantabank.com.tw";
+const emptyInputSchema = z.object({});
+
+function componentInputSchema(component: ExportedLibrettoWorkflow) {
+  return (component.inputSchema ?? emptyInputSchema).optional().default({});
+}
+
+const includeSchema = z.object({
+  statements: z.boolean().optional(),
+  foreignCurrency: z.boolean().optional(),
+  loan: z.boolean().optional(),
+  creditCard: z.boolean().optional(),
+  fund: z.boolean().optional(),
+});
+
+const inputSchema = z.object({
+  include: includeSchema.default({}),
+  continueOnError: z.boolean().default(false),
+  prepareBetweenComponents: z.boolean().default(true),
+  statements: componentInputSchema(yuantaStatements),
+  foreignCurrency: componentInputSchema(yuantaForeignCurrencyStatements),
+  loan: componentInputSchema(yuantaLoanStatements),
+  creditCard: componentInputSchema(yuantaCreditCardStatements),
+  fund: componentInputSchema(yuantaFundStatements),
+});
+
+const componentRunSchema = z.object({
+  workflow: z.string(),
+  status: z.enum(["skipped", "success", "failed"]),
+  output: z.unknown().optional(),
+  error: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  count: z.number().int().nonnegative(),
+  succeeded: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+  statements: componentRunSchema,
+  foreignCurrency: componentRunSchema,
+  loan: componentRunSchema,
+  creditCard: componentRunSchema,
+  fund: componentRunSchema,
+});
+
+type WorkflowInput = z.infer<typeof inputSchema> & {
+  credentials?: YuantaCredentials;
+};
+type ComponentRun = z.infer<typeof componentRunSchema>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function withCredentials(
+  input: unknown,
+  credentials: YuantaCredentials | undefined,
+): Record<string, unknown> {
+  const record = asRecord(input);
+  return credentials ? { ...record, credentials } : record;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function findScopeWithLocator(
+  page: Page,
+  locatorFor: (scope: BrowserScope) => Locator,
+  timeoutMs = 5_000,
+): Promise<BrowserScope | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const scope of [page, ...page.frames()]) {
+      const locator = locatorFor(scope);
+      if ((await locator.count().catch(() => 0)) > 0) return scope;
+    }
+    await page.waitForTimeout(250);
+  }
+  return null;
+}
+
+async function clickFirstVisible(locator: Locator): Promise<boolean> {
+  const count = await locator.count().catch(() => 0);
+  for (let index = 0; index < count; index += 1) {
+    const candidate = locator.nth(index);
+    if (await candidate.isVisible().catch(() => false)) {
+      await candidate.click({ force: true });
+      return true;
+    }
+  }
+  return false;
+}
+
+async function settleAfterMenuSwitch(page: Page): Promise<void> {
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {
+    // YuanTa keeps long-running frame activity; component waits verify readiness.
+  });
+  await page.waitForTimeout(750);
+}
+
+async function waitForFrame(
+  page: Page,
+  name: string,
+  timeoutMs = 10_000,
+): Promise<Frame> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const frame = page.frame({ name });
+    if (frame) return frame;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Timed out waiting for frame "${name}".`);
+}
+
+async function readCurrentCid(page: Page): Promise<string | null> {
+  const scope = await findScopeWithLocator(
+    page,
+    (candidate) => candidate.locator('input[name="cid"]').first(),
+    3_000,
+  );
+  if (scope) {
+    const cid = await scope
+      .locator('input[name="cid"]')
+      .first()
+      .inputValue()
+      .catch(() => "");
+    if (cid) return cid;
+  }
+
+  for (const frame of page.frames()) {
+    const match = frame.url().match(/[?&]cid=([^&]+)/);
+    if (match?.[1]) return decodeURIComponent(match[1]);
+  }
+
+  const pageMatch = page.url().match(/[?&]cid=([^&]+)/);
+  return pageMatch?.[1] ? decodeURIComponent(pageMatch[1]) : null;
+}
+
+async function gotoTransactionPage(
+  page: Page,
+  path: string,
+  label: string,
+): Promise<boolean> {
+  const cid = await readCurrentCid(page);
+  if (!cid) {
+    console.warn("yuanta-all-direct-navigation-skipped", {
+      area: label,
+      path,
+      reason: "missing-cid",
+    });
+    return false;
+  }
+
+  const fmain = await waitForFrame(page, "fmain").catch(() => null);
+  if (!fmain) {
+    console.warn("yuanta-all-direct-navigation-skipped", {
+      area: label,
+      path,
+      reason: "missing-fmain-frame",
+    });
+    return false;
+  }
+
+  const separator = path.includes("?") ? "&" : "?";
+  try {
+    await fmain.goto(
+      `${BANK_ORIGIN}/nib/tx/${path}${separator}type=page&cid=${encodeURIComponent(
+        cid,
+      )}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await settleAfterMenuSwitch(page);
+    console.log("yuanta-all-direct-navigation-complete", {
+      area: label,
+      path,
+    });
+    return true;
+  } catch (error: unknown) {
+    console.warn("yuanta-all-direct-navigation-failed", {
+      area: label,
+      path,
+      message: errorMessage(error),
+    });
+    return false;
+  }
+}
+
+async function runMenuAction(
+  page: Page,
+  action: string,
+  menuId: string,
+): Promise<boolean> {
+  const scope = await findMenuActionScope(page, 5_000);
+  if (!scope) {
+    console.warn("yuanta-all-menuaction-not-found", { action, menuId });
+    return false;
+  }
+
+  try {
+    await scope.evaluate(
+      ({ menuAction, id }) => {
+        const yuanTaWindow = window as typeof window & {
+          menuaction?: (action: string, menuId: string, flag?: string) => void;
+        };
+        if (typeof yuanTaWindow.menuaction !== "function") {
+          throw new Error("YuanTa page did not expose menuaction().");
+        }
+        yuanTaWindow.menuaction(menuAction, id, "N");
+      },
+      { menuAction: action, id: menuId },
+    );
+    await settleAfterMenuSwitch(page);
+    return true;
+  } catch (error: unknown) {
+    console.warn("yuanta-all-menuaction-failed", {
+      action,
+      menuId,
+      message: errorMessage(error),
+    });
+    return false;
+  }
+}
+
+async function findMenuActionScope(
+  page: Page,
+  timeoutMs = 10_000,
+): Promise<BrowserScope | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const scope of [page, ...page.frames()]) {
+      const hasMenuAction = await scope
+        .evaluate(() => {
+          const yuanTaWindow = window as typeof window & {
+            menuaction?: unknown;
+          };
+          return typeof yuanTaWindow.menuaction === "function";
+        })
+        .catch(() => false);
+      if (hasMenuAction) return scope;
+    }
+    await page.waitForTimeout(250);
+  }
+  return null;
+}
+
+async function hasForeignCurrencyDetailsForm(page: Page): Promise<boolean> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    for (const scope of [page, ...page.frames()]) {
+      const hasAccount = (await scope.locator("#acctno").count().catch(() => 0)) > 0;
+      const hasCurrency =
+        (await scope.locator('select[name="currency"]').count().catch(() => 0)) >
+        0;
+      if (hasAccount && hasCurrency) return true;
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function hasLoanStatementForm(page: Page): Promise<boolean> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    for (const scope of [page, ...page.frames()]) {
+      const hasAccount = (await scope.locator("#acctno").count().catch(() => 0)) > 0;
+      const hasOneYear =
+        (await scope
+          .locator("#duration a")
+          .filter({ hasText: "一年" })
+          .count()
+          .catch(() => 0)) > 0;
+      if (hasAccount && hasOneYear) return true;
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function hasCreditCardBillsPage(page: Page): Promise<boolean> {
+  const scope = await findScopeWithLocator(
+    page,
+    (candidate) =>
+      candidate
+        .locator('input[name="menutype"][value="creditcardbillsquery"]')
+        .or(candidate.locator('a[onclick*="queryMonth("]'))
+        .first(),
+    3_000,
+  );
+  return scope !== null;
+}
+
+async function revealYuanTaArea(
+  page: Page,
+  label: string,
+  options: {
+    menuSelectors: string[];
+  },
+): Promise<boolean> {
+  const menuScope = await findScopeWithLocator(page, (scope) =>
+    options.menuSelectors
+      .slice(1)
+      .reduce(
+        (locator, selector) => locator.or(scope.locator(selector)),
+        scope.locator(options.menuSelectors[0]),
+      )
+      .first(),
+  );
+  if (!menuScope) {
+    console.warn("yuanta-all-area-menu-not-found", { area: label });
+    return false;
+  }
+
+  const clicked = await clickFirstVisible(
+    options.menuSelectors
+      .slice(1)
+      .reduce(
+        (locator, selector) => locator.or(menuScope.locator(selector)),
+        menuScope.locator(options.menuSelectors[0]),
+      ),
+  );
+  if (!clicked) {
+    console.warn("yuanta-all-area-menu-not-visible", { area: label });
+    return false;
+  }
+
+  await settleAfterMenuSwitch(page);
+  console.log("yuanta-all-area-menu-revealed", { area: label });
+  return true;
+}
+
+async function prepareForComponent(
+  ctx: LibrettoWorkflowContext,
+  componentKey: keyof Pick<
+    WorkflowInput,
+    "foreignCurrency" | "loan" | "creditCard" | "fund"
+  >,
+): Promise<void> {
+  const { page } = ctx;
+  if (componentKey === "foreignCurrency") {
+    console.log("yuanta-all-component-prepare", {
+      workflow: "yuantaForeignCurrencyStatements",
+    });
+    const usedDirectNavigation = await gotoTransactionPage(
+      page,
+      "fxtransactiondetails",
+      "foreign-currency",
+    );
+    if (await hasForeignCurrencyDetailsForm(page)) {
+      console.log("yuanta-all-component-page-ready", {
+        workflow: "yuantaForeignCurrencyStatements",
+        via: usedDirectNavigation ? "direct-navigation" : "existing-page",
+      });
+      return;
+    }
+
+    await revealYuanTaArea(page, "foreign-currency", {
+      menuSelectors: [
+        'a[onclick*="doAction"][onclick*="FX"]',
+        'a[onclick*="menu_fx"]',
+        "#submenuAreaFX",
+      ],
+    });
+    console.warn("yuanta-all-component-page-not-ready", {
+      workflow: "yuantaForeignCurrencyStatements",
+      note: "falling back to the component's own menu navigation",
+    });
+    return;
+  }
+
+  if (componentKey === "loan") {
+    console.log("yuanta-all-component-prepare", {
+      workflow: "yuantaLoanStatements",
+    });
+    const usedDirectNavigation = await gotoTransactionPage(
+      page,
+      "loantransactiondetails",
+      "loan",
+    );
+    if (await hasLoanStatementForm(page)) {
+      console.log("yuanta-all-component-page-ready", {
+        workflow: "yuantaLoanStatements",
+        via: usedDirectNavigation ? "direct-navigation" : "existing-page",
+      });
+      return;
+    }
+
+    await revealYuanTaArea(page, "loan", {
+      menuSelectors: [
+        'a[onclick*="doAction"][onclick*="LOAN"]',
+        'a[onclick*="doAction"][onclick*="LN"]',
+        'a[onclick*="menu_loan"]',
+      ],
+    });
+    console.warn("yuanta-all-component-page-not-ready", {
+      workflow: "yuantaLoanStatements",
+      note: "falling back to the component's own menu navigation",
+    });
+    return;
+  }
+
+  if (componentKey === "creditCard") {
+    console.log("yuanta-all-component-prepare", {
+      workflow: "yuantaCreditCardStatements",
+    });
+    const usedDirectNavigation = await gotoTransactionPage(
+      page,
+      "creditcardbillsquery",
+      "credit-card",
+    );
+    if (await hasCreditCardBillsPage(page)) {
+      console.log("yuanta-all-component-page-ready", {
+        workflow: "yuantaCreditCardStatements",
+        via: usedDirectNavigation ? "direct-navigation" : "existing-page",
+      });
+      return;
+    }
+
+    await revealYuanTaArea(page, "credit-card", {
+      menuSelectors: [
+        'a[onclick*="doAction"][onclick*="CD"]',
+        'a[onclick*="doAction"][onclick*="CREDIT"]',
+        'a[onclick*="menu_credit"]',
+        "#submenuAreaCD",
+      ],
+    });
+    console.warn("yuanta-all-component-page-not-ready", {
+      workflow: "yuantaCreditCardStatements",
+      note: "falling back to the component's own menu navigation",
+    });
+    return;
+  }
+
+  console.log("yuanta-all-component-prepare", {
+    workflow: "yuantaFundStatements",
+  });
+  if (await runMenuAction(page, "fundsummary?TxnType=FundSummary", "menu_fundSummary")) {
+    console.log("yuanta-all-component-page-ready", {
+      workflow: "yuantaFundStatements",
+      via: "menuaction",
+    });
+    return;
+  }
+
+  await revealYuanTaArea(page, "fund", {
+    menuSelectors: [
+      'a[onclick*="doAction"][onclick*="FUND"]',
+      'a[onclick*="menu_fund"]',
+    ],
+  });
+  console.warn("yuanta-all-component-page-not-ready", {
+    workflow: "yuantaFundStatements",
+    note: "falling back to the component's own menu navigation",
+  });
+}
+
+async function runComponent(
+  ctx: LibrettoWorkflowContext,
+  component: ExportedLibrettoWorkflow,
+  enabled: boolean,
+  input: unknown,
+  credentials: YuantaCredentials | undefined,
+  continueOnError: boolean,
+): Promise<ComponentRun> {
+  if (!enabled) {
+    return { workflow: component.name, status: "skipped" };
+  }
+
+  console.log("yuanta-all-component-start", { workflow: component.name });
+
+  try {
+    const output = await component.run(ctx, withCredentials(input, credentials));
+    console.log("yuanta-all-component-complete", { workflow: component.name });
+    return { workflow: component.name, status: "success", output };
+  } catch (error: unknown) {
+    const message = errorMessage(error);
+    console.error("yuanta-all-component-failed", {
+      workflow: component.name,
+      message,
+    });
+    if (!continueOnError) throw error;
+    return { workflow: component.name, status: "failed", error: message };
+  }
+}
+
+export default workflow("yuantaAllStatements", {
+  credentials: ["yuanta_user_id", "yuanta_account", "yuanta_password"],
+  input: inputSchema,
+  output: outputSchema,
+  handler: async (ctx: LibrettoWorkflowContext, rawInput) => {
+    const input = rawInput as WorkflowInput;
+    const credentials = input.credentials;
+    const include = input.include;
+    const prepare = input.prepareBetweenComponents;
+
+    const statements = await runComponent(
+      ctx,
+      yuantaStatements,
+      include.statements ?? true,
+      input.statements,
+      credentials,
+      input.continueOnError,
+    );
+    if (prepare && (include.foreignCurrency ?? true)) {
+      await prepareForComponent(ctx, "foreignCurrency");
+    }
+    const foreignCurrency = await runComponent(
+      ctx,
+      yuantaForeignCurrencyStatements,
+      include.foreignCurrency ?? true,
+      input.foreignCurrency,
+      credentials,
+      input.continueOnError,
+    );
+    if (prepare && (include.loan ?? true)) {
+      await prepareForComponent(ctx, "loan");
+    }
+    const loan = await runComponent(
+      ctx,
+      yuantaLoanStatements,
+      include.loan ?? true,
+      input.loan,
+      credentials,
+      input.continueOnError,
+    );
+    if (prepare && (include.creditCard ?? true)) {
+      await prepareForComponent(ctx, "creditCard");
+    }
+    const creditCard = await runComponent(
+      ctx,
+      yuantaCreditCardStatements,
+      include.creditCard ?? true,
+      input.creditCard,
+      credentials,
+      input.continueOnError,
+    );
+
+    // The existing fund workflow logs out in its finally block, so keep it last.
+    if (prepare && (include.fund ?? true)) {
+      await prepareForComponent(ctx, "fund");
+    }
+    const fund = await runComponent(
+      ctx,
+      yuantaFundStatements,
+      include.fund ?? true,
+      input.fund,
+      credentials,
+      input.continueOnError,
+    );
+
+    const runs = [statements, foreignCurrency, loan, creditCard, fund];
+    const succeeded = runs.filter((run) => run.status === "success").length;
+    const failed = runs.filter((run) => run.status === "failed").length;
+    const skipped = runs.filter((run) => run.status === "skipped").length;
+
+    return {
+      count: succeeded,
+      succeeded,
+      failed,
+      skipped,
+      statements,
+      foreignCurrency,
+      loan,
+      creditCard,
+      fund,
+    };
+  },
+});

--- a/src/workflows/yuanta-foreign-currency-statements.ts
+++ b/src/workflows/yuanta-foreign-currency-statements.ts
@@ -1,15 +1,17 @@
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { TextDecoder } from "node:util";
 import {
   librettoAuthenticate,
   pause,
   workflow,
   type LibrettoWorkflowContext,
 } from "libretto";
-import type { Frame, Locator, Page } from "playwright";
+import type { Download, Frame, Locator, Page } from "playwright";
 import { z } from "zod";
 
 const BANK_ENTRY_URL = "https://ebank.yuantabank.com.tw/nib/ibanc.jsp";
+const big5Decoder = new TextDecoder("big5");
 
 type BrowserScope = Page | Frame;
 
@@ -123,6 +125,15 @@ function maskAccountLabel(value: string): string {
 
 function safeFilename(filename: string): string {
   return filename.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+async function saveBig5DownloadAsUtf8(
+  download: Download,
+  path: string,
+): Promise<void> {
+  await download.saveAs(path);
+  const big5Bytes = await readFile(path);
+  await writeFile(path, big5Decoder.decode(big5Bytes), "utf8");
 }
 
 function matchesFilter(
@@ -643,7 +654,7 @@ async function downloadCsv(
     downloadsDir,
     `${Date.now()}-${safeFilename(accountLabel)}-${safeFilename(currencyLabel)}-${safeFilename(filename)}`,
   );
-  await download.saveAs(path);
+  await saveBig5DownloadAsUtf8(download, path);
 
   const fileStat = await stat(path);
   return { filename, path, bytes: fileStat.size };

--- a/src/workflows/yuanta-statements.ts
+++ b/src/workflows/yuanta-statements.ts
@@ -1,10 +1,12 @@
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { TextDecoder } from "node:util";
 import { pause, workflow, type LibrettoWorkflowContext } from "libretto";
-import type { Frame, Locator, Page } from "playwright";
+import type { Download, Frame, Locator, Page } from "playwright";
 import { z } from "zod";
 
 const BANK_ENTRY_URL = "https://ebank.yuantabank.com.tw/nib/ibanc.jsp";
+const big5Decoder = new TextDecoder("big5");
 
 type BrowserScope = Page | Frame;
 
@@ -78,6 +80,15 @@ function maskAccountLabel(value: string): string {
 
 function safeFilename(filename: string): string {
   return filename.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+async function saveBig5DownloadAsUtf8(
+  download: Download,
+  path: string,
+): Promise<void> {
+  await download.saveAs(path);
+  const big5Bytes = await readFile(path);
+  await writeFile(path, big5Decoder.decode(big5Bytes), "utf8");
 }
 
 function matchesAccountFilter(
@@ -421,7 +432,7 @@ async function downloadCsv(page: Page, accountLabel: string) {
     downloadsDir,
     `${Date.now()}-${safeFilename(accountLabel)}-${safeFilename(filename)}`,
   );
-  await download.saveAs(path);
+  await saveBig5DownloadAsUtf8(download, path);
 
   const fileStat = await stat(path);
   return { filename, path, bytes: fileStat.size };


### PR DESCRIPTION
## Summary
- Add a new `yuanta-all-statements` workflow that runs the Yuanta statement variants in one orchestrated flow.
- Support selective inclusion, optional pre-navigation between components, and continue-on-error behavior.
- Convert Yuanta CSV downloads from Big5 to UTF-8 before saving for both statement and foreign-currency exports.
- Add a package script to run the new combined workflow directly.

## Testing
- Not run (not requested)