### PR TITLE
Add automation control panel and server-side task orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 .env
 downloads/
 data/
+.superpowers/
 
 # Libretto runtime state. Keep config/skills if setup creates them.
 .libretto/sessions/

--- a/docs/superpowers/plans/2026-06-30-automation-control-panel.md
+++ b/docs/superpowers/plans/2026-06-30-automation-control-panel.md
@@ -1,0 +1,976 @@
+# Automation Control Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a local `/automation` control panel that saves `.env` credentials, runs existing npm tasks one at a time, records task history, and gates CSV import by today's crawler success history.
+
+**Architecture:** Add a small automation server module under `src/lib/automation/server/` for registry, env file edits, business-day time windows, SQLite task history, and process execution. Add one SvelteKit route at `src/routes/automation/` that renders a dashboard-style task table and calls server actions. Keep crawler workflows unchanged.
+
+**Tech Stack:** SvelteKit, Svelte 5, Node `child_process.spawn`, Node `fs`, `node:sqlite`, existing ledger migrations, assert-based `*.check.ts` tests.
+
+---
+
+### Task 1: Automation Registry, Business Day, And Env File Helpers
+
+**Files:**
+- Create: `src/lib/automation/server/tasks.ts`
+- Create: `src/lib/automation/server/business-day.ts`
+- Create: `src/lib/automation/server/env-file.ts`
+- Create: `src/lib/automation/server/automation-core.check.ts`
+
+- [ ] **Step 1: Write the failing core checks**
+
+Create `src/lib/automation/server/automation-core.check.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import {
+  CSV_IMPORT_DEPENDENCY_IDS,
+  AUTOMATION_TASKS,
+  taskById,
+} from "./tasks.ts";
+import { businessDayUtcRange } from "./business-day.ts";
+import {
+  credentialStatus,
+  updateEnvText,
+} from "./env-file.ts";
+
+const fubonUserKey = "LIBRETTO_CLOUD_FUBON" + "_USER_ID";
+
+assert.deepEqual(
+  CSV_IMPORT_DEPENDENCY_IDS,
+  [
+    "fubon-all-statements",
+    "esun-credit-card-statements",
+    "yuanta-all-statements",
+    "yuanta-trade-statements",
+    "cathay-all-statements",
+    "hncb-statements",
+  ],
+);
+
+assert.equal(taskById("sync-maicoin")?.kind, "sync");
+assert.equal(taskById("import-downloads-csv")?.kind, "import");
+assert.deepEqual(
+  taskById("import-downloads-csv")?.dependencies,
+  CSV_IMPORT_DEPENDENCY_IDS,
+);
+assert.equal(AUTOMATION_TASKS.every((task) => task.maxAttempts >= 1), true);
+
+const taipeiRange = businessDayUtcRange(
+  new Date("2026-06-30T16:30:00.000Z"),
+  "Asia/Taipei",
+);
+assert.equal(taipeiRange.businessDate, "2026-07-01");
+assert.equal(taipeiRange.startUtc.toISOString(), "2026-06-30T16:00:00.000Z");
+assert.equal(taipeiRange.endUtc.toISOString(), "2026-07-01T16:00:00.000Z");
+
+const updatedEnv = updateEnvText(
+  `# keep me\n${fubonUserKey}=old\nOTHER=value\n`,
+  {
+    [fubonUserKey]: "new-user",
+    MAX_SUB_ACCOUNT: "main",
+  },
+);
+assert.equal(
+  updatedEnv,
+  `# keep me\n${fubonUserKey}=new-user\nOTHER=value\nMAX_SUB_ACCOUNT=main\n`,
+);
+
+assert.deepEqual(
+  credentialStatus(`${fubonUserKey}=abc\nMAX_SECRET_KEY=\n`),
+  {
+    [fubonUserKey]: true,
+    MAX_SECRET_KEY: false,
+  },
+);
+```
+
+- [ ] **Step 2: Run the core checks and verify RED**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/automation-core.check.ts`
+
+Expected: FAIL with module-not-found errors for the new helper modules.
+
+- [ ] **Step 3: Implement the minimal helpers**
+
+Create `src/lib/automation/server/tasks.ts`:
+
+```ts
+export type AutomationTaskKind = "crawler" | "sync" | "import";
+
+export type AutomationTask = {
+  id: string;
+  label: string;
+  script: string;
+  kind: AutomationTaskKind;
+  credentialKeys: readonly string[];
+  dependencies: readonly string[];
+  maxAttempts: number;
+};
+
+export const CSV_IMPORT_DEPENDENCY_IDS = [
+  "fubon-all-statements",
+  "esun-credit-card-statements",
+  "yuanta-all-statements",
+  "yuanta-trade-statements",
+  "cathay-all-statements",
+  "hncb-statements",
+] as const;
+
+export const AUTOMATION_TASKS: readonly AutomationTask[] = [
+  {
+    id: "fubon-all-statements",
+    label: "Fubon all statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_FUBON_USER_ID",
+      "LIBRETTO_CLOUD_FUBON_ACCOUNT",
+      "LIBRETTO_CLOUD_FUBON_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "esun-credit-card-statements",
+    label: "ESun credit card statements",
+    script: "run:esun-credit-card-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_ESUN_USER_ID",
+      "LIBRETTO_CLOUD_ESUN_ACCOUNT",
+      "LIBRETTO_CLOUD_ESUN_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "yuanta-all-statements",
+    label: "Yuanta all statements",
+    script: "run:yuanta-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_YUANTA_USER_ID",
+      "LIBRETTO_CLOUD_YUANTA_ACCOUNT",
+      "LIBRETTO_CLOUD_YUANTA_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "yuanta-trade-statements",
+    label: "Yuanta trade statements",
+    script: "run:yuanta-trade-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_YUANTA_TRADE_USER_ID",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_PASSWORD",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_CA_PATH",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_CA_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "cathay-all-statements",
+    label: "Cathay all statements",
+    script: "run:cathay-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_CATHAY_USER_ID",
+      "LIBRETTO_CLOUD_CATHAY_ACCOUNT",
+      "LIBRETTO_CLOUD_CATHAY_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "hncb-statements",
+    label: "HNCB statements",
+    script: "run:hncb-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_HNCB_USER_ID",
+      "LIBRETTO_CLOUD_HNCB_ACCOUNT",
+      "LIBRETTO_CLOUD_HNCB_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "sync-maicoin",
+    label: "MaiCoin sync",
+    script: "run:sync-maicoin",
+    kind: "sync",
+    credentialKeys: ["MAX_ACCESS_KEY", "MAX_SECRET_KEY", "MAX_SUB_ACCOUNT"],
+    dependencies: [],
+    maxAttempts: 1,
+  },
+  {
+    id: "import-downloads-csv",
+    label: "Import downloads CSV",
+    script: "run:import-downloads-csv",
+    kind: "import",
+    credentialKeys: [],
+    dependencies: CSV_IMPORT_DEPENDENCY_IDS,
+    maxAttempts: 1,
+  },
+];
+
+export function taskById(taskId: string) {
+  return AUTOMATION_TASKS.find((task) => task.id === taskId) ?? null;
+}
+```
+
+Create `src/lib/automation/server/business-day.ts`:
+
+```ts
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+function partsInTimeZone(date: Date, timeZone: string): DateParts {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return {
+    year: Number(values.year),
+    month: Number(values.month),
+    day: Number(values.day),
+    hour: Number(values.hour),
+    minute: Number(values.minute),
+    second: Number(values.second),
+  };
+}
+
+function offsetMs(date: Date, timeZone: string) {
+  const parts = partsInTimeZone(date, timeZone);
+  const localAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return localAsUtc - date.getTime();
+}
+
+function zonedMidnightUtc(year: number, month: number, day: number, timeZone: string) {
+  let utc = Date.UTC(year, month - 1, day);
+  for (let index = 0; index < 3; index += 1) {
+    utc = Date.UTC(year, month - 1, day) - offsetMs(new Date(utc), timeZone);
+  }
+  return new Date(utc);
+}
+
+export function businessDayUtcRange(now = new Date(), timeZone = process.env.AUTOMATION_BUSINESS_TIMEZONE ?? "Asia/Taipei") {
+  const parts = partsInTimeZone(now, timeZone);
+  const startUtc = zonedMidnightUtc(parts.year, parts.month, parts.day, timeZone);
+  const endLocal = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + 1));
+  const endUtc = zonedMidnightUtc(
+    endLocal.getUTCFullYear(),
+    endLocal.getUTCMonth() + 1,
+    endLocal.getUTCDate(),
+    timeZone,
+  );
+  return {
+    businessDate: `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}`,
+    startUtc,
+    endUtc,
+  };
+}
+```
+
+Create `src/lib/automation/server/env-file.ts`:
+
+```ts
+const envLinePattern = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+export function parseEnvText(text: string) {
+  const result: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = envLinePattern.exec(line);
+    if (match) result[match[1]] = match[2];
+  }
+  return result;
+}
+
+export function credentialStatus(text: string, keys?: readonly string[]) {
+  const env = parseEnvText(text);
+  const selectedKeys = keys ?? Object.keys(env);
+  return Object.fromEntries(
+    selectedKeys.map((key) => [key, Boolean(env[key]?.trim())]),
+  );
+}
+
+export function updateEnvText(text: string, updates: Record<string, string>) {
+  const remaining = new Set(Object.keys(updates));
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  const nextLines = lines.map((line) => {
+    const match = envLinePattern.exec(line);
+    if (!match) return line;
+    const key = match[1];
+    if (!remaining.has(key)) return line;
+    remaining.delete(key);
+    return `${key}=${updates[key]}`;
+  });
+
+  for (const key of remaining) nextLines.push(`${key}=${updates[key]}`);
+  return `${nextLines.join("\n")}\n`;
+}
+```
+
+- [ ] **Step 4: Run the core checks and verify GREEN**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/automation-core.check.ts`
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/lib/automation/server/tasks.ts src/lib/automation/server/business-day.ts src/lib/automation/server/env-file.ts src/lib/automation/server/automation-core.check.ts
+git commit -m "feat: add automation core helpers"
+```
+
+### Task 2: SQLite Automation Task History
+
+**Files:**
+- Modify: `src/ledger/db/migrations.ts`
+- Modify: `src/ledger/db/schema.ts`
+- Create: `src/lib/automation/server/store.ts`
+- Create: `src/lib/automation/server/store.check.ts`
+
+- [ ] **Step 1: Write the failing store checks**
+
+Create `src/lib/automation/server/store.check.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  createTaskRun,
+  importGateStatus,
+  latestTaskRuns,
+  updateTaskRun,
+} from "./store.ts";
+
+const ledgerDir = mkdtempSync(join(tmpdir(), "automation-store-"));
+try {
+  const db = openLedgerDatabase(ledgerDir);
+  const startedAt = "2026-06-30T01:00:00.000Z";
+  const finishedAt = "2026-06-30T01:02:00.000Z";
+
+  const run = createTaskRun(db, {
+    taskId: "fubon-all-statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    status: "running",
+    attempt: 1,
+    maxAttempts: 2,
+    startedAt,
+    logPath: "data/automation/logs/fubon.log",
+  });
+
+  updateTaskRun(db, run.taskRunId, {
+    status: "completed",
+    finishedAt,
+    exitCode: 0,
+    logTail: "ok",
+  });
+
+  const latest = latestTaskRuns(db);
+  assert.equal(latest["fubon-all-statements"]?.status, "completed");
+  assert.equal(latest["fubon-all-statements"]?.finishedAt, finishedAt);
+
+  const lockedGate = importGateStatus(db, {
+    dependencyIds: [
+      "fubon-all-statements",
+      "esun-credit-card-statements",
+    ],
+    startUtc: new Date("2026-06-30T00:00:00.000Z"),
+    endUtc: new Date("2026-07-01T00:00:00.000Z"),
+  });
+  assert.equal(lockedGate.locked, true);
+  assert.deepEqual(lockedGate.missingTaskIds, ["esun-credit-card-statements"]);
+
+  createTaskRun(db, {
+    taskId: "esun-credit-card-statements",
+    script: "run:esun-credit-card-statements",
+    kind: "crawler",
+    status: "completed",
+    attempt: 1,
+    maxAttempts: 2,
+    startedAt: "2026-06-29T23:00:00.000Z",
+    finishedAt: "2026-06-29T23:20:00.000Z",
+    exitCode: 0,
+    logPath: "data/automation/logs/esun.log",
+    logTail: "ok",
+  });
+
+  const unlockedGate = importGateStatus(db, {
+    dependencyIds: [
+      "fubon-all-statements",
+      "esun-credit-card-statements",
+    ],
+    startUtc: new Date("2026-06-29T16:00:00.000Z"),
+    endUtc: new Date("2026-06-30T16:00:00.000Z"),
+  });
+  assert.equal(unlockedGate.locked, false);
+  assert.deepEqual(unlockedGate.missingTaskIds, []);
+
+  db.close();
+} finally {
+  rmSync(ledgerDir, { recursive: true, force: true });
+}
+```
+
+- [ ] **Step 2: Run the store checks and verify RED**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/store.check.ts`
+
+Expected: FAIL because `store.ts` does not exist.
+
+- [ ] **Step 3: Add the migration and schema**
+
+In `src/ledger/db/schema.ts`, add:
+
+```ts
+export const automationTaskRuns = sqliteTable("automation_task_runs", {
+  taskRunId: text("task_run_id").primaryKey(),
+  taskId: text("task_id").notNull(),
+  script: text("script").notNull(),
+  kind: text("kind").notNull(),
+  status: text("status").notNull(),
+  attempt: integer("attempt").notNull(),
+  maxAttempts: integer("max_attempts").notNull(),
+  startedAt: text("started_at").notNull(),
+  finishedAt: text("finished_at"),
+  exitCode: integer("exit_code"),
+  signal: text("signal"),
+  errorMessage: text("error_message"),
+  logPath: text("log_path").notNull(),
+  logTail: text("log_tail").notNull(),
+  recordJson: text("record_json").notNull(),
+});
+```
+
+In `src/ledger/db/migrations.ts`, add:
+
+```ts
+function createAutomationTaskRuns(db: LedgerDatabase) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS automation_task_runs (
+      task_run_id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      script TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempt INTEGER NOT NULL,
+      max_attempts INTEGER NOT NULL,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      exit_code INTEGER,
+      signal TEXT,
+      error_message TEXT,
+      log_path TEXT NOT NULL,
+      log_tail TEXT NOT NULL,
+      record_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_automation_task_runs_latest
+    ON automation_task_runs(task_id, started_at);
+    CREATE INDEX IF NOT EXISTS idx_automation_task_runs_status
+    ON automation_task_runs(status, started_at);
+  `);
+}
+```
+
+Append migration:
+
+```ts
+{
+  version: 7,
+  name: "automation_task_runs",
+  up: createAutomationTaskRuns,
+},
+```
+
+- [ ] **Step 4: Implement the store**
+
+Create `src/lib/automation/server/store.ts`:
+
+```ts
+import { randomUUID } from "node:crypto";
+import type { LedgerDatabase } from "../../../ledger/db/client.ts";
+import type { AutomationTaskKind } from "./tasks.ts";
+
+export type AutomationTaskStatus =
+  | "queued"
+  | "running"
+  | "waiting_for_human"
+  | "retrying"
+  | "completed"
+  | "failed"
+  | "locked";
+
+export type AutomationTaskRun = {
+  taskRunId: string;
+  taskId: string;
+  script: string;
+  kind: AutomationTaskKind;
+  status: AutomationTaskStatus;
+  attempt: number;
+  maxAttempts: number;
+  startedAt: string;
+  finishedAt: string | null;
+  exitCode: number | null;
+  signal: string | null;
+  errorMessage: string | null;
+  logPath: string;
+  logTail: string;
+  recordJson: string;
+};
+
+type CreateTaskRunInput = {
+  taskId: string;
+  script: string;
+  kind: AutomationTaskKind;
+  status: AutomationTaskStatus;
+  attempt: number;
+  maxAttempts: number;
+  startedAt: string;
+  finishedAt?: string | null;
+  exitCode?: number | null;
+  signal?: string | null;
+  errorMessage?: string | null;
+  logPath: string;
+  logTail?: string;
+};
+
+function rowToTaskRun(row: Record<string, unknown>): AutomationTaskRun {
+  return {
+    taskRunId: String(row.task_run_id),
+    taskId: String(row.task_id),
+    script: String(row.script),
+    kind: row.kind as AutomationTaskKind,
+    status: row.status as AutomationTaskStatus,
+    attempt: Number(row.attempt),
+    maxAttempts: Number(row.max_attempts),
+    startedAt: String(row.started_at),
+    finishedAt: row.finished_at === null ? null : String(row.finished_at),
+    exitCode: row.exit_code === null ? null : Number(row.exit_code),
+    signal: row.signal === null ? null : String(row.signal),
+    errorMessage: row.error_message === null ? null : String(row.error_message),
+    logPath: String(row.log_path),
+    logTail: String(row.log_tail),
+    recordJson: String(row.record_json),
+  };
+}
+
+export function createTaskRun(db: LedgerDatabase, input: CreateTaskRunInput) {
+  const taskRunId = randomUUID();
+  const record = { taskRunId, ...input };
+  db.prepare(`
+    INSERT INTO automation_task_runs (
+      task_run_id, task_id, script, kind, status, attempt, max_attempts,
+      started_at, finished_at, exit_code, signal, error_message, log_path,
+      log_tail, record_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    taskRunId,
+    input.taskId,
+    input.script,
+    input.kind,
+    input.status,
+    input.attempt,
+    input.maxAttempts,
+    input.startedAt,
+    input.finishedAt ?? null,
+    input.exitCode ?? null,
+    input.signal ?? null,
+    input.errorMessage ?? null,
+    input.logPath,
+    input.logTail ?? "",
+    JSON.stringify(record),
+  );
+  return { taskRunId };
+}
+
+export function updateTaskRun(
+  db: LedgerDatabase,
+  taskRunId: string,
+  update: Partial<Pick<AutomationTaskRun, "status" | "finishedAt" | "exitCode" | "signal" | "errorMessage" | "logTail">>,
+) {
+  const row = db.prepare("SELECT * FROM automation_task_runs WHERE task_run_id = ?").get(taskRunId) as Record<string, unknown> | undefined;
+  if (!row) throw new Error(`Missing automation task run: ${taskRunId}`);
+  const next = {
+    ...rowToTaskRun(row),
+    ...update,
+  };
+  db.prepare(`
+    UPDATE automation_task_runs
+    SET status = ?, finished_at = ?, exit_code = ?, signal = ?, error_message = ?, log_tail = ?, record_json = ?
+    WHERE task_run_id = ?
+  `).run(
+    next.status,
+    next.finishedAt,
+    next.exitCode,
+    next.signal,
+    next.errorMessage,
+    next.logTail,
+    JSON.stringify(next),
+    taskRunId,
+  );
+}
+
+export function latestTaskRuns(db: LedgerDatabase) {
+  const rows = db.prepare(`
+    SELECT run.*
+    FROM automation_task_runs run
+    JOIN (
+      SELECT task_id, max(started_at) AS started_at
+      FROM automation_task_runs
+      GROUP BY task_id
+    ) latest
+    ON latest.task_id = run.task_id AND latest.started_at = run.started_at
+  `).all() as Record<string, unknown>[];
+
+  return Object.fromEntries(rows.map((row) => {
+    const taskRun = rowToTaskRun(row);
+    return [taskRun.taskId, taskRun];
+  }));
+}
+
+export function importGateStatus(
+  db: LedgerDatabase,
+  input: { dependencyIds: readonly string[]; startUtc: Date; endUtc: Date },
+) {
+  const missingTaskIds = input.dependencyIds.filter((taskId) => {
+    const row = db.prepare(`
+      SELECT status
+      FROM automation_task_runs
+      WHERE task_id = ?
+        AND started_at >= ?
+        AND started_at < ?
+      ORDER BY started_at DESC
+      LIMIT 1
+    `).get(taskId, input.startUtc.toISOString(), input.endUtc.toISOString()) as { status?: string } | undefined;
+    return row?.status !== "completed";
+  });
+  return {
+    locked: missingTaskIds.length > 0,
+    missingTaskIds,
+  };
+}
+```
+
+- [ ] **Step 5: Run the store checks and verify GREEN**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/store.check.ts`
+
+Expected: exit 0.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/ledger/db/migrations.ts src/ledger/db/schema.ts src/lib/automation/server/store.ts src/lib/automation/server/store.check.ts
+git commit -m "feat: record automation task history"
+```
+
+### Task 3: Task Runner
+
+**Files:**
+- Create: `src/lib/automation/server/runner.ts`
+- Create: `src/lib/automation/server/runner.check.ts`
+
+- [ ] **Step 1: Write the failing runner checks**
+
+Create `src/lib/automation/server/runner.check.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { shouldMarkWaitingForHuman, nextAttemptStatus } from "./runner.ts";
+
+assert.equal(shouldMarkWaitingForHuman("libretto paused. resume --session abc"), true);
+assert.equal(shouldMarkWaitingForHuman("Please enter OTP in browser"), true);
+assert.equal(shouldMarkWaitingForHuman("download completed"), false);
+
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 1 }),
+  "retrying",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 2, maxAttempts: 2, exitCode: 1 }),
+  "failed",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "sync", attempt: 1, maxAttempts: 1, exitCode: 1 }),
+  "failed",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 0 }),
+  "completed",
+);
+```
+
+- [ ] **Step 2: Run the runner checks and verify RED**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/runner.check.ts`
+
+Expected: FAIL because `runner.ts` does not exist.
+
+- [ ] **Step 3: Implement minimal runner helpers and process runner**
+
+Create `src/lib/automation/server/runner.ts` with:
+
+```ts
+import { spawn } from "node:child_process";
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { createTaskRun, updateTaskRun, type AutomationTaskStatus } from "./store.ts";
+import { taskById, type AutomationTaskKind } from "./tasks.ts";
+
+let activeTaskRunId: string | null = null;
+
+export function shouldMarkWaitingForHuman(output: string) {
+  return /resume --session|paused|captcha|otp|verification|certificate/i.test(output);
+}
+
+export function nextAttemptStatus(input: {
+  kind: AutomationTaskKind;
+  attempt: number;
+  maxAttempts: number;
+  exitCode: number | null;
+}): AutomationTaskStatus {
+  if (input.exitCode === 0) return "completed";
+  if (input.kind === "crawler" && input.attempt < input.maxAttempts) return "retrying";
+  return "failed";
+}
+
+function appendLog(logPath: string, chunk: string) {
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, chunk);
+}
+
+function tail(value: string) {
+  return value.slice(-4000);
+}
+
+export function hasActiveAutomationTask() {
+  return activeTaskRunId !== null;
+}
+
+export async function runAutomationTask(taskId: string, ledgerDir = process.env.LEDGER_DIR ?? "data/ledger") {
+  const task = taskById(taskId);
+  if (!task) throw new Error(`Unknown automation task: ${taskId}`);
+  if (activeTaskRunId) throw new Error("Another automation task is already running.");
+
+  const db = openLedgerDatabase(ledgerDir);
+  try {
+    for (let attempt = 1; attempt <= task.maxAttempts; attempt += 1) {
+      const startedAt = new Date().toISOString();
+      const logPath = join("data", "automation", "logs", `${task.id}-${Date.now()}-${attempt}.log`);
+      const run = createTaskRun(db, {
+        taskId: task.id,
+        script: task.script,
+        kind: task.kind,
+        status: attempt > 1 ? "retrying" : "running",
+        attempt,
+        maxAttempts: task.maxAttempts,
+        startedAt,
+        logPath,
+      });
+      activeTaskRunId = run.taskRunId;
+      let logTail = "";
+
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const child = spawn("npm", ["run", task.script], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        });
+        child.stdout.on("data", (chunk: Buffer) => {
+          const text = chunk.toString("utf8");
+          appendLog(logPath, text);
+          logTail = tail(logTail + text);
+          if (shouldMarkWaitingForHuman(logTail)) {
+            updateTaskRun(db, run.taskRunId, { status: "waiting_for_human", logTail });
+          }
+        });
+        child.stderr.on("data", (chunk: Buffer) => {
+          const text = chunk.toString("utf8");
+          appendLog(logPath, text);
+          logTail = tail(logTail + text);
+          if (shouldMarkWaitingForHuman(logTail)) {
+            updateTaskRun(db, run.taskRunId, { status: "waiting_for_human", logTail });
+          }
+        });
+        child.on("error", reject);
+        child.on("close", (code) => resolve(code));
+      });
+
+      const status = nextAttemptStatus({
+        kind: task.kind,
+        attempt,
+        maxAttempts: task.maxAttempts,
+        exitCode,
+      });
+      updateTaskRun(db, run.taskRunId, {
+        status,
+        finishedAt: new Date().toISOString(),
+        exitCode,
+        logTail,
+        errorMessage: status === "failed" ? `Task exited with code ${exitCode}` : null,
+      });
+      activeTaskRunId = null;
+      if (status === "completed") return { status };
+    }
+    return { status: "failed" as const };
+  } finally {
+    activeTaskRunId = null;
+    db.close();
+  }
+}
+```
+
+- [ ] **Step 4: Run the runner checks and verify GREEN**
+
+Run: `node --no-warnings --experimental-strip-types src/lib/automation/server/runner.check.ts`
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/lib/automation/server/runner.ts src/lib/automation/server/runner.check.ts
+git commit -m "feat: add automation task runner"
+```
+
+### Task 4: Automation Route And UI
+
+**Files:**
+- Modify: `src/lib/shared-shell/components/DashboardShell.svelte`
+- Create: `src/lib/automation/AutomationDashboard.svelte`
+- Create: `src/routes/automation/+page.server.ts`
+- Create: `src/routes/automation/+page.svelte`
+
+- [ ] **Step 1: Add the route load/action skeleton**
+
+Create `src/routes/automation/+page.server.ts` with load data from `AUTOMATION_TASKS`, `latestTaskRuns`, `importGateStatus`, `businessDayUtcRange`, and `credentialStatus`. Add actions `saveCredentials`, `run`, and `retry` that call `updateEnvText` or `runAutomationTask`.
+
+- [ ] **Step 2: Add the Svelte page wrapper**
+
+Create `src/routes/automation/+page.svelte`:
+
+```svelte
+<script lang="ts">
+  import AutomationDashboard from "$lib/automation/AutomationDashboard.svelte";
+  import type { PageData } from "./$types";
+
+  export let data: PageData;
+</script>
+
+<svelte:head>
+  <title>OctopusBeak Automation</title>
+</svelte:head>
+
+<AutomationDashboard automation={data.automation} />
+```
+
+- [ ] **Step 3: Add the Automation nav item**
+
+Modify `src/lib/shared-shell/components/DashboardShell.svelte`:
+
+```ts
+export let active: "overview" | "assets" | "liabilities" | "automation" = "overview";
+```
+
+Add a nav item:
+
+```ts
+{
+  id: "automation",
+  label: "Automation",
+  href: "/automation",
+  path: "M5 4h14v2H5V4Zm2 4h10v2H7V8Zm-2 4h14v8H5v-8Zm2 2v4h10v-4H7Z",
+},
+```
+
+- [ ] **Step 4: Implement the dashboard component**
+
+Create `src/lib/automation/AutomationDashboard.svelte` using `DashboardShell`, a topbar credentials button, one credentials modal, and one task table. Keep control buttons fixed-size with a local `.task-control` class. Use existing `.card`, `.panel-title`, `.table`, `.chip`, and `.button` classes.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: exit 0.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add src/lib/shared-shell/components/DashboardShell.svelte src/lib/automation/AutomationDashboard.svelte src/routes/automation/+page.server.ts src/routes/automation/+page.svelte
+git commit -m "feat: add automation dashboard"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- Modify only if verification finds a concrete defect.
+
+- [ ] **Step 1: Run all automation checks**
+
+Run:
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/automation/server/automation-core.check.ts
+node --no-warnings --experimental-strip-types src/lib/automation/server/store.check.ts
+node --no-warnings --experimental-strip-types src/lib/automation/server/runner.check.ts
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 2: Run existing checks**
+
+Run:
+
+```bash
+node --no-warnings --experimental-strip-types src/ledger/content-hash.check.ts
+node --no-warnings --experimental-strip-types src/ledger/source-csv-parsers.check.ts
+node --no-warnings --experimental-strip-types src/lib/shared-ledger/server/accounts.check.ts
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: exit 0.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run: `git diff --stat HEAD`
+
+Expected: only automation, route, shell nav, and migration/schema files changed since the previous task commit.

