### PR TITLE
Encrypt automation credentials with safeStorage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Developer-only fallback for direct workflow runs.
-# The desktop automation panel stores app settings in settings.json and
-# credential values in credentials.json.
+# The desktop automation panel stores app settings in plaintext settings.json
+# and credential values in a safeStorage-encrypted credentials.json envelope.
 # Direct libretto run commands read exported shell env. An ignored .env.local
 # file is manual only: set -a; source .env.local; set +a
 AUTOMATION_BUSINESS_TIMEZONE=Asia/Taipei

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `#/automation` page wraps the existing npm scripts. It stores non-secret swi
 
 `import downloads csv` stays locked until every enabled producing crawler has a successful run for the current business day.
 
-`credentials.json` is local and ignored, but it is not OS-keychain encrypted yet. Electron `safeStorage` is a follow-up now that the Electron main/preload API boundary owns credential access.
+`credentials.json` is local, ignored, and encrypted by Electron `safeStorage` in desktop runtime. If `safeStorage` encryption is unavailable, the desktop app fails startup instead of writing plaintext credentials.
 
 Useful `settings.json` keys:
 

--- a/docs/superpowers/plans/2026-07-02-automation-safe-storage-credentials.md
+++ b/docs/superpowers/plans/2026-07-02-automation-safe-storage-credentials.md
@@ -1,0 +1,452 @@
+# Automation SafeStorage Credentials Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Encrypt desktop automation `credentials.json` at rest with Electron `safeStorage`, while leaving `settings.json` plaintext.
+
+**Architecture:** Keep `src/lib/automation/server/config-files.ts` as the only credential file read/write layer. Add a tiny process-wide codec there; Electron main registers a `safeStorage` codec after switching cwd to `userData`, then migrates any legacy plaintext credentials file. If `safeStorage.isEncryptionAvailable()` is false, desktop startup fails instead of writing plaintext.
+
+**Tech Stack:** Electron `safeStorage`, Node `fs`/`Buffer`/`assert`, existing TypeScript strip-types checks, existing Electron preload IPC boundary.
+
+---
+
+## Scope Decisions
+
+- Encrypt only `credentials.json`.
+- Keep `settings.json` plaintext.
+- Store all credentials in one encrypted envelope, not per-key envelopes.
+- Keep legacy plaintext credentials readable.
+- Migrate plaintext credentials during Electron startup, not during ordinary reads.
+- Do not add `keytar` or another keychain dependency.
+- Do not add a plaintext fallback in Electron desktop runtime.
+- Keep workflows unchanged; they still receive secrets through environment variables from the automation runner.
+- Keep direct `libretto run ...` development on exported shell env, not desktop JSON injection.
+
+## File Structure
+
+- Modify `src/lib/automation/server/config-files.ts`: add the codec, encrypted envelope parsing, encrypted writing, and explicit migration helper.
+- Modify `src/lib/automation/server/config-files.check.ts`: cover fake-codec encryption, no-plaintext-at-rest, missing-codec failure, and plaintext migration.
+- Create `electron/credential-codec.ts`: bind Electron `safeStorage` to the config-file codec and run credential encryption migration.
+- Modify `electron/main.ts`: register the safeStorage credential codec after `process.chdir(userData)` and before IPC handlers.
+- Modify `src/lib/automation/server/desktop-api.check.ts`: verify desktop credential saves write encrypted envelopes when a codec is configured.
+- Modify `README.md` and `.env.example`: replace "safeStorage follow-up" wording with current encrypted behavior and explicit-failure behavior.
+
+---
+
+### Task 1: Add Encrypted Credential File Support
+
+**Files:**
+- Modify: `src/lib/automation/server/config-files.ts`
+- Modify: `src/lib/automation/server/config-files.check.ts`
+
+- [ ] **Step 1: Write the failing config-file check**
+
+Update the import in `src/lib/automation/server/config-files.check.ts`:
+
+```ts
+import {
+  AUTOMATION_CREDENTIALS_FORMAT,
+  AUTOMATION_CREDENTIALS_PATH,
+  AUTOMATION_SETTINGS_PATH,
+  automationConfigEnv,
+  credentialStatusFromValues,
+  migrateAutomationCredentialsFileEncryption,
+  migrateAutomationEnvFile,
+  readAutomationCredentialsFile,
+  readAutomationSettingsFile,
+  setAutomationCredentialCodec,
+  settingsToEnv,
+  splitAutomationUpdates,
+  writeAutomationCredentialsFile,
+  writeAutomationSettingsFile,
+} from "./config-files.ts";
+```
+
+Append this block before the `finally` in the same file:
+
+```ts
+  const fakeCodec = {
+    encrypt(text: string) {
+      return Buffer.from(`safe:${text}`, "utf8").toString("base64");
+    },
+    decrypt(payload: string) {
+      const text = Buffer.from(payload, "base64").toString("utf8");
+      if (!text.startsWith("safe:")) throw new Error("bad fake credential payload");
+      return text.slice("safe:".length);
+    },
+  };
+
+  const encryptedCredentialsPath = join(dir, "encrypted-credentials.json");
+  setAutomationCredentialCodec(fakeCodec);
+  writeAutomationCredentialsFile(encryptedCredentialsPath, {
+    [fubonPasswordKey]: "encrypted-secret",
+  });
+  const encryptedText = readFileSync(encryptedCredentialsPath, "utf8");
+  const encryptedRecord = JSON.parse(encryptedText) as { format?: unknown; data?: unknown };
+  assert.equal(encryptedRecord.format, AUTOMATION_CREDENTIALS_FORMAT);
+  assert.equal(typeof encryptedRecord.data, "string");
+  assert.equal(encryptedText.includes("encrypted-secret"), false);
+  assert.deepEqual(readAutomationCredentialsFile(encryptedCredentialsPath), {
+    [fubonPasswordKey]: "encrypted-secret",
+  });
+
+  setAutomationCredentialCodec(null);
+  assert.throws(
+    () => readAutomationCredentialsFile(encryptedCredentialsPath),
+    /Credential encryption is not configured/,
+  );
+
+  const legacyCredentialsPath = join(dir, "legacy-credentials.json");
+  writeFileSync(legacyCredentialsPath, `${JSON.stringify({
+    [maxSecretKey]: "legacy-secret",
+  }, null, 2)}\n`);
+  setAutomationCredentialCodec(fakeCodec);
+  assert.equal(migrateAutomationCredentialsFileEncryption(legacyCredentialsPath), true);
+  assert.deepEqual(readAutomationCredentialsFile(legacyCredentialsPath), {
+    [maxSecretKey]: "legacy-secret",
+  });
+  assert.equal(readFileSync(legacyCredentialsPath, "utf8").includes("legacy-secret"), false);
+  assert.equal(migrateAutomationCredentialsFileEncryption(legacyCredentialsPath), false);
+  setAutomationCredentialCodec(null);
+```
+
+- [ ] **Step 2: Run the check and verify it fails**
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/automation/server/config-files.check.ts
+```
+
+Expected: FAIL because `AUTOMATION_CREDENTIALS_FORMAT`, `setAutomationCredentialCodec`, and `migrateAutomationCredentialsFileEncryption` do not exist yet.
+
+- [ ] **Step 3: Add the credential codec and envelope helpers**
+
+In `src/lib/automation/server/config-files.ts`, add this after `export const AUTOMATION_CREDENTIALS_PATH = "credentials.json";`:
+
+```ts
+export const AUTOMATION_CREDENTIALS_FORMAT = "octopusbeak.credentials.safeStorage.v1";
+
+export type AutomationCredentialCodec = {
+  encrypt(text: string): string;
+  decrypt(payload: string): string;
+};
+
+type EncryptedAutomationCredentialsFile = {
+  format: typeof AUTOMATION_CREDENTIALS_FORMAT;
+  data: string;
+};
+
+let automationCredentialCodec: AutomationCredentialCodec | null = null;
+
+export function setAutomationCredentialCodec(codec: AutomationCredentialCodec | null) {
+  automationCredentialCodec = codec;
+}
+```
+
+Add these helpers after `cleanCredentials`:
+
+```ts
+function encryptedAutomationCredentialsFile(
+  record: Record<string, unknown>,
+): EncryptedAutomationCredentialsFile | null {
+  if (record.format !== AUTOMATION_CREDENTIALS_FORMAT) return null;
+  if (typeof record.data !== "string" || !record.data.trim()) {
+    throw new Error(`${AUTOMATION_CREDENTIALS_PATH} encrypted envelope is invalid.`);
+  }
+  return {
+    format: AUTOMATION_CREDENTIALS_FORMAT,
+    data: record.data,
+  };
+}
+
+function requireAutomationCredentialCodec() {
+  if (!automationCredentialCodec) {
+    throw new Error("Credential encryption is not configured. Refusing to read encrypted automation credentials.");
+  }
+  return automationCredentialCodec;
+}
+
+function decodeCredentialsRecord(record: Record<string, unknown>) {
+  const encrypted = encryptedAutomationCredentialsFile(record);
+  if (!encrypted) return record;
+  const text = requireAutomationCredentialCodec().decrypt(encrypted.data);
+  const parsed = JSON.parse(text) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${AUTOMATION_CREDENTIALS_PATH} encrypted payload must contain a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function credentialsFileText(credentials: AutomationCredentialsFile) {
+  const cleaned = cleanCredentials(credentials);
+  if (!automationCredentialCodec) return `${JSON.stringify(cleaned, null, 2)}\n`;
+  return `${JSON.stringify({
+    format: AUTOMATION_CREDENTIALS_FORMAT,
+    data: automationCredentialCodec.encrypt(JSON.stringify(cleaned)),
+  }, null, 2)}\n`;
+}
+```
+
+Replace `readAutomationCredentialsFile` and `writeAutomationCredentialsFile` with:
+
+```ts
+export function readAutomationCredentialsFile(path = AUTOMATION_CREDENTIALS_PATH) {
+  return cleanCredentials(decodeCredentialsRecord(readJsonRecord(path)));
+}
+
+export function writeAutomationCredentialsFile(path: string, credentials: AutomationCredentialsFile) {
+  atomicWrite(path, credentialsFileText(credentials));
+}
+```
+
+Add this exported migration helper after `writeAutomationCredentials`:
+
+```ts
+export function migrateAutomationCredentialsFileEncryption(path = AUTOMATION_CREDENTIALS_PATH) {
+  if (!existsSync(path)) return false;
+  const record = readJsonRecord(path);
+  if (encryptedAutomationCredentialsFile(record)) return false;
+  const credentials = cleanCredentials(record);
+  if (Object.keys(credentials).length === 0) return false;
+  requireAutomationCredentialCodec();
+  writeAutomationCredentialsFile(path, credentials);
+  return true;
+}
+```
+
+- [ ] **Step 4: Run the config-file check**
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/automation/server/config-files.check.ts
+```
+
+Expected: exits `0` with no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/automation/server/config-files.ts src/lib/automation/server/config-files.check.ts
+git commit -m "feat: encrypt automation credential file"
+```
+
+---
+
+### Task 2: Register Electron SafeStorage
+
+**Files:**
+- Create: `electron/credential-codec.ts`
+- Modify: `electron/main.ts`
+
+- [ ] **Step 1: Create the safeStorage adapter**
+
+Create `electron/credential-codec.ts`:
+
+```ts
+import { safeStorage } from "electron";
+import {
+  migrateAutomationCredentialsFileEncryption,
+  setAutomationCredentialCodec,
+} from "../src/lib/automation/server/config-files.ts";
+
+export function registerAutomationCredentialSafeStorage() {
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error("Electron safeStorage encryption is not available. Refusing to read or write automation credentials.");
+  }
+
+  setAutomationCredentialCodec({
+    encrypt(text: string) {
+      return safeStorage.encryptString(text).toString("base64");
+    },
+    decrypt(payload: string) {
+      return safeStorage.decryptString(Buffer.from(payload, "base64"));
+    },
+  });
+
+  migrateAutomationCredentialsFileEncryption();
+}
+```
+
+- [ ] **Step 2: Register it during desktop startup**
+
+In `electron/main.ts`, add the import:
+
+```ts
+import { registerAutomationCredentialSafeStorage } from "./credential-codec.ts";
+```
+
+Then update `start()` so registration happens after `process.chdir(userData)` and before `registerOctopusBeakIpc()`:
+
+```ts
+  process.chdir(userData);
+  registerAutomationCredentialSafeStorage();
+  registerOctopusBeakIpc();
+```
+
+- [ ] **Step 3: Run the Electron build**
+
+```bash
+npm run build:electron
+```
+
+Expected: exits `0`.
+
+- [ ] **Step 4: Run the desktop runtime probe**
+
+```bash
+npm run desktop:runtime-probe
+```
+
+Expected: exits `0`. A macOS codesign diagnostic is acceptable if the probe still exits `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/credential-codec.ts electron/main.ts
+git commit -m "feat: register safeStorage credentials"
+```
+
+---
+
+### Task 3: Cover Desktop Save Integration
+
+**Files:**
+- Modify: `src/lib/automation/server/desktop-api.check.ts`
+
+- [ ] **Step 1: Add the desktop save integration check**
+
+In `src/lib/automation/server/desktop-api.check.ts`, import the config helpers before importing `desktop-api.ts`:
+
+```ts
+  const configFiles = await import("./config-files.ts");
+  const api = await import("./desktop-api.ts");
+```
+
+Replace the existing `const api = await import("./desktop-api.ts");` line with the two lines above.
+
+Add this fake codec before `automationSaveCredentials`:
+
+```ts
+  const fakeCodec = {
+    encrypt(text: string) {
+      return Buffer.from(`safe:${text}`, "utf8").toString("base64");
+    },
+    decrypt(payload: string) {
+      const text = Buffer.from(payload, "base64").toString("utf8");
+      if (!text.startsWith("safe:")) throw new Error("bad fake credential payload");
+      return text.slice("safe:".length);
+    },
+  };
+  configFiles.setAutomationCredentialCodec(fakeCodec);
+```
+
+Replace the credential assertions after `automationSaveCredentials` with:
+
+```ts
+  const settings = JSON.parse(readFileSync("settings.json", "utf8"));
+  const rawCredentialsText = readFileSync("credentials.json", "utf8");
+  const rawCredentials = JSON.parse(rawCredentialsText) as { format?: unknown };
+  const credentials = configFiles.readAutomationCredentialsFile("credentials.json");
+  assert.equal(settings[enabledKey], false);
+  assert.equal(Object.hasOwn(settings, accountKey), false);
+  assert.equal(rawCredentials.format, configFiles.AUTOMATION_CREDENTIALS_FORMAT);
+  assert.equal(rawCredentialsText.includes("next-acct"), false);
+  assert.equal(credentials[accountKey], "next-acct");
+  assert.equal(Object.hasOwn(credentials, enabledKey), false);
+  configFiles.setAutomationCredentialCodec(null);
+```
+
+- [ ] **Step 2: Run the check**
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/automation/server/desktop-api.check.ts
+```
+
+Expected: exits `0` with no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/automation/server/desktop-api.check.ts
+git commit -m "test: cover encrypted desktop credential saves"
+```
+
+---
+
+### Task 4: Update Docs and Run Final Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Update README credential wording**
+
+In `README.md`, replace this paragraph:
+
+```md
+`credentials.json` is local and ignored, but it is not OS-keychain encrypted yet. Electron `safeStorage` is a follow-up now that the Electron main/preload API boundary owns credential access.
+```
+
+with:
+
+```md
+`credentials.json` is local, ignored, and encrypted by Electron `safeStorage` in desktop runtime. If `safeStorage` encryption is unavailable, the desktop app fails startup instead of writing plaintext credentials.
+```
+
+- [ ] **Step 2: Update `.env.example` credential wording**
+
+At the top of `.env.example`, replace the current storage comment with:
+
+```sh
+# The desktop automation panel stores app settings in plaintext settings.json
+# and credential values in a safeStorage-encrypted credentials.json envelope.
+```
+
+- [ ] **Step 3: Run focused checks**
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/automation/server/config-files.check.ts
+node --no-warnings --experimental-strip-types src/lib/automation/server/desktop-api.check.ts
+npm run desktop:runtime-probe
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 4: Run broad verification**
+
+```bash
+npm run typecheck
+npm run build
+npm run privacy-check
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Run a temp-userData desktop smoke**
+
+```bash
+OCTOPUSBEAK_USER_DATA=/private/tmp/octopusbeak-safe-storage-smoke npm run desktop:dev
+```
+
+Manual expected result:
+
+- `#/automation` opens.
+- Saving a credential succeeds.
+- `/private/tmp/octopusbeak-safe-storage-smoke/credentials.json` contains `format` and `data`.
+- The saved credential value does not appear as plaintext in that file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md .env.example
+git commit -m "docs: describe encrypted automation credentials"
+```
+
+---
+
+## Final Review
+
+- [ ] `credentials.json` writes encrypted envelopes in Electron runtime.
+- [ ] Legacy plaintext `credentials.json` migrates to the encrypted envelope during Electron startup.
+- [ ] Encrypted credentials fail clearly when no codec is configured.
+- [ ] `settings.json` remains plaintext.
+- [ ] No new dependencies were added.
+- [ ] No credential values appear in logs, docs, test output, or tracked files.

--- a/docs/superpowers/specs/2026-07-02-automation-safe-storage-credentials-design.md
+++ b/docs/superpowers/specs/2026-07-02-automation-safe-storage-credentials-design.md
@@ -1,0 +1,85 @@
+# Automation SafeStorage Credentials Design
+
+## Goal
+
+Encrypt desktop automation credentials at rest with Electron `safeStorage`. Keep non-secret automation switches in plaintext `settings.json`; keep secret values in `credentials.json`, but store them as an encrypted whole-file envelope.
+
+## Scope
+
+In scope:
+
+- Register an Electron `safeStorage` credential codec in the main process.
+- Fail desktop startup with a clear error when `safeStorage.isEncryptionAvailable()` is false.
+- Keep legacy plaintext `credentials.json` readable.
+- Migrate an existing plaintext `credentials.json` to the encrypted envelope during Electron startup.
+- Keep automation workflows unchanged: spawned tasks still receive credentials through `process.env`.
+- Keep direct CLI workflow development on exported shell environment variables.
+
+Out of scope:
+
+- Adding `keytar`, native keychain libraries, or another dependency.
+- Plaintext fallback in desktop runtime.
+- Cross-device credential sync or manual export/import.
+- UI redesign or credential form changes.
+- Encrypting `settings.json`.
+
+## Approach
+
+Use one storage format for all desktop secrets:
+
+```json
+{
+  "format": "octopusbeak.credentials.safeStorage.v1",
+  "data": "<base64 safeStorage ciphertext>"
+}
+```
+
+The encrypted payload is the JSON object that `credentials.json` stores today. Whole-file encryption is smaller and less error-prone than per-field encryption because every value in `credentials.json` is already classified as secret.
+
+`src/lib/automation/server/config-files.ts` remains the single credential read/write path. It gains a small process-wide credential codec. When the codec is registered, writes produce the encrypted envelope and reads decrypt it. When no codec is registered, the helper can still read and write plaintext for Node checks and direct development, but an encrypted file without a codec fails with a clear error.
+
+Electron main registers the codec after `app.whenReady()`, `ensureDataRoot(userData)`, runtime env setup, and `process.chdir(userData)`. If `safeStorage.isEncryptionAvailable()` is false, registration throws and the existing startup error dialog quits the app.
+
+## Migration
+
+On Electron startup, after registering the codec and after changing cwd to `userData`, run an explicit credential encryption migration:
+
+1. If `credentials.json` does not exist, do nothing.
+2. If it is already an encrypted envelope, do nothing.
+3. If it is a plaintext object with known automation secret keys, rewrite it through the normal encrypted writer.
+
+Reads stay side-effect-free. Migration is explicit so dashboard loading does not unexpectedly mutate files.
+
+## Error Handling
+
+- `safeStorage.isEncryptionAvailable() === false`: throw `Electron safeStorage encryption is not available. Refusing to read or write automation credentials.`
+- Encrypted credentials without a configured codec: throw `Credential encryption is not configured. Refusing to read encrypted automation credentials.`
+- Invalid encrypted envelope: throw an invalid-envelope error instead of treating it as empty credentials.
+
+Do not log credential values or decrypted payloads.
+
+## Testing
+
+Use the existing assert-based checks:
+
+- `config-files.check.ts`: fake codec encrypt/decrypt, encrypted envelope does not contain plaintext, encrypted reads fail without a codec, plaintext credentials migrate to encrypted envelope.
+- `desktop-api.check.ts`: saving credentials through the desktop API writes an encrypted envelope when the codec is configured.
+- Existing checks remain green: config files, desktop API, runtime, typecheck, build, privacy check.
+
+Manual smoke:
+
+```bash
+OCTOPUSBEAK_USER_DATA=/private/tmp/octopusbeak-safe-storage-smoke npm run desktop:dev
+```
+
+Save a credential in `#/automation`, quit, then verify the temp `credentials.json` contains an envelope and not the secret text.
+
+## Alternatives Considered
+
+Recommended: Electron `safeStorage` whole-file envelope. This uses the dependency already in the app and keeps the storage diff small.
+
+Rejected: per-field encryption. It adds schema complexity without buying much because every key in `credentials.json` is secret.
+
+Rejected: `keytar` or direct keychain integration. It adds a dependency and packaging surface before there is a demonstrated need beyond Electron `safeStorage`.
+
+Rejected: plaintext fallback when `safeStorage` is unavailable. The chosen behavior is explicit failure, as requested.

