### PR TITLE
Add account balance history views to asset and liability dashboards

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -62,13 +62,14 @@ a {
   font-variant-numeric: tabular-nums;
 }
 
-.money {
+.money,
+[data-sensitive] {
   transition: filter 160ms ease, opacity 160ms ease;
 }
 
-.values-hidden .money {
-  filter: blur(6px);
-  opacity: 0.72;
+.values-hidden :is(.money, [data-sensitive]) {
+  filter: blur(10px);
+  opacity: 0.64;
   user-select: none;
 }
 

--- a/src/ledger/financial-dashboard-builder.ts
+++ b/src/ledger/financial-dashboard-builder.ts
@@ -358,6 +358,9 @@ function renderOctopusBeakStyles(includeSources = false): string {
     }
     html[data-values-visible="false"] [data-sensitive] {
       color: var(--muted);
+      filter: blur(10px);
+      opacity: 0.64;
+      user-select: none;
     }
     .label, .eyebrow, .table th, .chip, .metric-label {
       color: var(--muted);

--- a/src/lib/assets/AssetsDashboard.svelte
+++ b/src/lib/assets/AssetsDashboard.svelte
@@ -119,6 +119,7 @@
       bind:search
       positionsByAccount={assets.positionsByAccount}
       transactionsByAccount={assets.transactionsByAccount}
+      dailyHistoryByAccount={assets.dailyHistoryByAccount}
     />
   </div>
 </DashboardShell>

--- a/src/lib/assets/server/load-assets.ts
+++ b/src/lib/assets/server/load-assets.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_LEDGER_DIR, openLedgerDrizzle } from "../../../ledger/db/client.ts";
 import * as schema from "../../../ledger/db/schema.ts";
 import type { AssetsPageDto } from "../types.ts";
+import { buildDailyHistoryByAccount } from "$lib/overview/server/daily-history.ts";
 import {
   buildAccountOverview,
   buildPositionsByAccount,
@@ -13,6 +14,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
   const { db, sqlite } = openLedgerDrizzle(ledgerDir);
   try {
     const [
+      sourceFiles,
       accountTransactions,
       foreignCurrencyTransactions,
       fundHoldings,
@@ -25,6 +27,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
       maicoinAccountSnapshots,
       maicoinStatementRows,
     ] = await Promise.all([
+      db.select().from(schema.sourceFiles).all(),
       db.select().from(schema.accountTransactions).all(),
       db.select().from(schema.foreignCurrencyTransactions).all(),
       db.select().from(schema.fundHoldings).all(),
@@ -40,6 +43,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
 
     const data: LedgerQueryData = {
       ...emptyLedgerQueryData(),
+      sourceFiles,
       accountTransactions,
       foreignCurrencyTransactions,
       fundHoldings,
@@ -58,6 +62,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
       accounts,
       positionsByAccount: buildPositionsByAccount(data),
       transactionsByAccount: buildTransactionsByAccount(data),
+      dailyHistoryByAccount: buildDailyHistoryByAccount(data),
     };
   } finally {
     sqlite.close();

--- a/src/lib/assets/types.ts
+++ b/src/lib/assets/types.ts
@@ -1,7 +1,13 @@
-import type { AccountRowDto, AssetPositionDto, TransactionRowDto } from "$lib/shared-ledger/types.ts";
+import type {
+  AccountRowDto,
+  AssetPositionDto,
+  DailyHistoryRowDto,
+  TransactionRowDto,
+} from "$lib/shared-ledger/types.ts";
 
 export type AssetsPageDto = {
   accounts: AccountRowDto[];
   positionsByAccount: Record<string, AssetPositionDto[]>;
   transactionsByAccount: Record<string, TransactionRowDto[]>;
+  dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>;
 };

--- a/src/lib/liabilities/LiabilitiesDashboard.svelte
+++ b/src/lib/liabilities/LiabilitiesDashboard.svelte
@@ -114,6 +114,7 @@
       mode="liability"
       bind:search
       transactionsByAccount={liabilities.transactionsByAccount}
+      dailyHistoryByAccount={liabilities.dailyHistoryByAccount}
     />
   </div>
 </DashboardShell>

--- a/src/lib/liabilities/server/load-liabilities.ts
+++ b/src/lib/liabilities/server/load-liabilities.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_LEDGER_DIR, openLedgerDrizzle } from "../../../ledger/db/client.ts";
 import * as schema from "../../../ledger/db/schema.ts";
 import type { LiabilitiesPageDto } from "../types.ts";
+import { buildDailyHistoryByAccount } from "$lib/overview/server/daily-history.ts";
 import {
   buildAccountOverview,
   buildTransactionsByAccount,
@@ -11,7 +12,8 @@ import {
 export async function loadLiabilities(ledgerDir = DEFAULT_LEDGER_DIR): Promise<LiabilitiesPageDto> {
   const { db, sqlite } = openLedgerDrizzle(ledgerDir);
   try {
-    const [creditCardStatementLines, loanTransactions, maicoinAccountSnapshots] = await Promise.all([
+    const [sourceFiles, creditCardStatementLines, loanTransactions, maicoinAccountSnapshots] = await Promise.all([
+      db.select().from(schema.sourceFiles).all(),
       db.select().from(schema.creditCardStatementLines).all(),
       db.select().from(schema.loanTransactions).all(),
       db.select().from(schema.maicoinAccountSnapshots).all(),
@@ -19,6 +21,7 @@ export async function loadLiabilities(ledgerDir = DEFAULT_LEDGER_DIR): Promise<L
 
     const data: LedgerQueryData = {
       ...emptyLedgerQueryData(),
+      sourceFiles,
       creditCardStatementLines,
       loanTransactions,
       maicoinAccountSnapshots,
@@ -28,6 +31,7 @@ export async function loadLiabilities(ledgerDir = DEFAULT_LEDGER_DIR): Promise<L
     return {
       accounts,
       transactionsByAccount: buildTransactionsByAccount(data),
+      dailyHistoryByAccount: buildDailyHistoryByAccount(data),
     };
   } finally {
     sqlite.close();

--- a/src/lib/liabilities/types.ts
+++ b/src/lib/liabilities/types.ts
@@ -1,6 +1,7 @@
-import type { AccountRowDto, TransactionRowDto } from "$lib/shared-ledger/types.ts";
+import type { AccountRowDto, DailyHistoryRowDto, TransactionRowDto } from "$lib/shared-ledger/types.ts";
 
 export type LiabilitiesPageDto = {
   accounts: AccountRowDto[];
   transactionsByAccount: Record<string, TransactionRowDto[]>;
+  dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>;
 };

--- a/src/lib/overview/OverviewDashboard.svelte
+++ b/src/lib/overview/OverviewDashboard.svelte
@@ -27,6 +27,7 @@
   $: sideSub =
     netAmounts.slice(1).map((amount) => formatMoney(amount)).join(" / ") ||
     `Imported ${formatImportedAt(overview.importedAt)}`;
+  $: sideSubSensitive = netAmounts.length > 1;
   $: assetAccounts = overview.accounts.filter((account) => account.group !== "liability");
   $: allocation = buildAllocation(assetAccounts);
   $: history = overview.dailyHistory;
@@ -63,6 +64,7 @@
   sideLabel="Net position"
   {sideValue}
   {sideSub}
+  {sideSubSensitive}
   syncLabel={`Imported ${formatImportedAt(overview.importedAt)}`}
   bind:valuesVisible
 >

--- a/src/lib/overview/components/SnapshotSparkline.svelte
+++ b/src/lib/overview/components/SnapshotSparkline.svelte
@@ -86,7 +86,7 @@
   {#each yTicks as tick}
     <g class="sparkline-tick">
       <path d={`M${left - 6} ${tick.y}H${left}`} />
-      <text x={left - 10} y={tick.y + 4} text-anchor="end">{shortAmount(tick.value)}</text>
+      <text data-sensitive x={left - 10} y={tick.y + 4} text-anchor="end">{shortAmount(tick.value)}</text>
     </g>
   {/each}
   {#each xTicks as tick}

--- a/src/lib/overview/server/daily-history.check.ts
+++ b/src/lib/overview/server/daily-history.check.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import {
+  buildAccountOverview,
+  emptyLedgerQueryData,
+  type LedgerQueryData,
+} from "../../shared-ledger/server/accounts.ts";
+import { buildDailyHistoryByAccount } from "./daily-history.ts";
+
+type AccountTransaction = LedgerQueryData["accountTransactions"][number];
+type SourceFile = LedgerQueryData["sourceFiles"][number];
+
+function sourceFile(sourceFileId: string, date: string): SourceFile {
+  return {
+    sourceFileId,
+    importRunId: "run",
+    sourceFile: `downloads/${sourceFileId}.csv`,
+    sourceRelativePath: `${sourceFileId}.csv`,
+    sourceFileHash: `hash-${sourceFileId}`,
+    sourceFileBytes: 256,
+    sourceFileModifiedAt: `${date}T09:00:00.000Z`,
+    importedAt: `${date}T10:00:00.000Z`,
+    bank: "demo",
+    product: "statements",
+    rowCount: 1,
+    status: "imported",
+    recordJson: "{}",
+  };
+}
+
+function bankRow(sourceFileId: string, sourceRowIndex: number, date: string, balanceAfter: number): AccountTransaction {
+  return {
+    statementRowId: `row-${sourceRowIndex}`,
+    sourceFileId,
+    importRunId: "run",
+    sourceRelativePath: `${sourceFileId}.csv`,
+    sourceRowIndex,
+    sourceHash: `source-${sourceFileId}`,
+    rawRowHash: `raw-${sourceRowIndex}`,
+    contentHash: `content-${sourceRowIndex}`,
+    bank: "demo",
+    product: "statements",
+    dedupeStatus: "unique",
+    rawPayloadJson: "{}",
+    importedAt: `${date}T10:00:00.000Z`,
+    createdAt: `${date}T10:00:00.000Z`,
+    accountName: "Demo account",
+    accountNumber: "1234567890",
+    currency: "TWD",
+    accountingDate: date,
+    transactionDate: date,
+    transactionTime: "09:30:00",
+    description: "balance",
+    withdrawalAmount: null,
+    depositAmount: null,
+    balanceAfter,
+    note: null,
+    fxRate: null,
+  };
+}
+
+const data = emptyLedgerQueryData();
+data.sourceFiles = [sourceFile("day-1", "2026-06-01"), sourceFile("day-2", "2026-06-02")];
+data.accountTransactions = [
+  bankRow("day-1", 1, "2026-06-01", 0),
+  bankRow("day-2", 2, "2026-06-02", 150),
+];
+
+const account = buildAccountOverview(data)[0];
+assert.ok(account);
+
+assert.deepEqual(buildDailyHistoryByAccount(data)[account.id], [
+  {
+    date: "2026-06-01",
+    netAssets: [{ currency: "TWD", value: 0 }],
+    dailyChange: [],
+    assets: [{ currency: "TWD", value: 0 }],
+    liabilities: [],
+    accountChanges: [account.label],
+    positionCount: 0,
+  },
+  {
+    date: "2026-06-02",
+    netAssets: [{ currency: "TWD", value: 150 }],
+    dailyChange: [{ currency: "TWD", value: 150 }],
+    assets: [{ currency: "TWD", value: 150 }],
+    liabilities: [],
+    accountChanges: [account.label],
+    positionCount: 0,
+  },
+]);

--- a/src/lib/overview/server/daily-history.ts
+++ b/src/lib/overview/server/daily-history.ts
@@ -3,20 +3,11 @@ import {
   bucketToAmounts,
   totalsForAccounts,
   type LedgerQueryData,
-} from "$lib/shared-ledger/server/accounts.ts";
-import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+} from "../../shared-ledger/server/accounts.ts";
+import type { AccountRowDto, CurrencyAmountDto, DailyHistoryRowDto } from "../../shared-ledger/types.ts";
 
 export function buildDailyHistory(data: LedgerQueryData): DailyHistoryRowDto[] {
-  const dates = [
-    ...new Set(
-      data.sourceFiles
-        .map((source) => sourceFileDate(source))
-        .concat(data.maicoinAccountSnapshots.map((snapshot) => snapshot.capturedAt.slice(0, 10)))
-        .filter(Boolean)
-        .sort(),
-    ),
-  ];
-  const rows = dates.length > 0 ? dates : [new Date().toISOString().slice(0, 10)];
+  const rows = dailyHistoryDates(data);
   let previousNet: Record<string, number> | null = null;
 
   return rows.map((date) => {
@@ -34,6 +25,61 @@ export function buildDailyHistory(data: LedgerQueryData): DailyHistoryRowDto[] {
       positionCount: accounts.reduce((total, account) => total + account.assetPositionCount, 0),
     };
   });
+}
+
+export function buildDailyHistoryByAccount(data: LedgerQueryData): Record<string, DailyHistoryRowDto[]> {
+  const histories: Record<string, DailyHistoryRowDto[]> = {};
+  const previousByAccount = new Map<string, Record<string, number>>();
+
+  for (const date of dailyHistoryDates(data)) {
+    const accounts = buildAccountOverview(snapshotData(data, date));
+    for (const account of accounts) {
+      const balance = amountBucket(account.amountLines);
+      const previous = previousByAccount.get(account.id);
+      const dailyChange = previous ? subtractBuckets(balance, previous) : {};
+      previousByAccount.set(account.id, balance);
+      histories[account.id] = [...(histories[account.id] ?? []), accountHistoryRow(date, account, balance, dailyChange)];
+    }
+  }
+
+  return histories;
+}
+
+function dailyHistoryDates(data: LedgerQueryData) {
+  const dates = [
+    ...new Set(
+      data.sourceFiles
+        .map((source) => sourceFileDate(source))
+        .concat(data.maicoinAccountSnapshots.map((snapshot) => snapshot.capturedAt.slice(0, 10)))
+        .filter(Boolean)
+        .sort(),
+    ),
+  ];
+  return dates.length > 0 ? dates : [new Date().toISOString().slice(0, 10)];
+}
+
+function accountHistoryRow(
+  date: string,
+  account: AccountRowDto,
+  balance: Record<string, number>,
+  dailyChange: Record<string, number>,
+): DailyHistoryRowDto {
+  const amounts = bucketToAmounts(balance, { includeZero: true });
+  return {
+    date,
+    netAssets: amounts,
+    dailyChange: bucketToAmounts(dailyChange),
+    assets: account.group === "liability" ? [] : amounts,
+    liabilities: account.group === "liability" ? amounts : [],
+    accountChanges: [account.label],
+    positionCount: account.assetPositionCount,
+  };
+}
+
+function amountBucket(amounts: CurrencyAmountDto[]) {
+  const bucket: Record<string, number> = {};
+  for (const amount of amounts) bucket[amount.currency] = amount.value;
+  return bucket;
 }
 
 function sourceFileDate(source: LedgerQueryData["sourceFiles"][number]) {

--- a/src/lib/shared-accounts/components/AccountHistoryModal.svelte
+++ b/src/lib/shared-accounts/components/AccountHistoryModal.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import DailyHistoryTable from "$lib/overview/components/DailyHistoryTable.svelte";
+  import SnapshotSparkline from "$lib/overview/components/SnapshotSparkline.svelte";
+  import type { AccountRowDto, DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+  export let open = false;
+  export let account: AccountRowDto | null = null;
+  export let rows: DailyHistoryRowDto[] = [];
+
+  let currency = "TWD";
+
+  $: currencies = [
+    ...new Set(rows.flatMap((row) => row.netAssets.map((amount) => amount.currency))),
+  ];
+  $: if (!currencies.includes(currency)) currency = currencies[0] ?? "TWD";
+  $: chartRows = [...rows].sort((left, right) => left.date.localeCompare(right.date)).slice(-30);
+
+  function closeOnEscape(event: KeyboardEvent) {
+    if (open && event.key === "Escape") open = false;
+  }
+
+  function selectValue(event: Event) {
+    return (event.currentTarget as HTMLSelectElement).value;
+  }
+</script>
+
+<svelte:window onkeydown={closeOnEscape} />
+
+{#if open}
+  <div class="modal open">
+    <button class="modal-backdrop" type="button" aria-label="Close" onclick={() => (open = false)}></button>
+    <div class="modal-panel" role="dialog" aria-modal="true" tabindex="-1">
+      <div class="modal-head">
+        <div>
+          <h2>{account ? `${account.label} Balance history` : "Balance history"}</h2>
+          <p class="lead">{account ? `${account.institution} / ${account.typeLabel}` : ""}</p>
+        </div>
+        <div class="modal-actions">
+          {#if currencies.length > 0}
+            <label class="chip select-chip" for="account-history-currency">
+              <select
+                id="account-history-currency"
+                aria-label="Account history currency"
+                bind:value={currency}
+                onchange={(event) => (currency = selectValue(event))}
+                oninput={(event) => (currency = selectValue(event))}
+              >
+                {#each currencies as option}
+                  <option>{option}</option>
+                {/each}
+              </select>
+            </label>
+          {/if}
+          <button class="modal-close" type="button" aria-label="Close" onclick={() => (open = false)}>x</button>
+        </div>
+      </div>
+      <div class="modal-body history-modal-body">
+        <div class="history-chart">
+          <SnapshotSparkline rows={chartRows} {currency} />
+        </div>
+        {#key currency}
+          <DailyHistoryTable rows={rows} {currency} netLabel="Balance" paginate pageSize={20} visibleRows={6} />
+        {/key}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .history-modal-body {
+    display: grid;
+    gap: var(--space-4);
+    padding: var(--space-5);
+  }
+
+  .history-chart {
+    min-height: 220px;
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-soft);
+  }
+</style>

--- a/src/lib/shared-accounts/components/AccountHistoryModal.svelte
+++ b/src/lib/shared-accounts/components/AccountHistoryModal.svelte
@@ -81,9 +81,16 @@
 
   .history-chart {
     min-height: 220px;
-    overflow-x: auto;
+    aspect-ratio: 720 / 220;
+    overflow: hidden;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: var(--surface-soft);
+  }
+
+  .history-chart :global(.sparkline) {
+    display: block;
+    width: 100%;
+    height: 100%;
   }
 </style>

--- a/src/lib/shared-accounts/components/AccountTable.svelte
+++ b/src/lib/shared-accounts/components/AccountTable.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
-  import type { AccountKind, AccountRowDto, AssetPositionDto, TransactionRowDto } from "$lib/shared-ledger/types.ts";
+  import type {
+    AccountKind,
+    AccountRowDto,
+    AssetPositionDto,
+    DailyHistoryRowDto,
+    TransactionRowDto,
+  } from "$lib/shared-ledger/types.ts";
   import { formatAmountLines, amountValue } from "$lib/shared-money/money.ts";
+  import AccountHistoryModal from "./AccountHistoryModal.svelte";
   import AssetModal from "./AssetModal.svelte";
   import TransactionModal from "./TransactionModal.svelte";
 
@@ -15,6 +22,7 @@
   export let accounts: AccountRowDto[] = [];
   export let positionsByAccount: Record<string, AssetPositionDto[]> = {};
   export let transactionsByAccount: Record<string, TransactionRowDto[]> = {};
+  export let dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]> = {};
   export let search = "";
   export let mode: "asset" | "liability" = "asset";
 
@@ -22,6 +30,7 @@
   let selectedAccountId: string | null = null;
   let transactionsOpen = false;
   let positionsOpen = false;
+  let historyOpen = false;
   let sortKey: SortKey | null = null;
   let sortDirection: SortDirection = "asc";
   let sortColumns: SortColumn[] = [];
@@ -71,6 +80,8 @@
     selectedAccount ? transactionsByAccount[selectedAccount.id] ?? [] : [];
   $: selectedPositions =
     selectedAccount ? positionsByAccount[selectedAccount.id] ?? [] : [];
+  $: selectedDailyHistory =
+    selectedAccount ? dailyHistoryByAccount[selectedAccount.id] ?? [] : [];
   $: sortColumns = [
     { key: "label", label: "Account Name" },
     { key: "institution", label: "Institution" },
@@ -198,6 +209,14 @@
                       transactionsOpen = true;
                     }}>TX</button
                   >
+                  <button
+                    class="chip"
+                    type="button"
+                    on:click|stopPropagation={() => {
+                      selectedAccountId = account.id;
+                      historyOpen = true;
+                    }}>History</button
+                  >
                   {#if mode === "asset" && account.assetPositionCount > 0}
                     <button
                       class="chip"
@@ -224,6 +243,7 @@
 
 <TransactionModal bind:open={transactionsOpen} account={selectedAccount} rows={selectedTransactions} />
 <AssetModal bind:open={positionsOpen} account={selectedAccount} rows={selectedPositions} />
+<AccountHistoryModal bind:open={historyOpen} account={selectedAccount} rows={selectedDailyHistory} />
 
 <style>
   .sort-button {

--- a/src/lib/shared-shell/components/DashboardShell.svelte
+++ b/src/lib/shared-shell/components/DashboardShell.svelte
@@ -9,6 +9,7 @@
   export let sideLabel = "Net position";
   export let sideValue = "--";
   export let sideSub = "";
+  export let sideSubSensitive = false;
   export let search = "";
   export let searchPlaceholder: string | null = null;
   export let syncLabel: string | null = null;
@@ -103,7 +104,7 @@
     <div class="side-status">
       <p class="label">{sideLabel}</p>
       <p class="money">{sideValue}</p>
-      <p class="sub">{sideSub}</p>
+      <p class="sub" data-sensitive={sideSubSensitive ? "" : undefined}>{sideSub}</p>
     </div>
   </aside>
 


### PR DESCRIPTION
## Summary
- Thread daily history data through the assets and liabilities loaders and DTOs
- Add a balance history action on account rows to open a shared history modal
- Render the account balance sparkline and history table from the existing daily history data
- Add a focused self-check for `buildDailyHistoryByAccount`

## Testing
- Added a runnable assertion-based check for daily history generation
- Not run (not requested)