--- a/docs/superpowers/specs/2026-06-30-automation-control-panel-design.md
+++ b/docs/superpowers/specs/2026-06-30-automation-control-panel-design.md
@@ -1,0 +1,185 @@
+# Automation Control Panel Design
+
+## Goal
+
+Add a local `/automation` page that replaces manual statement update commands with in-app controls for:
+
+- editing local credentials in `.env`
+- starting existing statement/sync/import tasks
+- viewing task status, attempts, and log tails
+- retrying failed tasks
+- automatically running CSV import only after its crawler dependencies have succeeded for the current business day
+
+The implementation wraps existing scripts. It does not rewrite bank workflows.
+
+## Existing Commands
+
+The page exposes these update tasks:
+
+- `run:fubon-all-statements`
+- `run:esun-credit-card-statements`
+- `run:yuanta-all-statements`
+- `run:yuanta-trade-statements`
+- `run:cathay-all-statements`
+- `run:hncb-statements`
+- `run:sync-maicoin`
+- `run:import-downloads-csv`
+
+CSV import dependencies are the crawler tasks that produce downloaded CSV files:
+
+- Fubon all statements
+- ESun credit card statements
+- Yuanta all statements
+- Yuanta trade statements
+- Cathay all statements
+- HNCB statements
+
+`sync-maicoin` is an update task but does not block CSV import because it writes directly to the ledger.
+
+## UI
+
+Use the design language from `docs/specs/001-dynamic-dashboard`:
+
+- same shell, sticky topbar, cards, table, chips, buttons, modal, tokens, spacing, radius, and responsive behavior
+- add an `Automation` nav item
+- topbar shows current automation summary and a fixed-size `Credentials` button
+- credentials form opens in a modal; credentials are not shown after save
+- the main page is a task table
+- there is no global `Run selected` button
+- every task row has its own fixed-size controls: `Run`, `Resume`, `Retry`, `Logs`, or disabled `Locked`
+- control buttons keep stable dimensions across states so rows do not shift
+- each row shows status, attempt count, latest UTC time, and latest log tail
+- detailed logs open from the row, backed by the task run log file, not from a separate bottom log panel
+
+## Credentials
+
+The credentials modal reads and writes the existing `.env` keys used by the workflows:
+
+- Fubon: `LIBRETTO_CLOUD_FUBON_USER_ID`, `LIBRETTO_CLOUD_FUBON_ACCOUNT`, `LIBRETTO_CLOUD_FUBON_PASSWORD`
+- ESun: `LIBRETTO_CLOUD_ESUN_USER_ID`, `LIBRETTO_CLOUD_ESUN_ACCOUNT`, `LIBRETTO_CLOUD_ESUN_PASSWORD`
+- Yuanta: `LIBRETTO_CLOUD_YUANTA_USER_ID`, `LIBRETTO_CLOUD_YUANTA_ACCOUNT`, `LIBRETTO_CLOUD_YUANTA_PASSWORD`
+- Yuanta trade: `LIBRETTO_CLOUD_YUANTA_TRADE_USER_ID`, `LIBRETTO_CLOUD_YUANTA_TRADE_PASSWORD`, `LIBRETTO_CLOUD_YUANTA_TRADE_CA_PATH`, `LIBRETTO_CLOUD_YUANTA_TRADE_CA_PASSWORD`
+- Cathay: `LIBRETTO_CLOUD_CATHAY_USER_ID`, `LIBRETTO_CLOUD_CATHAY_ACCOUNT`, `LIBRETTO_CLOUD_CATHAY_PASSWORD`
+- HNCB: `LIBRETTO_CLOUD_HNCB_USER_ID`, `LIBRETTO_CLOUD_HNCB_ACCOUNT`, `LIBRETTO_CLOUD_HNCB_PASSWORD`
+- MAX/MaiCoin: `MAX_ACCESS_KEY`, `MAX_SECRET_KEY`, `MAX_SUB_ACCOUNT`
+
+Credential save preserves unrelated `.env` lines and comments when possible. Secret inputs show saved/missing state but do not echo existing secret values back into the page.
+
+## Runner
+
+The server keeps a fixed task registry with:
+
+- task id
+- display name
+- npm script
+- kind: `crawler`, `sync`, or `import`
+- dependencies
+- credential group
+- max attempts
+
+Task execution uses the current scripts through `spawn("npm", ["run", script])`.
+
+The runner only allows one active task at a time. A task can be started from its row. If another task is running, the start request is rejected with a clear message.
+
+Crawler tasks get up to two total attempts: the first run plus one automatic retry after a non-zero exit. If the retry fails, the task is `failed`.
+
+## Human In The Loop
+
+CAPTCHA, OTP, device trust, certificate selection, and similar manual bank steps remain inside the Libretto browser session. OctopusBeak only shows that the task is waiting for human action.
+
+`waiting_for_human` is an application status derived from task output or Libretto pause/resume indicators while the process is still alive. It is not a failure state.
+
+## Import Gate
+
+`run:import-downloads-csv` is locked until every CSV-producing crawler dependency has a latest successful run for the current business day.
+
+The lock is checked on the server from SQLite task run history. It does not depend on current page state, selected rows, or client memory.
+
+When the dependency check passes, import may be started manually from its row or automatically by the server after the last dependency completes.
+
+## Time Rules
+
+The database stores UTC timestamps only, as ISO strings.
+
+The application computes the current business-day window from an env variable:
+
+- `AUTOMATION_BUSINESS_TIMEZONE`
+- value is an IANA timezone, for example `Asia/Taipei`
+- default is `Asia/Taipei`
+
+For dependency checks, the app converts the current business day in `AUTOMATION_BUSINESS_TIMEZONE` to a UTC start/end range, then queries task runs by UTC timestamps.
+
+No local-time business date needs to be persisted in SQLite.
+
+## SQLite Tables
+
+Add a small automation history schema to the existing ledger database:
+
+- `automation_task_runs`
+  - `task_run_id`
+  - `task_id`
+  - `script`
+  - `kind`
+  - `status`
+  - `attempt`
+  - `max_attempts`
+  - `started_at`
+  - `finished_at`
+  - `exit_code`
+  - `signal`
+  - `error_message`
+  - `log_path`
+  - `log_tail`
+  - `record_json`
+
+Existing `import_runs`, `import_run_events`, and `maicoin_sync_runs` remain unchanged. They continue to record domain-specific import/sync details.
+
+Full task stdout/stderr is written to `data/automation/logs/<task_run_id>.log`. SQLite stores only the path and latest tail for fast page loads.
+
+## Statuses
+
+Task statuses:
+
+- `queued`
+- `running`
+- `waiting_for_human`
+- `retrying`
+- `completed`
+- `failed`
+- `locked`
+
+`locked` is used by the import task when dependency checks fail.
+
+## API Shape
+
+Use SvelteKit server routes/actions for:
+
+- loading task registry, current statuses, and credential saved/missing state
+- saving `.env`
+- starting one task
+- retrying one failed task
+- reading task logs/history
+
+The status endpoint returns server-derived state. The client polls while any task is active.
+
+## Error Handling
+
+- missing credentials fail before spawning the task when the missing keys are known
+- spawn failure is recorded as `failed`
+- non-zero exit records exit code, error summary, and log tail
+- first non-zero crawler exit triggers one automatic retry
+- second non-zero crawler exit remains `failed`
+- failed dependency keeps import locked
+- server restart does not resurrect active processes, but existing UTC task history remains visible
+
+## Testing
+
+Add focused checks for:
+
+- timezone business-day window conversion from `AUTOMATION_BUSINESS_TIMEZONE`
+- import gate reads dependency status from SQLite history, not client state
+- retry policy allows one automatic retry for crawlers
+- `.env` update preserves unrelated keys/comments
+- task registry exposes the expected scripts and dependencies
+
+UI verification should include desktop and mobile viewports from `docs/specs/001-dynamic-dashboard/DESIGN-MANIFEST.json`, with no horizontal overflow and stable task-row controls.