--- a/electron/credential-codec.ts
+++ b/electron/credential-codec.ts
@@ -3,11 +3,10 @@ import {
   migrateAutomationCredentialsFileEncryption,
   setAutomationCredentialCodec,
 } from "../src/lib/automation/server/config-files.ts";
+import { assertSafeStorageCanEncrypt } from "./safe-storage-availability.ts";
 
 export function registerAutomationCredentialSafeStorage() {
-  if (!safeStorage.isEncryptionAvailable()) {
-    throw new Error("Electron safeStorage encryption is not available. Refusing to read or write automation credentials.");
-  }
+  assertSafeStorageCanEncrypt(safeStorage);
 
   setAutomationCredentialCodec({
     encrypt(text: string) {

--- a/electron/credential-codec.ts
+++ b/electron/credential-codec.ts
@@ -1,0 +1,22 @@
+import { safeStorage } from "electron";
+import {
+  migrateAutomationCredentialsFileEncryption,
+  setAutomationCredentialCodec,
+} from "../src/lib/automation/server/config-files.ts";
+
+export function registerAutomationCredentialSafeStorage() {
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error("Electron safeStorage encryption is not available. Refusing to read or write automation credentials.");
+  }
+
+  setAutomationCredentialCodec({
+    encrypt(text: string) {
+      return safeStorage.encryptString(text).toString("base64");
+    },
+    decrypt(payload: string) {
+      return safeStorage.decryptString(Buffer.from(payload, "base64"));
+    },
+  });
+
+  migrateAutomationCredentialsFileEncryption();
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { app, BrowserWindow, dialog } from "electron";
+import { registerAutomationCredentialSafeStorage } from "./credential-codec.ts";
 import { registerOctopusBeakIpc } from "./ipc.ts";
 // @ts-expect-error runtime.cjs is bundled by Vite; keeping it CJS avoids changing the packaged entry.
 import runtime from "./runtime.cjs";
@@ -121,6 +122,7 @@ async function start() {
     electronPath: process.execPath,
   }));
   process.chdir(userData);
+  registerAutomationCredentialSafeStorage();
   registerOctopusBeakIpc();
   currentRendererUrl = rendererEntry(appRoot);
   currentPreloadPath = path.join(__dirname, "preload.cjs");

--- a/electron/safe-storage-availability.check.ts
+++ b/electron/safe-storage-availability.check.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { assertSafeStorageCanEncrypt, SAFE_STORAGE_UNAVAILABLE_MESSAGE } from "./safe-storage-availability.ts";
+
+assert.throws(
+  () => assertSafeStorageCanEncrypt({ isEncryptionAvailable: () => false }),
+  { message: SAFE_STORAGE_UNAVAILABLE_MESSAGE },
+);
+
+assert.throws(
+  () =>
+    assertSafeStorageCanEncrypt(
+      {
+        isEncryptionAvailable: () => true,
+        getSelectedStorageBackend: () => "basic_text",
+      },
+      "linux",
+    ),
+  { message: SAFE_STORAGE_UNAVAILABLE_MESSAGE },
+);
+
+assert.doesNotThrow(() =>
+  assertSafeStorageCanEncrypt(
+    {
+      isEncryptionAvailable: () => true,
+      getSelectedStorageBackend: () => "gnome_libsecret",
+    },
+    "linux",
+  ),
+);
+
+assert.doesNotThrow(() =>
+  assertSafeStorageCanEncrypt(
+    {
+      isEncryptionAvailable: () => true,
+      getSelectedStorageBackend: () => "basic_text",
+    },
+    "darwin",
+  ),
+);

--- a/electron/safe-storage-availability.ts
+++ b/electron/safe-storage-availability.ts
@@ -1,0 +1,16 @@
+export const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
+  "Electron safeStorage encryption is not available. Refusing to read or write automation credentials.";
+
+type SafeStorageAvailability = {
+  isEncryptionAvailable(): boolean;
+  getSelectedStorageBackend?(): string;
+};
+
+export function assertSafeStorageCanEncrypt(storage: SafeStorageAvailability, platform = process.platform) {
+  if (!storage.isEncryptionAvailable()) {
+    throw new Error(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+  }
+  if (platform === "linux" && storage.getSelectedStorageBackend?.() === "basic_text") {
+    throw new Error(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+  }
+}

--- a/src/lib/automation/server/config-files.check.ts
+++ b/src/lib/automation/server/config-files.check.ts
@@ -5,13 +5,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  AUTOMATION_CREDENTIALS_FORMAT,
   AUTOMATION_CREDENTIALS_PATH,
   AUTOMATION_SETTINGS_PATH,
   automationConfigEnv,
   credentialStatusFromValues,
+  migrateAutomationCredentialsFileEncryption,
   migrateAutomationEnvFile,
   readAutomationCredentialsFile,
   readAutomationSettingsFile,
+  setAutomationCredentialCodec,
   settingsToEnv,
   splitAutomationUpdates,
   writeAutomationCredentialsFile,
@@ -152,6 +155,50 @@ try {
   });
   assert.equal(existsSync(join(importCwd, "settings.json")), false);
   assert.equal(existsSync(join(importCwd, "credentials.json")), false);
+
+  const fakeCodec = {
+    encrypt(text: string) {
+      return Buffer.from(`safe:${text}`, "utf8").toString("base64");
+    },
+    decrypt(payload: string) {
+      const text = Buffer.from(payload, "base64").toString("utf8");
+      if (!text.startsWith("safe:")) throw new Error("bad fake credential payload");
+      return text.slice("safe:".length);
+    },
+  };
+
+  const encryptedCredentialsPath = join(dir, "encrypted-credentials.json");
+  setAutomationCredentialCodec(fakeCodec);
+  writeAutomationCredentialsFile(encryptedCredentialsPath, {
+    [fubonPasswordKey]: "encrypted-secret",
+  });
+  const encryptedText = readFileSync(encryptedCredentialsPath, "utf8");
+  const encryptedRecord = JSON.parse(encryptedText) as { format?: unknown; data?: unknown };
+  assert.equal(encryptedRecord.format, AUTOMATION_CREDENTIALS_FORMAT);
+  assert.equal(typeof encryptedRecord.data, "string");
+  assert.equal(encryptedText.includes("encrypted-secret"), false);
+  assert.deepEqual(readAutomationCredentialsFile(encryptedCredentialsPath), {
+    [fubonPasswordKey]: "encrypted-secret",
+  });
+
+  setAutomationCredentialCodec(null);
+  assert.throws(
+    () => readAutomationCredentialsFile(encryptedCredentialsPath),
+    /Credential encryption is not configured/,
+  );
+
+  const legacyCredentialsPath = join(dir, "legacy-credentials.json");
+  writeFileSync(legacyCredentialsPath, `${JSON.stringify({
+    [maxSecretKey]: "legacy-secret",
+  }, null, 2)}\n`);
+  setAutomationCredentialCodec(fakeCodec);
+  assert.equal(migrateAutomationCredentialsFileEncryption(legacyCredentialsPath), true);
+  assert.deepEqual(readAutomationCredentialsFile(legacyCredentialsPath), {
+    [maxSecretKey]: "legacy-secret",
+  });
+  assert.equal(readFileSync(legacyCredentialsPath, "utf8").includes("legacy-secret"), false);
+  assert.equal(migrateAutomationCredentialsFileEncryption(legacyCredentialsPath), false);
+  setAutomationCredentialCodec(null);
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }

--- a/src/lib/automation/server/config-files.ts
+++ b/src/lib/automation/server/config-files.ts
@@ -19,6 +19,23 @@ export type AutomationCredentialsFile = Record<string, string>;
 
 export const AUTOMATION_SETTINGS_PATH = "settings.json";
 export const AUTOMATION_CREDENTIALS_PATH = "credentials.json";
+export const AUTOMATION_CREDENTIALS_FORMAT = "octopusbeak.credentials.safeStorage.v1";
+
+export type AutomationCredentialCodec = {
+  encrypt(text: string): string;
+  decrypt(payload: string): string;
+};
+
+type EncryptedAutomationCredentialsFile = {
+  format: typeof AUTOMATION_CREDENTIALS_FORMAT;
+  data: string;
+};
+
+let automationCredentialCodec: AutomationCredentialCodec | null = null;
+
+export function setAutomationCredentialCodec(codec: AutomationCredentialCodec | null) {
+  automationCredentialCodec = codec;
+}
 
 const automationSettingKeys = new Set<string>(AUTOMATION_NON_SECRET_KEYS);
 const automationSecretKeys = new Set<string>(AUTOMATION_SECRET_KEYS);
@@ -62,12 +79,52 @@ function cleanCredentials(record: Record<string, unknown>): AutomationCredential
   return result;
 }
 
+function encryptedAutomationCredentialsFile(
+  record: Record<string, unknown>,
+): EncryptedAutomationCredentialsFile | null {
+  if (record.format !== AUTOMATION_CREDENTIALS_FORMAT) return null;
+  if (typeof record.data !== "string" || !record.data.trim()) {
+    throw new Error(`${AUTOMATION_CREDENTIALS_PATH} encrypted envelope is invalid.`);
+  }
+  return {
+    format: AUTOMATION_CREDENTIALS_FORMAT,
+    data: record.data,
+  };
+}
+
+function requireAutomationCredentialCodec() {
+  if (!automationCredentialCodec) {
+    throw new Error("Credential encryption is not configured. Refusing to read encrypted automation credentials.");
+  }
+  return automationCredentialCodec;
+}
+
+function decodeCredentialsRecord(record: Record<string, unknown>) {
+  const encrypted = encryptedAutomationCredentialsFile(record);
+  if (!encrypted) return record;
+  const text = requireAutomationCredentialCodec().decrypt(encrypted.data);
+  const parsed = JSON.parse(text) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${AUTOMATION_CREDENTIALS_PATH} encrypted payload must contain a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function credentialsFileText(credentials: AutomationCredentialsFile) {
+  const cleaned = cleanCredentials(credentials);
+  if (!automationCredentialCodec) return `${JSON.stringify(cleaned, null, 2)}\n`;
+  return `${JSON.stringify({
+    format: AUTOMATION_CREDENTIALS_FORMAT,
+    data: automationCredentialCodec.encrypt(JSON.stringify(cleaned)),
+  }, null, 2)}\n`;
+}
+
 export function readAutomationSettingsFile(path = AUTOMATION_SETTINGS_PATH) {
   return cleanSettings(readJsonRecord(path));
 }
 
 export function readAutomationCredentialsFile(path = AUTOMATION_CREDENTIALS_PATH) {
-  return cleanCredentials(readJsonRecord(path));
+  return cleanCredentials(decodeCredentialsRecord(readJsonRecord(path)));
 }
 
 export function writeAutomationSettingsFile(path: string, settings: AutomationSettingsFile) {
@@ -75,7 +132,7 @@ export function writeAutomationSettingsFile(path: string, settings: AutomationSe
 }
 
 export function writeAutomationCredentialsFile(path: string, credentials: AutomationCredentialsFile) {
-  atomicWrite(path, `${JSON.stringify(cleanCredentials(credentials), null, 2)}\n`);
+  atomicWrite(path, credentialsFileText(credentials));
 }
 
 export function writeAutomationSettings(settings: AutomationSettingsFile) {
@@ -84,6 +141,17 @@ export function writeAutomationSettings(settings: AutomationSettingsFile) {
 
 export function writeAutomationCredentials(credentials: AutomationCredentialsFile) {
   writeAutomationCredentialsFile(AUTOMATION_CREDENTIALS_PATH, credentials);
+}
+
+export function migrateAutomationCredentialsFileEncryption(path = AUTOMATION_CREDENTIALS_PATH) {
+  if (!existsSync(path)) return false;
+  const record = readJsonRecord(path);
+  if (encryptedAutomationCredentialsFile(record)) return false;
+  const credentials = cleanCredentials(record);
+  if (Object.keys(credentials).length === 0) return false;
+  requireAutomationCredentialCodec();
+  writeAutomationCredentialsFile(path, credentials);
+  return true;
 }
 
 function envValueToSetting(key: string, value: string): AutomationSettingValue {

--- a/src/lib/automation/server/desktop-api.check.ts
+++ b/src/lib/automation/server/desktop-api.check.ts
@@ -10,6 +10,7 @@ const enabledKey = `${credentialPrefix}ENABLED`;
 const userIdKey = `${credentialPrefix}USER_ID`;
 const accountKey = `${credentialPrefix}ACCOUNT`;
 const passwordKey = `${credentialPrefix}PASSWORD`;
+let resetCredentialCodec: (() => void) | null = null;
 
 try {
   process.chdir(dir);
@@ -23,6 +24,8 @@ try {
     [passwordKey]: "pw",
   }, null, 2));
 
+  const configFiles = await import("./config-files.ts");
+  resetCredentialCodec = () => configFiles.setAutomationCredentialCodec(null);
   const api = await import("./desktop-api.ts");
 
   const model = api.loadAutomationDesktopModel(dir);
@@ -34,6 +37,18 @@ try {
     /Import is locked/,
   );
 
+  const fakeCodec = {
+    encrypt(text: string) {
+      return Buffer.from(`safe:${text}`, "utf8").toString("base64");
+    },
+    decrypt(payload: string) {
+      const text = Buffer.from(payload, "base64").toString("utf8");
+      if (!text.startsWith("safe:")) throw new Error("bad fake credential payload");
+      return text.slice("safe:".length);
+    },
+  };
+  configFiles.setAutomationCredentialCodec(fakeCodec);
+
   const saveResult = api.automationSaveCredentials({
     [enabledKey]: "false",
     [accountKey]: "next-acct",
@@ -41,12 +56,22 @@ try {
   assert.deepEqual(saveResult, { saved: true });
 
   const settings = JSON.parse(readFileSync("settings.json", "utf8"));
-  const credentials = JSON.parse(readFileSync("credentials.json", "utf8"));
+  const rawCredentialsText = readFileSync("credentials.json", "utf8");
+  const rawCredentials = JSON.parse(rawCredentialsText) as { format?: unknown };
+  const credentials = configFiles.readAutomationCredentialsFile("credentials.json");
   assert.equal(settings[enabledKey], false);
   assert.equal(Object.hasOwn(settings, accountKey), false);
+  assert.equal(rawCredentials.format, configFiles.AUTOMATION_CREDENTIALS_FORMAT);
+  assert.equal(rawCredentialsText.includes("next-acct"), false);
   assert.equal(credentials[accountKey], "next-acct");
   assert.equal(Object.hasOwn(credentials, enabledKey), false);
+  resetCredentialCodec();
+  assert.throws(
+    () => configFiles.readAutomationCredentialsFile("credentials.json"),
+    /Credential encryption is not configured/,
+  );
 } finally {
+  resetCredentialCodec?.();
   process.chdir(originalCwd);
   rmSync(dir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- Encrypt desktop automation `credentials.json` as a whole-file Electron `safeStorage` envelope.
- Keep `settings.json` plaintext and preserve existing workflow env injection.
- Migrate legacy plaintext credentials during Electron startup and fail fast when safeStorage is unavailable or Linux uses the unsafe `basic_text` backend.

## Test Plan

- [x] `node --no-warnings --experimental-strip-types electron/safe-storage-availability.check.ts`
- [x] `node --no-warnings --experimental-strip-types src/lib/automation/server/config-files.check.ts`
- [x] `node --no-warnings --experimental-strip-types src/lib/automation/server/desktop-api.check.ts`
- [x] `npm run desktop:runtime-probe`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run privacy-check`
- [x] Playwright/Electron temp-userData smoke: save credential through preload API, verify `credentials.json` has `format`/`data` and does not contain the sentinel plaintext.