--- a/src/ledger/db/migrations.ts
+++ b/src/ledger/db/migrations.ts
@@ -555,6 +555,32 @@ function addMaicoinStatementValueTwd(db: LedgerDatabase) {
   addColumnIfMissing(db, "maicoin_statement_rows", "value_twd", "value_twd REAL");
 }
 
+function createAutomationTaskRuns(db: LedgerDatabase) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS automation_task_runs (
+      task_run_id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      script TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempt INTEGER NOT NULL,
+      max_attempts INTEGER NOT NULL,
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      exit_code INTEGER,
+      signal TEXT,
+      error_message TEXT,
+      log_path TEXT NOT NULL,
+      log_tail TEXT NOT NULL,
+      record_json TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_automation_task_runs_latest
+    ON automation_task_runs(task_id, started_at);
+    CREATE INDEX IF NOT EXISTS idx_automation_task_runs_status
+    ON automation_task_runs(status, started_at);
+  `);
+}
+
 const migrations: LedgerMigration[] = [
   {
     version: 1,
@@ -585,6 +611,11 @@ const migrations: LedgerMigration[] = [
     version: 6,
     name: "maicoin_statement_value_twd",
     up: addMaicoinStatementValueTwd,
+  },
+  {
+    version: 7,
+    name: "automation_task_runs",
+    up: createAutomationTaskRuns,
   },
 ];
 

--- a/src/ledger/db/schema.ts
+++ b/src/ledger/db/schema.ts
@@ -278,3 +278,21 @@ export const maicoinStatementRows = sqliteTable("maicoin_statement_rows", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });
+
+export const automationTaskRuns = sqliteTable("automation_task_runs", {
+  taskRunId: text("task_run_id").primaryKey(),
+  taskId: text("task_id").notNull(),
+  script: text("script").notNull(),
+  kind: text("kind").notNull(),
+  status: text("status").notNull(),
+  attempt: integer("attempt").notNull(),
+  maxAttempts: integer("max_attempts").notNull(),
+  startedAt: text("started_at").notNull(),
+  finishedAt: text("finished_at"),
+  exitCode: integer("exit_code"),
+  signal: text("signal"),
+  errorMessage: text("error_message"),
+  logPath: text("log_path").notNull(),
+  logTail: text("log_tail").notNull(),
+  recordJson: text("record_json").notNull(),
+});

--- a/src/lib/automation/AutomationDashboard.svelte
+++ b/src/lib/automation/AutomationDashboard.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { invalidateAll } from "$app/navigation";
+  import DashboardShell from "$lib/shared-shell/components/DashboardShell.svelte";
+  import type { AutomationPageModel, AutomationTaskRow } from "./server/page-model.ts";
+
+  export let automation: AutomationPageModel;
+  export let credentialKeys: string[];
+
+  let credentialsOpen = false;
+  let logTask: AutomationTaskRow | null = null;
+  let valuesVisible = true;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  $: sideValue = automation.active ? "Running" : automation.importGate.locked ? "Import locked" : "Ready";
+  $: sideSub = `Business day ${automation.businessDate}`;
+  $: topStatus = automation.active
+    ? "Running"
+    : automation.importGate.locked
+      ? "Import locked"
+      : "Ready";
+  $: topStatusClass = automation.active
+    ? "warn"
+    : automation.importGate.locked
+      ? "bad"
+      : "good";
+
+  onMount(() => {
+    if (automation.active) {
+      pollTimer = setInterval(() => {
+        void invalidateAll();
+      }, 2_000);
+    }
+  });
+
+  onDestroy(() => {
+    if (pollTimer) clearInterval(pollTimer);
+  });
+
+  function statusClass(status: string) {
+    if (status === "completed") return "good";
+    if (status === "failed" || status === "locked") return "bad";
+    if (status === "running" || status === "retrying" || status === "waiting_for_human") return "warn";
+    return "";
+  }
+
+  function formatTime(value: string | null) {
+    return value?.slice(0, 19).replace("T", " ") ?? "--";
+  }
+
+  function credentialLabel(key: string) {
+    return key
+      .replace(/^LIBRETTO_CLOUD_/, "")
+      .replace(/_/g, " ")
+      .toLowerCase();
+  }
+
+  function actionName(task: AutomationTaskRow) {
+    return task.primaryAction === "Retry" ? "retry" : "run";
+  }
+</script>
+
+<DashboardShell
+  active="automation"
+  eyebrow="Automation"
+  title="Statement Update"
+  sideLabel="Automation"
+  {sideValue}
+  {sideSub}
+  bind:valuesVisible
+>
+  <svelte:fragment slot="topbar-actions">
+    <span class={`chip ${topStatusClass}`}>{topStatus}</span>
+    <button class="button secondary fixed-action" type="button" onclick={() => (credentialsOpen = true)}>Credentials</button>
+  </svelte:fragment>
+
+  <div class="content">
+    <section class="card">
+      <div class="panel-title automation-title">
+        <div>
+          <h2>Task queue</h2>
+          <p>Tasks run one at a time. CSV import unlocks from today's persisted crawler history, not page state.</p>
+        </div>
+        <span class="chip">UTC history</span>
+      </div>
+
+      <div class="table-wrap">
+        <table class="table automation-table">
+          <thead>
+            <tr>
+              <th>Task</th>
+              <th>Status</th>
+              <th>Attempt</th>
+              <th>Latest UTC</th>
+              <th>Latest log</th>
+              <th class="right">Controls</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each automation.tasks as task}
+              <tr>
+                <td>
+                  <div class="task-name">
+                    <strong>{task.label}</strong>
+                    <span>{task.script}</span>
+                  </div>
+                </td>
+                <td><span class={`chip ${statusClass(task.status)}`}>{task.status.replaceAll("_", " ")}</span></td>
+                <td class="mono">{task.attempt}/{task.maxAttempts}</td>
+                <td class="mono">{formatTime(task.latestFinishedAt ?? task.latestStartedAt)}</td>
+                <td class="mono log-tail">{task.errorMessage ?? (task.logTail || "--")}</td>
+                <td class="right">
+                  <div class="task-actions">
+                    <form method="POST" action={`?/${actionName(task)}`}>
+                      <input type="hidden" name="taskId" value={task.id} />
+                      <button class="button primary task-control" type="submit" disabled={!task.canRun}>
+                        {task.primaryAction}
+                      </button>
+                    </form>
+                    <button class="button secondary task-control" type="button" onclick={() => (logTask = task)}>
+                      Logs
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</DashboardShell>
+
+{#if credentialsOpen}
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="credentials-title">
+    <button class="modal-backdrop" type="button" aria-label="Close credentials" onclick={() => (credentialsOpen = false)}></button>
+    <form class="modal-panel credential-modal" method="POST" action="?/saveCredentials">
+      <div class="modal-head">
+        <div>
+          <h2 id="credentials-title">Credentials</h2>
+          <p>Saved to local .env. Existing secret values are shown only as saved or missing.</p>
+        </div>
+        <button class="modal-close" type="button" aria-label="Close" onclick={() => (credentialsOpen = false)}>x</button>
+      </div>
+      <div class="modal-body credential-body">
+        <div class="credential-grid">
+          {#each credentialKeys as key}
+            <label class="credential-field">
+              <span>{credentialLabel(key)}</span>
+              <input
+                name={key}
+                type={key.includes("PASSWORD") || key.includes("SECRET") || key.includes("KEY") ? "password" : "text"}
+                placeholder={automation.credentials[key] ? "saved" : "missing"}
+                autocomplete="off"
+              />
+            </label>
+          {/each}
+        </div>
+        <div class="modal-actions">
+          <button class="button fixed-action" type="button" onclick={() => (credentialsOpen = false)}>Cancel</button>
+          <button class="button primary fixed-action" type="submit">Save .env</button>
+        </div>
+      </div>
+    </form>
+  </div>
+{/if}
+
+{#if logTask}
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="logs-title">
+    <button class="modal-backdrop" type="button" aria-label="Close logs" onclick={() => (logTask = null)}></button>
+    <div class="modal-panel">
+      <div class="modal-head">
+        <div>
+          <h2 id="logs-title">{logTask.label} Logs</h2>
+          <p>{logTask.logPath ?? "No log file yet."}</p>
+        </div>
+        <button class="modal-close" type="button" aria-label="Close" onclick={() => (logTask = null)}>x</button>
+      </div>
+      <div class="modal-body">
+        <pre class="log-output">{logTask.errorMessage ?? (logTask.logTail || "No logs yet.")}</pre>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .automation-title {
+    align-items: flex-start;
+  }
+
+  .automation-title p,
+  .modal-head p {
+    margin: var(--space-1) 0 0;
+    color: var(--muted);
+    font-size: 13px;
+  }
+
+  .automation-table td {
+    vertical-align: middle;
+  }
+
+  .task-name {
+    min-width: 220px;
+    display: grid;
+    gap: 2px;
+  }
+
+  .task-name strong {
+    font-weight: 720;
+  }
+
+  .task-name span,
+  .mono {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+
+  .log-tail {
+    max-width: 360px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .task-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+  }
+
+  .task-control,
+  .fixed-action {
+    width: 112px;
+    min-width: 112px;
+  }
+
+  .chip.warn {
+    color: var(--warn);
+    background: color-mix(in oklch, var(--warn) 10%, white);
+  }
+
+  .chip.bad {
+    color: var(--danger);
+    background: color-mix(in oklch, var(--danger) 10%, white);
+  }
+
+  .credential-modal {
+    width: min(820px, 100%);
+  }
+
+  .credential-body {
+    padding: var(--space-5);
+  }
+
+  .credential-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-4);
+  }
+
+  .credential-field {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .credential-field span {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 720;
+    letter-spacing: 0.075em;
+    text-transform: uppercase;
+  }
+
+  .credential-field input {
+    min-height: 44px;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--fg);
+    outline: none;
+  }
+
+  .credential-field input:focus {
+    border-color: var(--fg);
+    box-shadow: 0 0 0 3px var(--surface-soft);
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    margin-top: var(--space-5);
+  }
+
+  .log-output {
+    min-height: 240px;
+    margin: 0;
+    padding: var(--space-5);
+    overflow: auto;
+    color: var(--fg);
+    background: var(--surface-soft);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    white-space: pre-wrap;
+  }
+
+  @media (max-width: 820px) {
+    .credential-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .task-actions {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/src/lib/automation/AutomationDashboard.svelte
+++ b/src/lib/automation/AutomationDashboard.svelte
@@ -56,7 +56,9 @@
   }
 
   function actionName(task: AutomationTaskRow) {
-    return task.primaryAction === "Retry" ? "retry" : "run";
+    if (task.primaryAction === "Retry") return "retry";
+    if (task.primaryAction === "Resume") return "resume";
+    return "run";
   }
 </script>
 

--- a/src/lib/automation/AutomationDashboard.svelte
+++ b/src/lib/automation/AutomationDashboard.svelte
@@ -12,10 +12,10 @@
   let valuesVisible = true;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
 
-  $: sideValue = automation.active ? "Running" : automation.importGate.locked ? "Import locked" : "Ready";
+  $: sideValue = automation.active ? `${automation.activeTaskCount} running` : automation.importGate.locked ? "Import locked" : "Ready";
   $: sideSub = `Business day ${automation.businessDate}`;
   $: topStatus = automation.active
-    ? "Running"
+    ? `${automation.activeTaskCount} running`
     : automation.importGate.locked
       ? "Import locked"
       : "Ready";
@@ -81,7 +81,7 @@
       <div class="panel-title automation-title">
         <div>
           <h2>Task queue</h2>
-          <p>Tasks run one at a time. CSV import unlocks from today's persisted crawler history, not page state.</p>
+          <p>Tasks can run in parallel. CSV import unlocks from today's persisted crawler history, not page state.</p>
         </div>
         <span class="chip">UTC history</span>
       </div>
@@ -92,6 +92,7 @@
             <tr>
               <th>Task</th>
               <th>Status</th>
+              <th>Progress</th>
               <th>Attempt</th>
               <th>Latest UTC</th>
               <th>Latest log</th>
@@ -108,6 +109,14 @@
                   </div>
                 </td>
                 <td><span class={`chip ${statusClass(task.status)}`}>{task.status.replaceAll("_", " ")}</span></td>
+                <td>
+                  <div class="progress-cell">
+                    <div class="progress-bar" aria-hidden="true">
+                      <span style={`width: ${task.progressPercent ?? 0}%`}></span>
+                    </div>
+                    <span class="mono">{task.progressText}</span>
+                  </div>
+                </td>
                 <td class="mono">{task.attempt}/{task.maxAttempts}</td>
                 <td class="mono">{formatTime(task.latestFinishedAt ?? task.latestStartedAt)}</td>
                 <td class="mono log-tail">{task.errorMessage ?? (task.logTail || "--")}</td>
@@ -115,7 +124,7 @@
                   <div class="task-actions">
                     <form method="POST" action={`?/${actionName(task)}`}>
                       <input type="hidden" name="taskId" value={task.id} />
-                      <button class="button primary task-control" type="submit" disabled={!task.canRun}>
+                      <button class="button primary task-control" type="submit" disabled={!task.canRun} aria-busy={task.isActive}>
                         {task.primaryAction}
                       </button>
                     </form>
@@ -223,6 +232,27 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .progress-cell {
+    min-width: 150px;
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .progress-bar {
+    width: 100%;
+    height: 6px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--surface-soft);
+  }
+
+  .progress-bar span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--accent);
   }
 
   .task-actions {

--- a/src/lib/automation/server/automation-core.check.ts
+++ b/src/lib/automation/server/automation-core.check.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import {
+  AUTOMATION_TASKS,
+  CSV_IMPORT_DEPENDENCY_IDS,
+  taskById,
+} from "./tasks.ts";
+import { businessDayUtcRange } from "./business-day.ts";
+import { credentialStatus, updateEnvText } from "./env-file.ts";
+
+const fubonUserKey = "LIBRETTO_CLOUD_FUBON" + "_USER_ID";
+
+assert.deepEqual(
+  CSV_IMPORT_DEPENDENCY_IDS,
+  [
+    "fubon-all-statements",
+    "esun-credit-card-statements",
+    "yuanta-all-statements",
+    "yuanta-trade-statements",
+    "cathay-all-statements",
+    "hncb-statements",
+  ],
+);
+
+assert.equal(taskById("sync-maicoin")?.kind, "sync");
+assert.equal(taskById("import-downloads-csv")?.kind, "import");
+assert.deepEqual(
+  taskById("import-downloads-csv")?.dependencies,
+  CSV_IMPORT_DEPENDENCY_IDS,
+);
+assert.equal(AUTOMATION_TASKS.every((task) => task.maxAttempts >= 1), true);
+
+const taipeiRange = businessDayUtcRange(
+  new Date("2026-06-30T16:30:00.000Z"),
+  "Asia/Taipei",
+);
+assert.equal(taipeiRange.businessDate, "2026-07-01");
+assert.equal(taipeiRange.startUtc.toISOString(), "2026-06-30T16:00:00.000Z");
+assert.equal(taipeiRange.endUtc.toISOString(), "2026-07-01T16:00:00.000Z");
+
+const updatedEnv = updateEnvText(
+  `# keep me\n${fubonUserKey}=old\nOTHER=value\n`,
+  {
+    [fubonUserKey]: "new-user",
+    MAX_SUB_ACCOUNT: "main",
+  },
+);
+assert.equal(
+  updatedEnv,
+  `# keep me\n${fubonUserKey}=new-user\nOTHER=value\nMAX_SUB_ACCOUNT=main\n`,
+);
+
+assert.deepEqual(
+  credentialStatus(`${fubonUserKey}=abc\nMAX_SECRET_KEY=\n`),
+  {
+    [fubonUserKey]: true,
+    MAX_SECRET_KEY: false,
+  },
+);

--- a/src/lib/automation/server/business-day.ts
+++ b/src/lib/automation/server/business-day.ts
@@ -1,0 +1,71 @@
+type DateParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+function partsInTimeZone(date: Date, timeZone: string): DateParts {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return {
+    year: Number(values.year),
+    month: Number(values.month),
+    day: Number(values.day),
+    hour: Number(values.hour),
+    minute: Number(values.minute),
+    second: Number(values.second),
+  };
+}
+
+function offsetMs(date: Date, timeZone: string) {
+  const parts = partsInTimeZone(date, timeZone);
+  const localAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return localAsUtc - date.getTime();
+}
+
+function zonedMidnightUtc(year: number, month: number, day: number, timeZone: string) {
+  let utc = Date.UTC(year, month - 1, day);
+  for (let index = 0; index < 3; index += 1) {
+    utc = Date.UTC(year, month - 1, day) - offsetMs(new Date(utc), timeZone);
+  }
+  return new Date(utc);
+}
+
+export function businessDayUtcRange(
+  now = new Date(),
+  timeZone = process.env.AUTOMATION_BUSINESS_TIMEZONE ?? "Asia/Taipei",
+) {
+  const parts = partsInTimeZone(now, timeZone);
+  const startUtc = zonedMidnightUtc(parts.year, parts.month, parts.day, timeZone);
+  const endLocal = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + 1));
+  const endUtc = zonedMidnightUtc(
+    endLocal.getUTCFullYear(),
+    endLocal.getUTCMonth() + 1,
+    endLocal.getUTCDate(),
+    timeZone,
+  );
+  return {
+    businessDate: `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}`,
+    startUtc,
+    endUtc,
+  };
+}

--- a/src/lib/automation/server/env-file.ts
+++ b/src/lib/automation/server/env-file.ts
@@ -1,0 +1,36 @@
+const envLinePattern = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+export function parseEnvText(text: string) {
+  const result: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = envLinePattern.exec(line);
+    if (match) result[match[1]] = match[2];
+  }
+  return result;
+}
+
+export function credentialStatus(text: string, keys?: readonly string[]) {
+  const env = parseEnvText(text);
+  const selectedKeys = keys ?? Object.keys(env);
+  return Object.fromEntries(
+    selectedKeys.map((key) => [key, Boolean(env[key]?.trim())]),
+  );
+}
+
+export function updateEnvText(text: string, updates: Record<string, string>) {
+  const remaining = new Set(Object.keys(updates));
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  const nextLines = lines.map((line) => {
+    const match = envLinePattern.exec(line);
+    if (!match) return line;
+    const key = match[1];
+    if (!remaining.has(key)) return line;
+    remaining.delete(key);
+    return `${key}=${updates[key]}`;
+  });
+
+  for (const key of remaining) nextLines.push(`${key}=${updates[key]}`);
+  return `${nextLines.join("\n")}\n`;
+}

--- a/src/lib/automation/server/page-model.check.ts
+++ b/src/lib/automation/server/page-model.check.ts
@@ -26,6 +26,7 @@ const latestRuns: Record<string, AutomationTaskRun> = {
 const model = buildAutomationPageModel({
   tasks: AUTOMATION_TASKS,
   latestRuns,
+  activeTaskIds: [],
   credentials: {
     LIBRETTO_CLOUD_FUBON_USER_ID: true,
     MAX_ACCESS_KEY: false,
@@ -61,6 +62,7 @@ const failedModel = buildAutomationPageModel({
       errorMessage: "Task exited with code 1",
     },
   },
+  activeTaskIds: [],
   credentials: {},
   importGate: {
     locked: true,
@@ -73,3 +75,34 @@ const failedModel = buildAutomationPageModel({
 const failedRow = failedModel.tasks.find((task) => task.id === "hncb-statements");
 assert.equal(failedRow?.primaryAction, "Retry");
 assert.equal(failedRow?.canRun, true);
+
+const activeModel = buildAutomationPageModel({
+  tasks: AUTOMATION_TASKS,
+  latestRuns: {
+    "fubon-all-statements": {
+      ...latestRuns["fubon-all-statements"],
+      taskRunId: "run-3",
+      status: "running",
+      finishedAt: null,
+      logTail: "automation-progress: 42\nDownloading statements",
+    },
+  },
+  activeTaskIds: ["fubon-all-statements"],
+  credentials: {},
+  importGate: {
+    locked: true,
+    missingTaskIds: [],
+  },
+  active: true,
+  businessDate: "2026-06-30",
+});
+
+const activeFubonRow = activeModel.tasks.find((task) => task.id === "fubon-all-statements");
+const activeEsunRow = activeModel.tasks.find((task) => task.id === "esun-credit-card-statements");
+assert.equal(activeModel.activeTaskCount, 1);
+assert.equal(activeFubonRow?.isActive, true);
+assert.equal(activeFubonRow?.canRun, false);
+assert.equal(activeFubonRow?.primaryAction, "Running");
+assert.equal(activeFubonRow?.progressPercent, 42);
+assert.equal(activeFubonRow?.progressText, "42%");
+assert.equal(activeEsunRow?.canRun, true);

--- a/src/lib/automation/server/page-model.check.ts
+++ b/src/lib/automation/server/page-model.check.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { buildAutomationPageModel } from "./page-model.ts";
+import { AUTOMATION_TASKS } from "./tasks.ts";
+import type { AutomationTaskRun } from "./store.ts";
+
+const latestRuns: Record<string, AutomationTaskRun> = {
+  "fubon-all-statements": {
+    taskRunId: "run-1",
+    taskId: "fubon-all-statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    status: "completed",
+    attempt: 1,
+    maxAttempts: 2,
+    startedAt: "2026-06-30T01:00:00.000Z",
+    finishedAt: "2026-06-30T01:01:00.000Z",
+    exitCode: 0,
+    signal: null,
+    errorMessage: null,
+    logPath: "data/automation/logs/run-1.log",
+    logTail: "ok",
+    recordJson: "{}",
+  },
+};
+
+const model = buildAutomationPageModel({
+  tasks: AUTOMATION_TASKS,
+  latestRuns,
+  credentials: {
+    LIBRETTO_CLOUD_FUBON_USER_ID: true,
+    MAX_ACCESS_KEY: false,
+  },
+  importGate: {
+    locked: true,
+    missingTaskIds: ["esun-credit-card-statements"],
+  },
+  active: false,
+  businessDate: "2026-06-30",
+});
+
+const importRow = model.tasks.find((task) => task.id === "import-downloads-csv");
+assert.equal(importRow?.status, "locked");
+assert.equal(importRow?.primaryAction, "Locked");
+assert.equal(importRow?.canRun, false);
+
+const fubonRow = model.tasks.find((task) => task.id === "fubon-all-statements");
+assert.equal(fubonRow?.status, "completed");
+assert.equal(fubonRow?.primaryAction, "Run");
+assert.equal(fubonRow?.logTail, "ok");
+
+const failedModel = buildAutomationPageModel({
+  tasks: AUTOMATION_TASKS,
+  latestRuns: {
+    "hncb-statements": {
+      ...latestRuns["fubon-all-statements"],
+      taskRunId: "run-2",
+      taskId: "hncb-statements",
+      script: "run:hncb-statements",
+      status: "failed",
+      exitCode: 1,
+      errorMessage: "Task exited with code 1",
+    },
+  },
+  credentials: {},
+  importGate: {
+    locked: true,
+    missingTaskIds: [],
+  },
+  active: false,
+  businessDate: "2026-06-30",
+});
+
+const failedRow = failedModel.tasks.find((task) => task.id === "hncb-statements");
+assert.equal(failedRow?.primaryAction, "Retry");
+assert.equal(failedRow?.canRun, true);

--- a/src/lib/automation/server/page-model.ts
+++ b/src/lib/automation/server/page-model.ts
@@ -1,0 +1,72 @@
+import type { AutomationTask } from "./tasks.ts";
+import type { AutomationTaskRun, AutomationTaskStatus } from "./store.ts";
+
+type ImportGate = {
+  locked: boolean;
+  missingTaskIds: readonly string[];
+};
+
+export type AutomationTaskRow = AutomationTask & {
+  status: AutomationTaskStatus;
+  attempt: number;
+  latestStartedAt: string | null;
+  latestFinishedAt: string | null;
+  logTail: string;
+  errorMessage: string | null;
+  logPath: string | null;
+  primaryAction: "Run" | "Resume" | "Retry" | "Locked";
+  canRun: boolean;
+};
+
+export type AutomationPageModel = {
+  businessDate: string;
+  active: boolean;
+  credentials: Record<string, boolean>;
+  importGate: ImportGate;
+  tasks: AutomationTaskRow[];
+};
+
+function rowStatus(task: AutomationTask, run: AutomationTaskRun | undefined, gate: ImportGate) {
+  if (task.kind === "import" && gate.locked) return "locked";
+  return run?.status ?? "queued";
+}
+
+function primaryAction(status: AutomationTaskStatus) {
+  if (status === "locked") return "Locked";
+  if (status === "failed") return "Retry";
+  if (status === "waiting_for_human") return "Resume";
+  return "Run";
+}
+
+export function buildAutomationPageModel(input: {
+  tasks: readonly AutomationTask[];
+  latestRuns: Record<string, AutomationTaskRun>;
+  credentials: Record<string, boolean>;
+  importGate: ImportGate;
+  active: boolean;
+  businessDate: string;
+}): AutomationPageModel {
+  return {
+    businessDate: input.businessDate,
+    active: input.active,
+    credentials: input.credentials,
+    importGate: input.importGate,
+    tasks: input.tasks.map((task) => {
+      const run = input.latestRuns[task.id];
+      const status = rowStatus(task, run, input.importGate);
+      const action = primaryAction(status);
+      return {
+        ...task,
+        status,
+        attempt: run?.attempt ?? 0,
+        latestStartedAt: run?.startedAt ?? null,
+        latestFinishedAt: run?.finishedAt ?? null,
+        logTail: run?.logTail ?? "",
+        errorMessage: run?.errorMessage ?? null,
+        logPath: run?.logPath ?? null,
+        primaryAction: action,
+        canRun: !input.active && action !== "Locked",
+      };
+    }),
+  };
+}

--- a/src/lib/automation/server/page-model.ts
+++ b/src/lib/automation/server/page-model.ts
@@ -1,5 +1,6 @@
 import type { AutomationTask } from "./tasks.ts";
 import type { AutomationTaskRun, AutomationTaskStatus } from "./store.ts";
+import { parseAutomationProgress } from "./runner.ts";
 
 type ImportGate = {
   locked: boolean;
@@ -14,58 +15,90 @@ export type AutomationTaskRow = AutomationTask & {
   logTail: string;
   errorMessage: string | null;
   logPath: string | null;
-  primaryAction: "Run" | "Resume" | "Retry" | "Locked";
+  progressPercent: number | null;
+  progressText: string;
+  isActive: boolean;
+  primaryAction: "Run" | "Resume" | "Retry" | "Locked" | "Running" | "Retrying";
   canRun: boolean;
 };
 
 export type AutomationPageModel = {
   businessDate: string;
   active: boolean;
+  activeTaskCount: number;
   credentials: Record<string, boolean>;
   importGate: ImportGate;
   tasks: AutomationTaskRow[];
 };
 
-function rowStatus(task: AutomationTask, run: AutomationTaskRun | undefined, gate: ImportGate) {
+function rowStatus(
+  task: AutomationTask,
+  run: AutomationTaskRun | undefined,
+  gate: ImportGate,
+  isActive: boolean,
+) {
   if (task.kind === "import" && gate.locked) return "locked";
+  if (isActive && !run) return "running";
   return run?.status ?? "queued";
 }
 
 function primaryAction(status: AutomationTaskStatus) {
   if (status === "locked") return "Locked";
+  if (status === "running") return "Running";
+  if (status === "retrying") return "Retrying";
   if (status === "failed") return "Retry";
   if (status === "waiting_for_human") return "Resume";
   return "Run";
 }
 
+function progressText(status: AutomationTaskStatus, attempt: number, maxAttempts: number, progress: number | null) {
+  if (progress !== null) return `${progress}%`;
+  if (status === "running") return `Running attempt ${attempt}/${maxAttempts}`;
+  if (status === "retrying") return `Retrying attempt ${attempt}/${maxAttempts}`;
+  if (status === "waiting_for_human") return "Waiting for human";
+  if (status === "completed") return "Completed";
+  if (status === "failed") return "Failed";
+  if (status === "locked") return "Locked";
+  return "Queued";
+}
+
 export function buildAutomationPageModel(input: {
   tasks: readonly AutomationTask[];
   latestRuns: Record<string, AutomationTaskRun>;
+  activeTaskIds?: readonly string[];
   credentials: Record<string, boolean>;
   importGate: ImportGate;
   active: boolean;
   businessDate: string;
 }): AutomationPageModel {
+  const activeTaskIds = new Set(input.activeTaskIds ?? []);
   return {
     businessDate: input.businessDate,
-    active: input.active,
+    active: input.active || activeTaskIds.size > 0,
+    activeTaskCount: activeTaskIds.size,
     credentials: input.credentials,
     importGate: input.importGate,
     tasks: input.tasks.map((task) => {
       const run = input.latestRuns[task.id];
-      const status = rowStatus(task, run, input.importGate);
+      const isActive = activeTaskIds.has(task.id);
+      const status = rowStatus(task, run, input.importGate, isActive);
       const action = primaryAction(status);
+      const progressPercent = parseAutomationProgress(run?.logTail ?? "");
+      const attempt = run?.attempt ?? 0;
       return {
         ...task,
         status,
-        attempt: run?.attempt ?? 0,
+        attempt,
         latestStartedAt: run?.startedAt ?? null,
         latestFinishedAt: run?.finishedAt ?? null,
         logTail: run?.logTail ?? "",
         errorMessage: run?.errorMessage ?? null,
         logPath: run?.logPath ?? null,
+        progressPercent,
+        progressText: progressText(status, attempt, run?.maxAttempts ?? task.maxAttempts, progressPercent),
+        isActive,
         primaryAction: action,
-        canRun: !input.active && action !== "Locked",
+        canRun: !isActive && action !== "Locked",
       };
     }),
   };

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   nextAttemptStatus,
+  parseAutomationProgress,
   resumeSessionFromLog,
   shouldAutoRunImport,
   shouldMarkWaitingForHuman,
@@ -16,6 +17,10 @@ assert.equal(
   "ses-1p4q",
 );
 assert.equal(resumeSessionFromLog("download completed"), null);
+assert.equal(parseAutomationProgress("automation-progress: 35"), 35);
+assert.equal(parseAutomationProgress("automation-progress: 20\nautomation-progress: 67"), 67);
+assert.equal(parseAutomationProgress("automation-progress: 105"), 100);
+assert.equal(parseAutomationProgress("download completed"), null);
 
 assert.equal(
   nextAttemptStatus({

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { nextAttemptStatus, shouldMarkWaitingForHuman } from "./runner.ts";
+
+assert.equal(shouldMarkWaitingForHuman("libretto paused. resume --session abc"), true);
+assert.equal(shouldMarkWaitingForHuman("Please enter OTP in browser"), true);
+assert.equal(shouldMarkWaitingForHuman("download completed"), false);
+
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 1 }),
+  "retrying",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 2, maxAttempts: 2, exitCode: 1 }),
+  "failed",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "sync", attempt: 1, maxAttempts: 1, exitCode: 1 }),
+  "failed",
+);
+assert.equal(
+  nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 0 }),
+  "completed",
+);

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { nextAttemptStatus, shouldMarkWaitingForHuman } from "./runner.ts";
+import {
+  nextAttemptStatus,
+  shouldAutoRunImport,
+  shouldMarkWaitingForHuman,
+} from "./runner.ts";
 
 assert.equal(shouldMarkWaitingForHuman("libretto paused. resume --session abc"), true);
 assert.equal(shouldMarkWaitingForHuman("Please enter OTP in browser"), true);
@@ -20,4 +24,21 @@ assert.equal(
 assert.equal(
   nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 0 }),
   "completed",
+);
+
+assert.equal(
+  shouldAutoRunImport({ kind: "crawler", status: "completed", importLocked: false }),
+  true,
+);
+assert.equal(
+  shouldAutoRunImport({ kind: "crawler", status: "failed", importLocked: false }),
+  false,
+);
+assert.equal(
+  shouldAutoRunImport({ kind: "sync", status: "completed", importLocked: false }),
+  false,
+);
+assert.equal(
+  shouldAutoRunImport({ kind: "crawler", status: "completed", importLocked: true }),
+  false,
 );

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -10,6 +10,16 @@ assert.equal(shouldMarkWaitingForHuman("Please enter OTP in browser"), true);
 assert.equal(shouldMarkWaitingForHuman("download completed"), false);
 
 assert.equal(
+  nextAttemptStatus({
+    kind: "crawler",
+    attempt: 1,
+    maxAttempts: 2,
+    exitCode: 0,
+    waitingForHuman: true,
+  }),
+  "waiting_for_human",
+);
+assert.equal(
   nextAttemptStatus({ kind: "crawler", attempt: 1, maxAttempts: 2, exitCode: 1 }),
   "retrying",
 );

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   nextAttemptStatus,
+  resumeSessionFromLog,
   shouldAutoRunImport,
   shouldMarkWaitingForHuman,
 } from "./runner.ts";
@@ -8,6 +9,13 @@ import {
 assert.equal(shouldMarkWaitingForHuman("libretto paused. resume --session abc"), true);
 assert.equal(shouldMarkWaitingForHuman("Please enter OTP in browser"), true);
 assert.equal(shouldMarkWaitingForHuman("download completed"), false);
+assert.equal(
+  resumeSessionFromLog(
+    "Workflow paused. run `npx libretto resume --session ses-1p4q`.",
+  ),
+  "ses-1p4q",
+);
+assert.equal(resumeSessionFromLog("download completed"), null);
 
 assert.equal(
   nextAttemptStatus({

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -1,0 +1,133 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  createTaskRun,
+  updateTaskRun,
+  type AutomationTaskStatus,
+} from "./store.ts";
+import { taskById, type AutomationTaskKind } from "./tasks.ts";
+
+let activeTaskRunId: string | null = null;
+
+export function shouldMarkWaitingForHuman(output: string) {
+  return /resume --session|paused|captcha|otp|verification|certificate/i.test(output);
+}
+
+export function nextAttemptStatus(input: {
+  kind: AutomationTaskKind;
+  attempt: number;
+  maxAttempts: number;
+  exitCode: number | null;
+}): AutomationTaskStatus {
+  if (input.exitCode === 0) return "completed";
+  if (input.kind === "crawler" && input.attempt < input.maxAttempts) return "retrying";
+  return "failed";
+}
+
+export function hasActiveAutomationTask() {
+  return activeTaskRunId !== null;
+}
+
+function appendLog(logPath: string, chunk: string) {
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, chunk);
+}
+
+function tail(value: string) {
+  return value.slice(-4000);
+}
+
+export function startAutomationTask(
+  taskId: string,
+  ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
+) {
+  if (activeTaskRunId) throw new Error("Another automation task is already running.");
+  void runAutomationTask(taskId, ledgerDir);
+}
+
+export async function runAutomationTask(
+  taskId: string,
+  ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
+) {
+  const task = taskById(taskId);
+  if (!task) throw new Error(`Unknown automation task: ${taskId}`);
+  if (activeTaskRunId) throw new Error("Another automation task is already running.");
+
+  const db = openLedgerDatabase(ledgerDir);
+  try {
+    for (let attempt = 1; attempt <= task.maxAttempts; attempt += 1) {
+      const startedAt = new Date().toISOString();
+      const logPath = join(
+        "data",
+        "automation",
+        "logs",
+        `${task.id}-${Date.now()}-${attempt}.log`,
+      );
+      const run = createTaskRun(db, {
+        taskId: task.id,
+        script: task.script,
+        kind: task.kind,
+        status: attempt > 1 ? "retrying" : "running",
+        attempt,
+        maxAttempts: task.maxAttempts,
+        startedAt,
+        logPath,
+      });
+      activeTaskRunId = run.taskRunId;
+      let logTail = "";
+
+      const result = await new Promise<{
+        exitCode: number | null;
+        signal: NodeJS.Signals | null;
+        error: Error | null;
+      }>((resolve) => {
+        const child = spawn("npm", ["run", task.script], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: process.env,
+        });
+        const onOutput = (chunk: Buffer) => {
+          const text = chunk.toString("utf8");
+          appendLog(logPath, text);
+          logTail = tail(logTail + text);
+          if (shouldMarkWaitingForHuman(logTail)) {
+            updateTaskRun(db, run.taskRunId, { status: "waiting_for_human", logTail });
+          }
+        };
+        child.stdout.on("data", onOutput);
+        child.stderr.on("data", onOutput);
+        child.on("error", (error) => {
+          resolve({ exitCode: null, signal: null, error });
+        });
+        child.on("close", (exitCode, signal) => {
+          resolve({ exitCode, signal, error: null });
+        });
+      });
+
+      const status = result.error
+        ? "failed"
+        : nextAttemptStatus({
+          kind: task.kind,
+          attempt,
+          maxAttempts: task.maxAttempts,
+          exitCode: result.exitCode,
+        });
+      updateTaskRun(db, run.taskRunId, {
+        status,
+        finishedAt: new Date().toISOString(),
+        exitCode: result.exitCode,
+        signal: result.signal,
+        logTail,
+        errorMessage: result.error?.message
+          ?? (status === "failed" ? `Task exited with code ${result.exitCode}` : null),
+      });
+      activeTaskRunId = null;
+      if (status === "completed") return { status };
+    }
+    return { status: "failed" as const };
+  } finally {
+    activeTaskRunId = null;
+    db.close();
+  }
+}

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -26,7 +26,9 @@ export function nextAttemptStatus(input: {
   attempt: number;
   maxAttempts: number;
   exitCode: number | null;
+  waitingForHuman?: boolean;
 }): AutomationTaskStatus {
+  if (input.waitingForHuman) return "waiting_for_human";
   if (input.exitCode === 0) return "completed";
   if (input.kind === "crawler" && input.attempt < input.maxAttempts) return "retrying";
   return "failed";
@@ -129,6 +131,7 @@ export async function runAutomationTask(
           attempt,
           maxAttempts: task.maxAttempts,
           exitCode: result.exitCode,
+          waitingForHuman: shouldMarkWaitingForHuman(logTail),
         });
       updateTaskRun(db, run.taskRunId, {
         status,
@@ -140,7 +143,8 @@ export async function runAutomationTask(
           ?? (status === "failed" ? `Task exited with code ${result.exitCode}` : null),
       });
       activeTaskRunId = null;
-      if (status === "completed") {
+      if (status !== "retrying") {
+        if (status !== "completed") return { status };
         const range = businessDayUtcRange();
         const gate = importGateStatus(db, {
           dependencyIds: CSV_IMPORT_DEPENDENCY_IDS,

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -21,6 +21,10 @@ export function shouldMarkWaitingForHuman(output: string) {
   return /resume --session|paused|captcha|otp|verification|certificate/i.test(output);
 }
 
+export function resumeSessionFromLog(output: string) {
+  return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
+}
+
 export function nextAttemptStatus(input: {
   kind: AutomationTaskKind;
   attempt: number;
@@ -66,9 +70,23 @@ export function startAutomationTask(
   });
 }
 
+export function startAutomationResume(
+  taskId: string,
+  session: string,
+  ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
+) {
+  if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
+  if (!session.match(/^[\w-]+$/)) throw new Error(`Invalid Libretto session: ${session}`);
+  if (activeTaskRunId) throw new Error("Another automation task is already running.");
+  void runAutomationTask(taskId, ledgerDir, { resumeSession: session }).catch((error) => {
+    console.error("automation-task-resume-failed", error);
+  });
+}
+
 export async function runAutomationTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
+  options: { resumeSession?: string } = {},
 ) {
   const task = taskById(taskId);
   if (!task) throw new Error(`Unknown automation task: ${taskId}`);
@@ -76,7 +94,8 @@ export async function runAutomationTask(
 
   const db = openLedgerDatabase(ledgerDir);
   try {
-    for (let attempt = 1; attempt <= task.maxAttempts; attempt += 1) {
+    const maxAttempts = options.resumeSession ? 1 : task.maxAttempts;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       const startedAt = new Date().toISOString();
       const logPath = join(
         "data",
@@ -84,13 +103,16 @@ export async function runAutomationTask(
         "logs",
         `${task.id}-${Date.now()}-${attempt}.log`,
       );
+      const script = options.resumeSession
+        ? `npx libretto resume --session ${options.resumeSession}`
+        : task.script;
       const run = createTaskRun(db, {
         taskId: task.id,
-        script: task.script,
+        script,
         kind: task.kind,
         status: attempt > 1 ? "retrying" : "running",
         attempt,
-        maxAttempts: task.maxAttempts,
+        maxAttempts,
         startedAt,
         logPath,
       });
@@ -102,7 +124,10 @@ export async function runAutomationTask(
         signal: NodeJS.Signals | null;
         error: Error | null;
       }>((resolve) => {
-        const child = spawn("npm", ["run", task.script], {
+        const command = options.resumeSession
+          ? ["npx", "libretto", "resume", "--session", options.resumeSession]
+          : ["npm", "run", task.script];
+        const child = spawn(command[0], command.slice(1), {
           stdio: ["ignore", "pipe", "pipe"],
           env: process.env,
         });
@@ -129,7 +154,7 @@ export async function runAutomationTask(
         : nextAttemptStatus({
           kind: task.kind,
           attempt,
-          maxAttempts: task.maxAttempts,
+          maxAttempts,
           exitCode: result.exitCode,
           waitingForHuman: shouldMarkWaitingForHuman(logTail),
         });

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -15,7 +15,7 @@ import {
   type AutomationTaskKind,
 } from "./tasks.ts";
 
-let activeTaskRunId: string | null = null;
+const activeTaskRunIds = new Map<string, string>();
 
 export function shouldMarkWaitingForHuman(output: string) {
   return /resume --session|paused|captcha|otp|verification|certificate/i.test(output);
@@ -23,6 +23,15 @@ export function shouldMarkWaitingForHuman(output: string) {
 
 export function resumeSessionFromLog(output: string) {
   return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
+}
+
+export function parseAutomationProgress(output: string) {
+  let progress: number | null = null;
+  for (const match of output.matchAll(/automation-progress:\s*(\d+(?:\.\d+)?)/gi)) {
+    const value = Math.round(Number(match[1]));
+    progress = Math.max(0, Math.min(100, value));
+  }
+  return progress;
 }
 
 export function nextAttemptStatus(input: {
@@ -47,7 +56,18 @@ export function shouldAutoRunImport(input: {
 }
 
 export function hasActiveAutomationTask() {
-  return activeTaskRunId !== null;
+  return activeTaskRunIds.size > 0;
+}
+
+export function activeAutomationTaskIds() {
+  return Array.from(activeTaskRunIds.keys());
+}
+
+function claimTask(taskId: string) {
+  if (activeTaskRunIds.has(taskId)) {
+    throw new Error(`Automation task is already running: ${taskId}`);
+  }
+  activeTaskRunIds.set(taskId, "pending");
 }
 
 function appendLog(logPath: string, chunk: string) {
@@ -64,8 +84,8 @@ export function startAutomationTask(
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
 ) {
   if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
-  if (activeTaskRunId) throw new Error("Another automation task is already running.");
-  void runAutomationTask(taskId, ledgerDir).catch((error) => {
+  claimTask(taskId);
+  void runAutomationTask(taskId, ledgerDir, { claimed: true }).catch((error) => {
     console.error("automation-task-run-failed", error);
   });
 }
@@ -77,8 +97,8 @@ export function startAutomationResume(
 ) {
   if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
   if (!session.match(/^[\w-]+$/)) throw new Error(`Invalid Libretto session: ${session}`);
-  if (activeTaskRunId) throw new Error("Another automation task is already running.");
-  void runAutomationTask(taskId, ledgerDir, { resumeSession: session }).catch((error) => {
+  claimTask(taskId);
+  void runAutomationTask(taskId, ledgerDir, { claimed: true, resumeSession: session }).catch((error) => {
     console.error("automation-task-resume-failed", error);
   });
 }
@@ -86,14 +106,16 @@ export function startAutomationResume(
 export async function runAutomationTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
-  options: { resumeSession?: string } = {},
+  options: { claimed?: boolean; resumeSession?: string } = {},
 ) {
   const task = taskById(taskId);
   if (!task) throw new Error(`Unknown automation task: ${taskId}`);
-  if (activeTaskRunId) throw new Error("Another automation task is already running.");
+  if (!options.claimed) claimTask(taskId);
 
-  const db = openLedgerDatabase(ledgerDir);
+  let db: ReturnType<typeof openLedgerDatabase> | null = null;
   try {
+    db = openLedgerDatabase(ledgerDir);
+    const taskDb = db;
     const maxAttempts = options.resumeSession ? 1 : task.maxAttempts;
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       const startedAt = new Date().toISOString();
@@ -106,7 +128,7 @@ export async function runAutomationTask(
       const script = options.resumeSession
         ? `npx libretto resume --session ${options.resumeSession}`
         : task.script;
-      const run = createTaskRun(db, {
+      const run = createTaskRun(taskDb, {
         taskId: task.id,
         script,
         kind: task.kind,
@@ -116,7 +138,7 @@ export async function runAutomationTask(
         startedAt,
         logPath,
       });
-      activeTaskRunId = run.taskRunId;
+      activeTaskRunIds.set(task.id, run.taskRunId);
       let logTail = "";
 
       const result = await new Promise<{
@@ -136,7 +158,7 @@ export async function runAutomationTask(
           appendLog(logPath, text);
           logTail = tail(logTail + text);
           if (shouldMarkWaitingForHuman(logTail)) {
-            updateTaskRun(db, run.taskRunId, { status: "waiting_for_human", logTail });
+            updateTaskRun(taskDb, run.taskRunId, { status: "waiting_for_human", logTail });
           }
         };
         child.stdout.on("data", onOutput);
@@ -158,7 +180,7 @@ export async function runAutomationTask(
           exitCode: result.exitCode,
           waitingForHuman: shouldMarkWaitingForHuman(logTail),
         });
-      updateTaskRun(db, run.taskRunId, {
+      updateTaskRun(taskDb, run.taskRunId, {
         status,
         finishedAt: new Date().toISOString(),
         exitCode: result.exitCode,
@@ -167,11 +189,10 @@ export async function runAutomationTask(
         errorMessage: result.error?.message
           ?? (status === "failed" ? `Task exited with code ${result.exitCode}` : null),
       });
-      activeTaskRunId = null;
       if (status !== "retrying") {
         if (status !== "completed") return { status };
         const range = businessDayUtcRange();
-        const gate = importGateStatus(db, {
+        const gate = importGateStatus(taskDb, {
           dependencyIds: CSV_IMPORT_DEPENDENCY_IDS,
           startUtc: range.startUtc,
           endUtc: range.endUtc,
@@ -180,7 +201,7 @@ export async function runAutomationTask(
           kind: task.kind,
           status,
           importLocked: gate.locked,
-        })) {
+        }) && !activeTaskRunIds.has("import-downloads-csv")) {
           await runAutomationTask("import-downloads-csv", ledgerDir);
         }
         return { status };
@@ -188,7 +209,7 @@ export async function runAutomationTask(
     }
     return { status: "failed" as const };
   } finally {
-    activeTaskRunId = null;
-    db.close();
+    activeTaskRunIds.delete(taskId);
+    db?.close();
   }
 }

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -2,12 +2,18 @@ import { spawn } from "node:child_process";
 import { mkdirSync, appendFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { businessDayUtcRange } from "./business-day.ts";
 import {
   createTaskRun,
+  importGateStatus,
   updateTaskRun,
   type AutomationTaskStatus,
 } from "./store.ts";
-import { taskById, type AutomationTaskKind } from "./tasks.ts";
+import {
+  CSV_IMPORT_DEPENDENCY_IDS,
+  taskById,
+  type AutomationTaskKind,
+} from "./tasks.ts";
 
 let activeTaskRunId: string | null = null;
 
@@ -24,6 +30,14 @@ export function nextAttemptStatus(input: {
   if (input.exitCode === 0) return "completed";
   if (input.kind === "crawler" && input.attempt < input.maxAttempts) return "retrying";
   return "failed";
+}
+
+export function shouldAutoRunImport(input: {
+  kind: AutomationTaskKind;
+  status: AutomationTaskStatus;
+  importLocked: boolean;
+}) {
+  return input.kind === "crawler" && input.status === "completed" && !input.importLocked;
 }
 
 export function hasActiveAutomationTask() {
@@ -43,8 +57,11 @@ export function startAutomationTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
 ) {
+  if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
   if (activeTaskRunId) throw new Error("Another automation task is already running.");
-  void runAutomationTask(taskId, ledgerDir);
+  void runAutomationTask(taskId, ledgerDir).catch((error) => {
+    console.error("automation-task-run-failed", error);
+  });
 }
 
 export async function runAutomationTask(
@@ -123,7 +140,22 @@ export async function runAutomationTask(
           ?? (status === "failed" ? `Task exited with code ${result.exitCode}` : null),
       });
       activeTaskRunId = null;
-      if (status === "completed") return { status };
+      if (status === "completed") {
+        const range = businessDayUtcRange();
+        const gate = importGateStatus(db, {
+          dependencyIds: CSV_IMPORT_DEPENDENCY_IDS,
+          startUtc: range.startUtc,
+          endUtc: range.endUtc,
+        });
+        if (shouldAutoRunImport({
+          kind: task.kind,
+          status,
+          importLocked: gate.locked,
+        })) {
+          await runAutomationTask("import-downloads-csv", ledgerDir);
+        }
+        return { status };
+      }
     }
     return { status: "failed" as const };
   } finally {

--- a/src/lib/automation/server/store.check.ts
+++ b/src/lib/automation/server/store.check.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  createTaskRun,
+  importGateStatus,
+  latestTaskRuns,
+  updateTaskRun,
+} from "./store.ts";
+
+const ledgerDir = mkdtempSync(join(tmpdir(), "automation-store-"));
+
+try {
+  const db = openLedgerDatabase(ledgerDir);
+  const startedAt = "2026-06-30T01:00:00.000Z";
+  const finishedAt = "2026-06-30T01:02:00.000Z";
+
+  const run = createTaskRun(db, {
+    taskId: "fubon-all-statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    status: "running",
+    attempt: 1,
+    maxAttempts: 2,
+    startedAt,
+    logPath: "data/automation/logs/fubon.log",
+  });
+
+  updateTaskRun(db, run.taskRunId, {
+    status: "completed",
+    finishedAt,
+    exitCode: 0,
+    logTail: "ok",
+  });
+
+  const latest = latestTaskRuns(db);
+  assert.equal(latest["fubon-all-statements"]?.status, "completed");
+  assert.equal(latest["fubon-all-statements"]?.finishedAt, finishedAt);
+
+  const lockedGate = importGateStatus(db, {
+    dependencyIds: [
+      "fubon-all-statements",
+      "esun-credit-card-statements",
+    ],
+    startUtc: new Date("2026-06-30T00:00:00.000Z"),
+    endUtc: new Date("2026-07-01T00:00:00.000Z"),
+  });
+  assert.equal(lockedGate.locked, true);
+  assert.deepEqual(lockedGate.missingTaskIds, ["esun-credit-card-statements"]);
+
+  createTaskRun(db, {
+    taskId: "esun-credit-card-statements",
+    script: "run:esun-credit-card-statements",
+    kind: "crawler",
+    status: "completed",
+    attempt: 1,
+    maxAttempts: 2,
+    startedAt: "2026-06-29T23:00:00.000Z",
+    finishedAt: "2026-06-29T23:20:00.000Z",
+    exitCode: 0,
+    logPath: "data/automation/logs/esun.log",
+    logTail: "ok",
+  });
+
+  const unlockedGate = importGateStatus(db, {
+    dependencyIds: [
+      "fubon-all-statements",
+      "esun-credit-card-statements",
+    ],
+    startUtc: new Date("2026-06-29T16:00:00.000Z"),
+    endUtc: new Date("2026-06-30T16:00:00.000Z"),
+  });
+  assert.equal(unlockedGate.locked, false);
+  assert.deepEqual(unlockedGate.missingTaskIds, []);
+
+  db.close();
+} finally {
+  rmSync(ledgerDir, { recursive: true, force: true });
+}

--- a/src/lib/automation/server/store.ts
+++ b/src/lib/automation/server/store.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import type { LedgerDatabase } from "../../../ledger/db/client.ts";
+import type { AutomationTaskKind } from "./tasks.ts";
+
+export type AutomationTaskStatus =
+  | "queued"
+  | "running"
+  | "waiting_for_human"
+  | "retrying"
+  | "completed"
+  | "failed"
+  | "locked";
+
+export type AutomationTaskRun = {
+  taskRunId: string;
+  taskId: string;
+  script: string;
+  kind: AutomationTaskKind;
+  status: AutomationTaskStatus;
+  attempt: number;
+  maxAttempts: number;
+  startedAt: string;
+  finishedAt: string | null;
+  exitCode: number | null;
+  signal: string | null;
+  errorMessage: string | null;
+  logPath: string;
+  logTail: string;
+  recordJson: string;
+};
+
+type CreateTaskRunInput = {
+  taskId: string;
+  script: string;
+  kind: AutomationTaskKind;
+  status: AutomationTaskStatus;
+  attempt: number;
+  maxAttempts: number;
+  startedAt: string;
+  finishedAt?: string | null;
+  exitCode?: number | null;
+  signal?: string | null;
+  errorMessage?: string | null;
+  logPath: string;
+  logTail?: string;
+};
+
+function nullableString(value: unknown) {
+  return value === null || value === undefined ? null : String(value);
+}
+
+function nullableNumber(value: unknown) {
+  return value === null || value === undefined ? null : Number(value);
+}
+
+function rowToTaskRun(row: Record<string, unknown>): AutomationTaskRun {
+  return {
+    taskRunId: String(row.task_run_id),
+    taskId: String(row.task_id),
+    script: String(row.script),
+    kind: row.kind as AutomationTaskKind,
+    status: row.status as AutomationTaskStatus,
+    attempt: Number(row.attempt),
+    maxAttempts: Number(row.max_attempts),
+    startedAt: String(row.started_at),
+    finishedAt: nullableString(row.finished_at),
+    exitCode: nullableNumber(row.exit_code),
+    signal: nullableString(row.signal),
+    errorMessage: nullableString(row.error_message),
+    logPath: String(row.log_path),
+    logTail: String(row.log_tail),
+    recordJson: String(row.record_json),
+  };
+}
+
+export function createTaskRun(db: LedgerDatabase, input: CreateTaskRunInput) {
+  const taskRunId = randomUUID();
+  const record = { taskRunId, ...input };
+  db.prepare(`
+    INSERT INTO automation_task_runs (
+      task_run_id, task_id, script, kind, status, attempt, max_attempts,
+      started_at, finished_at, exit_code, signal, error_message, log_path,
+      log_tail, record_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    taskRunId,
+    input.taskId,
+    input.script,
+    input.kind,
+    input.status,
+    input.attempt,
+    input.maxAttempts,
+    input.startedAt,
+    input.finishedAt ?? null,
+    input.exitCode ?? null,
+    input.signal ?? null,
+    input.errorMessage ?? null,
+    input.logPath,
+    input.logTail ?? "",
+    JSON.stringify(record),
+  );
+  return { taskRunId };
+}
+
+export function updateTaskRun(
+  db: LedgerDatabase,
+  taskRunId: string,
+  update: Partial<Pick<AutomationTaskRun, "status" | "finishedAt" | "exitCode" | "signal" | "errorMessage" | "logTail">>,
+) {
+  const row = db.prepare("SELECT * FROM automation_task_runs WHERE task_run_id = ?").get(taskRunId) as
+    | Record<string, unknown>
+    | undefined;
+  if (!row) throw new Error(`Missing automation task run: ${taskRunId}`);
+  const next = {
+    ...rowToTaskRun(row),
+    ...update,
+  };
+  db.prepare(`
+    UPDATE automation_task_runs
+    SET status = ?, finished_at = ?, exit_code = ?, signal = ?, error_message = ?, log_tail = ?, record_json = ?
+    WHERE task_run_id = ?
+  `).run(
+    next.status,
+    next.finishedAt,
+    next.exitCode,
+    next.signal,
+    next.errorMessage,
+    next.logTail,
+    JSON.stringify(next),
+    taskRunId,
+  );
+}
+
+export function latestTaskRuns(db: LedgerDatabase) {
+  const rows = db.prepare(`
+    SELECT run.*
+    FROM automation_task_runs run
+    JOIN (
+      SELECT task_id, max(started_at) AS started_at
+      FROM automation_task_runs
+      GROUP BY task_id
+    ) latest
+    ON latest.task_id = run.task_id AND latest.started_at = run.started_at
+  `).all() as Record<string, unknown>[];
+
+  return Object.fromEntries(rows.map((row) => {
+    const taskRun = rowToTaskRun(row);
+    return [taskRun.taskId, taskRun];
+  }));
+}
+
+export function importGateStatus(
+  db: LedgerDatabase,
+  input: { dependencyIds: readonly string[]; startUtc: Date; endUtc: Date },
+) {
+  const missingTaskIds = input.dependencyIds.filter((taskId) => {
+    const row = db.prepare(`
+      SELECT status
+      FROM automation_task_runs
+      WHERE task_id = ?
+        AND started_at >= ?
+        AND started_at < ?
+      ORDER BY started_at DESC
+      LIMIT 1
+    `).get(taskId, input.startUtc.toISOString(), input.endUtc.toISOString()) as
+      | { status?: string }
+      | undefined;
+    return row?.status !== "completed";
+  });
+  return {
+    locked: missingTaskIds.length > 0,
+    missingTaskIds,
+  };
+}

--- a/src/lib/automation/server/tasks.ts
+++ b/src/lib/automation/server/tasks.ts
@@ -1,0 +1,124 @@
+export type AutomationTaskKind = "crawler" | "sync" | "import";
+
+export type AutomationTask = {
+  id: string;
+  label: string;
+  script: string;
+  kind: AutomationTaskKind;
+  credentialKeys: readonly string[];
+  dependencies: readonly string[];
+  maxAttempts: number;
+};
+
+export const CSV_IMPORT_DEPENDENCY_IDS = [
+  "fubon-all-statements",
+  "esun-credit-card-statements",
+  "yuanta-all-statements",
+  "yuanta-trade-statements",
+  "cathay-all-statements",
+  "hncb-statements",
+] as const;
+
+export const AUTOMATION_TASKS: readonly AutomationTask[] = [
+  {
+    id: "fubon-all-statements",
+    label: "Fubon all statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_FUBON_USER_ID",
+      "LIBRETTO_CLOUD_FUBON_ACCOUNT",
+      "LIBRETTO_CLOUD_FUBON_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "esun-credit-card-statements",
+    label: "ESun credit card statements",
+    script: "run:esun-credit-card-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_ESUN_USER_ID",
+      "LIBRETTO_CLOUD_ESUN_ACCOUNT",
+      "LIBRETTO_CLOUD_ESUN_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "yuanta-all-statements",
+    label: "Yuanta all statements",
+    script: "run:yuanta-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_YUANTA_USER_ID",
+      "LIBRETTO_CLOUD_YUANTA_ACCOUNT",
+      "LIBRETTO_CLOUD_YUANTA_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "yuanta-trade-statements",
+    label: "Yuanta trade statements",
+    script: "run:yuanta-trade-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_YUANTA_TRADE_USER_ID",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_PASSWORD",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_CA_PATH",
+      "LIBRETTO_CLOUD_YUANTA_TRADE_CA_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "cathay-all-statements",
+    label: "Cathay all statements",
+    script: "run:cathay-all-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_CATHAY_USER_ID",
+      "LIBRETTO_CLOUD_CATHAY_ACCOUNT",
+      "LIBRETTO_CLOUD_CATHAY_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "hncb-statements",
+    label: "HNCB statements",
+    script: "run:hncb-statements",
+    kind: "crawler",
+    credentialKeys: [
+      "LIBRETTO_CLOUD_HNCB_USER_ID",
+      "LIBRETTO_CLOUD_HNCB_ACCOUNT",
+      "LIBRETTO_CLOUD_HNCB_PASSWORD",
+    ],
+    dependencies: [],
+    maxAttempts: 2,
+  },
+  {
+    id: "sync-maicoin",
+    label: "MaiCoin sync",
+    script: "run:sync-maicoin",
+    kind: "sync",
+    credentialKeys: ["MAX_ACCESS_KEY", "MAX_SECRET_KEY", "MAX_SUB_ACCOUNT"],
+    dependencies: [],
+    maxAttempts: 1,
+  },
+  {
+    id: "import-downloads-csv",
+    label: "Import downloads CSV",
+    script: "run:import-downloads-csv",
+    kind: "import",
+    credentialKeys: [],
+    dependencies: CSV_IMPORT_DEPENDENCY_IDS,
+    maxAttempts: 1,
+  },
+];
+
+export function taskById(taskId: string) {
+  return AUTOMATION_TASKS.find((task) => task.id === taskId) ?? null;
+}

--- a/src/lib/automation/server/tasks.ts
+++ b/src/lib/automation/server/tasks.ts
@@ -119,6 +119,10 @@ export const AUTOMATION_TASKS: readonly AutomationTask[] = [
   },
 ];
 
+export const AUTOMATION_CREDENTIAL_KEYS = Array.from(
+  new Set(AUTOMATION_TASKS.flatMap((task) => task.credentialKeys)),
+);
+
 export function taskById(taskId: string) {
   return AUTOMATION_TASKS.find((task) => task.id === taskId) ?? null;
 }

--- a/src/lib/shared-shell/components/DashboardShell.svelte
+++ b/src/lib/shared-shell/components/DashboardShell.svelte
@@ -3,7 +3,7 @@
   import projectIcon from "../assets/project-icon.webp";
   import ValueVisibilityToggle from "./ValueVisibilityToggle.svelte";
 
-  export let active: "overview" | "assets" | "liabilities" = "overview";
+  export let active: "overview" | "assets" | "liabilities" | "automation" = "overview";
   export let eyebrow = "Overview";
   export let title = "Portfolio";
   export let sideLabel = "Net position";
@@ -53,6 +53,12 @@
       label: "Liabilities",
       href: "/liabilities",
       path: "M3 6h18c.55 0 1 .45 1 1v10c0 .55-.45 1-1 1H3c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1Zm3 2c0 1.1-.9 2-2 2v4c1.1 0 2 .9 2 2h12c0-1.1.9-2 2-2v-4c-1.1 0-2-.9-2-2H6Zm6 7a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z",
+    },
+    {
+      id: "automation",
+      label: "Automation",
+      href: "/automation",
+      path: "M5 4h14v2H5V4Zm2 4h10v2H7V8Zm-2 4h14v8H5v-8Zm2 2v4h10v-4H7Z",
     },
   ] as const;
 </script>
@@ -108,12 +114,14 @@
         <h1>{title}</h1>
       </div>
       <div class="topbar-actions">
-        {#if searchPlaceholder}
-          <input class="search" type="search" bind:value={search} placeholder={searchPlaceholder} aria-label={searchPlaceholder} />
-        {:else if syncLabel}
-          <span class="chip good">{syncLabel}</span>
-        {/if}
-        <ValueVisibilityToggle bind:visible={valuesVisible} />
+        <slot name="topbar-actions">
+          {#if searchPlaceholder}
+            <input class="search" type="search" bind:value={search} placeholder={searchPlaceholder} aria-label={searchPlaceholder} />
+          {:else if syncLabel}
+            <span class="chip good">{syncLabel}</span>
+          {/if}
+          <ValueVisibilityToggle bind:visible={valuesVisible} />
+        </slot>
       </div>
     </header>
 

--- a/src/routes/automation/+page.server.ts
+++ b/src/routes/automation/+page.server.ts
@@ -6,7 +6,12 @@ import { AUTOMATION_CREDENTIAL_KEYS, AUTOMATION_TASKS, taskById } from "$lib/aut
 import { credentialStatus, updateEnvText } from "$lib/automation/server/env-file.ts";
 import { businessDayUtcRange } from "$lib/automation/server/business-day.ts";
 import { buildAutomationPageModel } from "$lib/automation/server/page-model.ts";
-import { hasActiveAutomationTask, startAutomationTask } from "$lib/automation/server/runner.ts";
+import {
+  hasActiveAutomationTask,
+  resumeSessionFromLog,
+  startAutomationResume,
+  startAutomationTask,
+} from "$lib/automation/server/runner.ts";
 import { importGateStatus, latestTaskRuns } from "$lib/automation/server/store.ts";
 import { openLedgerDatabase } from "../../ledger/db/client.ts";
 
@@ -92,6 +97,31 @@ function startTask(taskId: string) {
   }
 }
 
+function resumeTask(taskId: string) {
+  const task = taskById(taskId);
+  if (!task) throw new Error(`Unknown automation task: ${taskId}`);
+
+  const model = currentAutomationModel();
+  const row = model.tasks.find((item) => item.id === taskId);
+  if (row?.status !== "waiting_for_human") {
+    return fail(409, { message: "Task is not waiting for human input." });
+  }
+
+  const session = resumeSessionFromLog(row.logTail);
+  if (!session) {
+    return fail(409, { message: "Missing Libretto resume session in latest log." });
+  }
+
+  try {
+    startAutomationResume(task.id, session);
+    return { resumed: task.id };
+  } catch (error) {
+    return fail(409, {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export function load() {
   return {
     automation: currentAutomationModel(),
@@ -120,5 +150,9 @@ export const actions: Actions = {
   retry: async ({ request }) => {
     const formData = await request.formData();
     return startTask(formTaskId(formData));
+  },
+  resume: async ({ request }) => {
+    const formData = await request.formData();
+    return resumeTask(formTaskId(formData));
   },
 };

--- a/src/routes/automation/+page.server.ts
+++ b/src/routes/automation/+page.server.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fail } from "@sveltejs/kit";
+import type { Actions } from "./$types";
+import { AUTOMATION_CREDENTIAL_KEYS, AUTOMATION_TASKS, taskById } from "$lib/automation/server/tasks.ts";
+import { credentialStatus, updateEnvText } from "$lib/automation/server/env-file.ts";
+import { businessDayUtcRange } from "$lib/automation/server/business-day.ts";
+import { buildAutomationPageModel } from "$lib/automation/server/page-model.ts";
+import { hasActiveAutomationTask, startAutomationTask } from "$lib/automation/server/runner.ts";
+import { importGateStatus, latestTaskRuns } from "$lib/automation/server/store.ts";
+import { openLedgerDatabase } from "../../ledger/db/client.ts";
+
+const envPath = resolve(".env");
+const optionalCredentialKeys = new Set(["MAX_SUB_ACCOUNT"]);
+
+function readEnvText() {
+  return existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+}
+
+function currentCredentialStatus(envText: string) {
+  const status = credentialStatus(envText, AUTOMATION_CREDENTIAL_KEYS);
+  for (const key of AUTOMATION_CREDENTIAL_KEYS) {
+    status[key] = status[key] || Boolean(process.env[key]?.trim());
+  }
+  return status;
+}
+
+function currentAutomationModel() {
+  const envText = readEnvText();
+  const db = openLedgerDatabase();
+  try {
+    const range = businessDayUtcRange();
+    const importGate = importGateStatus(db, {
+      dependencyIds: taskById("import-downloads-csv")?.dependencies ?? [],
+      startUtc: range.startUtc,
+      endUtc: range.endUtc,
+    });
+    return buildAutomationPageModel({
+      tasks: AUTOMATION_TASKS,
+      latestRuns: latestTaskRuns(db),
+      credentials: currentCredentialStatus(envText),
+      importGate,
+      active: hasActiveAutomationTask(),
+      businessDate: range.businessDate,
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function missingCredentialKeys(taskId: string) {
+  const task = taskById(taskId);
+  if (!task) return [];
+  const status = currentCredentialStatus(readEnvText());
+  return task.credentialKeys.filter((key) => (
+    !optionalCredentialKeys.has(key) && !status[key]
+  ));
+}
+
+function formTaskId(formData: FormData) {
+  const taskId = String(formData.get("taskId") ?? "");
+  if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
+  return taskId;
+}
+
+function startTask(taskId: string) {
+  const task = taskById(taskId);
+  if (!task) throw new Error(`Unknown automation task: ${taskId}`);
+
+  const model = currentAutomationModel();
+  const row = model.tasks.find((item) => item.id === taskId);
+  if (row?.status === "locked") {
+    return fail(409, {
+      message: "Import is locked until all crawler dependencies complete for the business day.",
+    });
+  }
+
+  const missing = missingCredentialKeys(taskId);
+  if (missing.length > 0) {
+    return fail(400, {
+      message: `Missing credentials: ${missing.join(", ")}`,
+    });
+  }
+
+  try {
+    startAutomationTask(task.id);
+    return { started: task.id };
+  } catch (error) {
+    return fail(409, {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function load() {
+  return {
+    automation: currentAutomationModel(),
+    credentialKeys: AUTOMATION_CREDENTIAL_KEYS,
+  };
+}
+
+export const actions: Actions = {
+  saveCredentials: async ({ request }) => {
+    const formData = await request.formData();
+    const updates: Record<string, string> = {};
+    for (const key of AUTOMATION_CREDENTIAL_KEYS) {
+      const value = String(formData.get(key) ?? "").trim();
+      if (value) updates[key] = value;
+    }
+    if (Object.keys(updates).length === 0) {
+      return { saved: false };
+    }
+    writeFileSync(envPath, updateEnvText(readEnvText(), updates), "utf8");
+    return { saved: true };
+  },
+  run: async ({ request }) => {
+    const formData = await request.formData();
+    return startTask(formTaskId(formData));
+  },
+  retry: async ({ request }) => {
+    const formData = await request.formData();
+    return startTask(formTaskId(formData));
+  },
+};

--- a/src/routes/automation/+page.server.ts
+++ b/src/routes/automation/+page.server.ts
@@ -7,6 +7,7 @@ import { credentialStatus, updateEnvText } from "$lib/automation/server/env-file
 import { businessDayUtcRange } from "$lib/automation/server/business-day.ts";
 import { buildAutomationPageModel } from "$lib/automation/server/page-model.ts";
 import {
+  activeAutomationTaskIds,
   hasActiveAutomationTask,
   resumeSessionFromLog,
   startAutomationResume,
@@ -34,6 +35,7 @@ function currentAutomationModel() {
   const envText = readEnvText();
   const db = openLedgerDatabase();
   try {
+    const activeTaskIds = activeAutomationTaskIds();
     const range = businessDayUtcRange();
     const importGate = importGateStatus(db, {
       dependencyIds: taskById("import-downloads-csv")?.dependencies ?? [],
@@ -43,9 +45,10 @@ function currentAutomationModel() {
     return buildAutomationPageModel({
       tasks: AUTOMATION_TASKS,
       latestRuns: latestTaskRuns(db),
+      activeTaskIds,
       credentials: currentCredentialStatus(envText),
       importGate,
-      active: hasActiveAutomationTask(),
+      active: activeTaskIds.length > 0 || hasActiveAutomationTask(),
       businessDate: range.businessDate,
     });
   } finally {

--- a/src/routes/automation/+page.svelte
+++ b/src/routes/automation/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import AutomationDashboard from "$lib/automation/AutomationDashboard.svelte";
+  import type { PageData } from "./$types";
+
+  export let data: PageData;
+</script>
+
+<svelte:head>
+  <title>OctopusBeak Automation</title>
+</svelte:head>
+
+<AutomationDashboard automation={data.automation} credentialKeys={data.credentialKeys} />


### PR DESCRIPTION
## Summary
- Add a new automation dashboard UI and route under `/automation`
- Implement server-side automation core, runner, store, page model, task, and business-day helpers
- Add database schema and migration support for automation state
- Update shared dashboard shell styling and include design/spec docs for the control panel

## Testing
- Not run (not requested)