### PR TITLE
Adopt LayerChart for snapshot sparklines

### DIFF
--- a/docs/superpowers/plans/2026-07-02-layerchart-sparkline.md
+++ b/docs/superpowers/plans/2026-07-02-layerchart-sparkline.md
@@ -369,8 +369,8 @@ In `src/app.css`, replace the existing sparkline CSS block from `.sparkline { ..
   display: block;
 }
 
-.sparkline-grid :global(line),
-.sparkline-grid :global(path) {
+.sparkline-grid line,
+.sparkline-grid path {
   stroke: var(--border);
 }
 

--- a/docs/superpowers/plans/2026-07-02-layerchart-sparkline.md
+++ b/docs/superpowers/plans/2026-07-02-layerchart-sparkline.md
@@ -1,0 +1,543 @@
+# LayerChart Sparkline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the custom portfolio sparkline internals with LayerChart while keeping the existing `SnapshotSparkline.svelte` public API stable.
+
+**Architecture:** Keep dashboard callers unchanged and isolate chart-specific data mapping in a tiny TypeScript helper. LayerChart owns line/area/axis/tooltip rendering; the app still owns DTO filtering, money formatting, labels, privacy CSS, and page-level currency selection.
+
+**Tech Stack:** Svelte 5, SvelteKit, TypeScript, LayerChart 2.x, Node assert checks, existing `npm run typecheck`.
+
+---
+
+## Scope
+
+Implement only Phase 1 from `docs/superpowers/specs/2026-07-02-ui-library-evaluation-design.md`.
+
+Do not add shadcn-svelte.
+
+Do not add TanStack Table.
+
+Do not redesign `DashboardShell.svelte`.
+
+Before editing, run `git status --short`. This worktree currently has an unrelated unstaged `package-lock.json` change. Preserve it. If dependency installation changes `package-lock.json`, inspect the diff and stage only the dependency-related lockfile changes together with `package.json`.
+
+## File Structure
+
+- Modify: `package.json`
+  - Add `layerchart` as a development dependency.
+- Modify: `package-lock.json`
+  - Let `npm install` update the lockfile for LayerChart only.
+- Create: `src/lib/overview/components/snapshot-chart-data.ts`
+  - Convert `DailyHistoryRowDto[]` into sorted `{ date, dateLabel, value }` points for one currency and amount key.
+- Create: `src/lib/overview/components/snapshot-chart-data.check.ts`
+  - Assert the mapper filters missing currencies, sorts by date, keeps date labels, and preserves negative values.
+- Modify: `src/lib/overview/components/SnapshotSparkline.svelte`
+  - Replace custom SVG path/axis math with LayerChart `AreaChart` and a custom tooltip snippet.
+  - Keep props unchanged: `rows`, `currency`, `amountKey`, `label`.
+- Modify: `src/app.css`
+  - Remove unused custom SVG path/dot tooltip selectors after the Svelte file stops using them.
+  - Keep `.sparkline`, `.sparkline-axis`, `.sparkline-empty`, and privacy behavior.
+
+---
+
+### Task 1: Add LayerChart Dependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Confirm current worktree state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+ M package-lock.json
+```
+
+If additional unrelated files appear, leave them unstaged. If `package-lock.json` is still dirty, run:
+
+```bash
+git diff -- package-lock.json
+```
+
+Expected: output shows the pre-existing lockfile change. Keep it in mind before staging.
+
+- [ ] **Step 2: Install LayerChart**
+
+Run:
+
+```bash
+npm install -D layerchart@2.0.0
+```
+
+Expected: `package.json` gains a `devDependencies.layerchart` entry and `package-lock.json` gains the LayerChart dependency tree.
+
+- [ ] **Step 3: Verify dependency entry**
+
+Open `package.json` and confirm the `devDependencies` block contains:
+
+```json
+"layerchart": "^2.0.0"
+```
+
+If npm writes `"2.0.0"` instead of `"^2.0.0"`, keep npm's output.
+
+- [ ] **Step 4: Inspect the dependency diff**
+
+Run:
+
+```bash
+git diff -- package.json package-lock.json
+```
+
+Expected: diff contains the LayerChart dependency. If the pre-existing `package-lock.json` change is mixed into the same file, do not revert it; stage the final lockfile only after confirming it is still compatible with the user's existing change.
+
+- [ ] **Step 5: Typecheck dependency resolution**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS. No source imports LayerChart yet, but dependency resolution should not break SvelteKit sync or TypeScript.
+
+- [ ] **Step 6: Commit dependency**
+
+Run:
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add layerchart"
+```
+
+Expected: commit succeeds. If the lockfile had unrelated pre-existing edits, mention that in the commit body:
+
+```bash
+git commit -m "chore: add layerchart" -m "Preserves existing package-lock changes in the worktree."
+```
+
+---
+
+### Task 2: Add Tested Snapshot Chart Data Mapper
+
+**Files:**
+- Create: `src/lib/overview/components/snapshot-chart-data.ts`
+- Create: `src/lib/overview/components/snapshot-chart-data.check.ts`
+
+- [ ] **Step 1: Write the failing check**
+
+Create `src/lib/overview/components/snapshot-chart-data.check.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
+import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+const rows: DailyHistoryRowDto[] = [
+  {
+    date: "2026-07-02",
+    netAssets: [{ currency: "TWD", value: 120 }],
+    assets: [{ currency: "TWD", value: 160 }],
+    liabilities: [{ currency: "TWD", value: 40 }],
+    dailyChange: [{ currency: "TWD", value: -10 }],
+  },
+  {
+    date: "2026-07-01",
+    netAssets: [
+      { currency: "TWD", value: 100 },
+      { currency: "USD", value: 3 },
+    ],
+    assets: [{ currency: "TWD", value: 150 }],
+    liabilities: [{ currency: "TWD", value: 50 }],
+    dailyChange: [{ currency: "TWD", value: 5 }],
+  },
+  {
+    date: "2026-07-03",
+    netAssets: [{ currency: "USD", value: 4 }],
+    assets: [{ currency: "USD", value: 4 }],
+    liabilities: [],
+    dailyChange: [{ currency: "USD", value: 1 }],
+  },
+];
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "netAssets"), [
+  { date: new Date("2026-07-01T00:00:00.000Z"), dateLabel: "2026-07-01", value: 100 },
+  { date: new Date("2026-07-02T00:00:00.000Z"), dateLabel: "2026-07-02", value: 120 },
+]);
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "dailyChange"), [
+  { date: new Date("2026-07-01T00:00:00.000Z"), dateLabel: "2026-07-01", value: 5 },
+  { date: new Date("2026-07-02T00:00:00.000Z"), dateLabel: "2026-07-02", value: -10 },
+]);
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "JPY", "netAssets"), []);
+```
+
+- [ ] **Step 2: Run check to verify it fails**
+
+Run:
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/overview/components/snapshot-chart-data.check.ts
+```
+
+Expected: FAIL with a module-not-found error for `snapshot-chart-data.ts`.
+
+- [ ] **Step 3: Write the mapper**
+
+Create `src/lib/overview/components/snapshot-chart-data.ts`:
+
+```ts
+import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+type HistoryAmountKey = "netAssets" | "assets" | "liabilities" | "dailyChange";
+
+export type SnapshotChartPoint = {
+  date: Date;
+  dateLabel: string;
+  value: number;
+};
+
+export function buildSnapshotChartPoints(
+  rows: DailyHistoryRowDto[],
+  currency: string,
+  amountKey: HistoryAmountKey,
+): SnapshotChartPoint[] {
+  return rows
+    .map((row) => {
+      const amount = row[amountKey].find((item) => item.currency === currency);
+      return amount
+        ? {
+            date: new Date(`${row.date}T00:00:00.000Z`),
+            dateLabel: row.date,
+            value: amount.value,
+          }
+        : null;
+    })
+    .filter((item): item is SnapshotChartPoint => item !== null)
+    .sort((left, right) => left.dateLabel.localeCompare(right.dateLabel));
+}
+```
+
+- [ ] **Step 4: Run check to verify it passes**
+
+Run:
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/overview/components/snapshot-chart-data.check.ts
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit mapper**
+
+Run:
+
+```bash
+git add src/lib/overview/components/snapshot-chart-data.ts src/lib/overview/components/snapshot-chart-data.check.ts
+git commit -m "test: cover snapshot chart data mapping"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Replace SnapshotSparkline Internals
+
+**Files:**
+- Modify: `src/lib/overview/components/SnapshotSparkline.svelte`
+- Modify: `src/app.css`
+
+- [ ] **Step 1: Replace `SnapshotSparkline.svelte`**
+
+Replace the full contents of `src/lib/overview/components/SnapshotSparkline.svelte` with:
+
+```svelte
+<script lang="ts">
+  import { AreaChart, Tooltip } from "layerchart";
+  import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+  import { formatMoney } from "$lib/shared-money/money.ts";
+  import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
+
+  type HistoryAmountKey = "netAssets" | "assets" | "liabilities";
+
+  export let rows: DailyHistoryRowDto[] = [];
+  export let currency = "TWD";
+  export let amountKey: HistoryAmountKey = "netAssets";
+  export let label = "Net position";
+
+  $: points = buildSnapshotChartPoints(rows, currency, amountKey);
+  $: ariaLabel = `${label} trend ${currency}`;
+
+  function shortDate(value: string) {
+    return value.slice(5);
+  }
+
+  function pointTitle(point: { dateLabel: string; value: number }) {
+    return `${point.dateLabel} ${formatMoney({ currency, value: point.value })}`;
+  }
+</script>
+
+{#if points.length > 0}
+  <div class="sparkline" role="img" aria-label={ariaLabel}>
+    <AreaChart
+      data={points}
+      x="date"
+      y="value"
+      yNice
+      axis="xy"
+      grid="y"
+      height={220}
+      props={{
+        area: { class: "sparkline-area" },
+        line: { class: "sparkline-line" },
+        axis: {
+          x: { class: "sparkline-axis", format: shortDate },
+          y: { class: "sparkline-axis", props: { tickLabel: { "data-sensitive": "" } } },
+        },
+        grid: { class: "sparkline-grid" },
+        highlight: { points: { r: 5, class: "sparkline-dot" } },
+      }}
+    >
+      {#snippet tooltip({ context })}
+        <Tooltip.Root {context} class="sparkline-tooltip" variant="none">
+          {#snippet children({ data })}
+            <div class="sparkline-tooltip-body">
+              <span>{data.dateLabel}</span>
+              <strong>{formatMoney({ currency, value: data.value })}</strong>
+            </div>
+          {/snippet}
+        </Tooltip.Root>
+      {/snippet}
+    </AreaChart>
+    <ul class="sparkline-points" aria-hidden="true">
+      {#each points as point}
+        <li>{pointTitle(point)}</li>
+      {/each}
+    </ul>
+  </div>
+{:else}
+  <div class="sparkline sparkline-empty" role="img" aria-label={ariaLabel}>
+    No {currency} history
+  </div>
+{/if}
+```
+
+- [ ] **Step 2: Run typecheck to catch LayerChart API drift**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS. If this fails because LayerChart 2.0.0 prop names differ, use the installed package's TypeScript errors as the source of truth and make the smallest prop-name change that preserves the same behavior.
+
+- [ ] **Step 3: Trim obsolete SVG-only CSS**
+
+In `src/app.css`, replace the existing sparkline CSS block from `.sparkline { ... }` through `.sparkline-empty { ... }` with:
+
+```css
+.sparkline {
+  width: 100%;
+  height: 220px;
+  display: block;
+  margin-bottom: var(--space-4);
+}
+
+.sparkline svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.sparkline-grid :global(line),
+.sparkline-grid :global(path) {
+  stroke: var(--border);
+}
+
+.sparkline-axis {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.sparkline-area {
+  fill: color-mix(in oklch, var(--accent) 14%, white);
+}
+
+.sparkline-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.sparkline-dot {
+  fill: var(--accent);
+  stroke: white;
+  stroke-width: 3;
+}
+
+.sparkline-tooltip {
+  pointer-events: none;
+}
+
+.sparkline-tooltip-body {
+  display: grid;
+  gap: 2px;
+  min-width: 132px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--fg) 92%, transparent);
+  color: white;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.sparkline-tooltip-body strong {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.sparkline-points {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.sparkline-empty {
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+```
+
+- [ ] **Step 4: Run mapper check**
+
+Run:
+
+```bash
+node --no-warnings --experimental-strip-types src/lib/overview/components/snapshot-chart-data.check.ts
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Start mock dev server**
+
+Run:
+
+```bash
+npm run dev:mock
+```
+
+Expected: Vite starts and prints a local URL, usually `http://localhost:5173/`.
+
+- [ ] **Step 7: Browser-check chart rendering**
+
+Open the dev server URL in the browser and check these hash routes:
+
+```text
+http://localhost:5173/#/overview
+http://localhost:5173/#/assets
+http://localhost:5173/#/liabilities
+```
+
+Expected on each page:
+
+- the chart area is non-empty
+- x-axis dates render as `MM-DD`
+- y-axis values are visible when values are shown
+- the value visibility toggle still blurs sensitive chart tick values through `[data-sensitive]`
+- hovering the chart shows a tooltip with date and formatted money
+- the page does not horizontally overflow at desktop width
+
+- [ ] **Step 8: Stop dev server**
+
+Stop the Vite process with `Ctrl-C`.
+
+Expected: the server exits cleanly.
+
+- [ ] **Step 9: Commit chart replacement**
+
+Run:
+
+```bash
+git add src/lib/overview/components/SnapshotSparkline.svelte src/app.css
+git commit -m "feat: render snapshot charts with layerchart"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- LayerChart-first rollout is covered by Tasks 1 and 3.
+- Stable `SnapshotSparkline.svelte` props are covered in Task 3.
+- DTO-to-chart mapping is covered in Task 2.
+- Empty state, privacy behavior, typecheck, and browser visual checks are covered in Task 3.
+- TanStack Table and shadcn-svelte are intentionally out of scope for this plan.
+
+Placeholder scan:
+
+- No task relies on unspecified files.
+- Every code-writing step includes the exact file content or replacement block.
+- Every verification step has an exact command and expected result.
+
+Type consistency:
+
+- `HistoryAmountKey` in `SnapshotSparkline.svelte` remains the existing three chart keys.
+- `buildSnapshotChartPoints` supports `dailyChange` only for tests and future table/chart reuse.
+- `SnapshotChartPoint.dateLabel` is used for display and sort stability; `SnapshotChartPoint.date` is used by LayerChart.
+
+## Execution Choice
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-02-layerchart-sparkline.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** - Dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-02-ui-library-evaluation-design.md
+++ b/docs/superpowers/specs/2026-07-02-ui-library-evaluation-design.md
@@ -1,0 +1,181 @@
+# UI Library Evaluation Design
+
+Date: 2026-07-02
+
+## Context
+
+The app is a Svelte 5 + SvelteKit/Electron personal portfolio dashboard. The current UI is mostly hand-rolled:
+
+- `DashboardShell.svelte` owns the sidebar, topbar, value visibility state, and route-level chrome.
+- `AccountTable.svelte` and `DailyHistoryTable.svelte` each implement their own sorting, sort indicators, filtering, pagination, and row rendering.
+- `SnapshotSparkline.svelte` implements custom SVG charting, including axis ticks, line/area paths, tooltip placement, and pointer interaction.
+- `app.css` already has product-specific tokens, density, cards, table styles, modal styles, and responsive shell rules.
+
+The requested evaluation is whether shadcn-svelte, TanStack Table, and LayerChart should be used to optimize the current UI.
+
+## Findings
+
+LayerChart has the clearest immediate fit. The app has repeated trend charts and custom SVG chart logic that can be replaced while preserving the current data API.
+
+TanStack Table should not be adopted through `@tanstack/svelte-table` right now. The project uses Svelte 5, while TanStack's official installation docs still call out that the Svelte adapter targets Svelte 3/4 and recommends `@tanstack/table-core` plus a custom or community adapter for Svelte 5.
+
+shadcn-svelte should not be adopted as a full visual rewrite. It is useful as a source-owned component system for primitive controls, but its SvelteKit guide assumes Tailwind setup and CLI-generated component folders. The existing UI already has a strong product shell, so replacing everything would add churn before solving a concrete pain point.
+
+## Decision
+
+Use a three-phase, smallest-useful rollout:
+
+1. Adopt LayerChart for trend charts first.
+2. Keep tables hand-rolled for now, but extract repeated sorting and pagination helpers if table behavior keeps spreading.
+3. Add selected shadcn-svelte primitives only when replacing existing modal/button/input/switch/table markup pays for itself.
+
+## Non-Goals
+
+- Do not redesign the app shell.
+- Do not replace `DashboardShell.svelte`.
+- Do not add Tailwind only to satisfy shadcn-svelte.
+- Do not adopt `@tanstack/svelte-table` unless it has a Svelte 5-safe path in this codebase.
+- Do not move business data shaping into UI component libraries.
+
+## Approach Options
+
+### Option A: Full shadcn-svelte UI Migration
+
+This would initialize shadcn-svelte, add primitives for the shell, dialog, buttons, inputs, tables, pagination, switch, and chart container, then rework the app CSS around the generated component style.
+
+Tradeoff: It gives a consistent component vocabulary, but it is the most disruptive option and likely requires Tailwind or a parallel styling layer. It also risks flattening the product-specific density and shell that already work.
+
+Verdict: Do not do this now.
+
+### Option B: Table-First TanStack Migration
+
+This would replace `AccountTable.svelte`, `DailyHistoryTable.svelte`, and the automation task table with TanStack Table state and row models.
+
+Tradeoff: It becomes valuable if the app needs column visibility, row selection, faceted filters, multi-sort, or virtualized large tables. For current behavior, it introduces adapter work because Svelte 5 is not the happy path for `@tanstack/svelte-table`.
+
+Verdict: Defer. Use `@tanstack/table-core` later only if table requirements grow.
+
+### Option C: Chart-First LayerChart Migration
+
+This would replace `SnapshotSparkline.svelte` internals with LayerChart while keeping its props stable:
+
+- `rows`
+- `currency`
+- `amountKey`
+- `label`
+
+Overview, assets, and liabilities pages would continue to call the same component. The chart would use existing CSS tokens for colors and typography.
+
+Tradeoff: Adds one dependency, but removes the highest-maintenance custom visualization code.
+
+Verdict: Recommended first step.
+
+## Proposed Design
+
+### Phase 1: LayerChart Adapter
+
+Create a chart adapter inside `SnapshotSparkline.svelte` or a nearby helper only if needed. It should map `DailyHistoryRowDto[]` to simple `{ date, value }` points and render the existing trend chart using LayerChart primitives.
+
+Keep the public component API unchanged so these existing callers do not change:
+
+- `OverviewDashboard.svelte`
+- `AssetsDashboard.svelte`
+- `LiabilitiesDashboard.svelte`
+
+The visual output should preserve:
+
+- current chart labels
+- current currency selector behavior
+- empty-state text
+- value privacy behavior through `[data-sensitive]`
+- responsive width
+
+LayerChart should own scale, axes, line/area drawing, and tooltip mechanics. The app should still own money formatting and currency filtering.
+
+### Phase 2: Table Cleanup Without TanStack
+
+Before adopting TanStack, remove local duplication where it is cheap:
+
+- one tiny sort helper for date/string/number comparisons
+- one tiny pagination helper for page bounds and row slicing
+- keep all row markup inside each table component
+
+This keeps the diff small and avoids a Svelte 5 adapter decision until a table feature actually needs TanStack.
+
+TanStack Table becomes justified when at least one of these is requested:
+
+- multi-column sorting
+- column visibility controls
+- row selection across pages
+- faceted filtering
+- virtualized large tables
+- shared column definitions across multiple tables
+
+If adopted later, prefer `@tanstack/table-core` with a thin local Svelte 5 adapter rather than `@tanstack/svelte-table`.
+
+### Phase 3: Selective shadcn-svelte Primitives
+
+Only add shadcn-svelte primitives when they replace repeated or fragile UI code:
+
+- `Dialog` for account, asset, transaction, credential, log, and viewer modals
+- `Button` for primary/secondary/action controls
+- `Input` for search and credential inputs
+- `Switch` for value visibility
+- `Table` and `Pagination` only if they reduce markup without forcing a TanStack migration
+
+Do not add shadcn-svelte `Sidebar`; the existing sidebar is app-specific and already handles collapsed state, route navigation, responsive behavior, branding, and portfolio side status.
+
+## Data Flow
+
+Data continues to flow through the existing page DTOs:
+
+1. Svelte route loads dashboard data through `window.octopusBeak`.
+2. Page dashboards derive view-specific arrays and currencies.
+3. UI components receive DTO slices as props.
+4. Chart/table components render only presentation state.
+
+No library should fetch data, own persistence, or change DTO shapes.
+
+## Error Handling
+
+Library-backed components should preserve current empty and missing-data behavior:
+
+- missing currency amount renders `--` in tables
+- no chart points renders `No <currency> history`
+- loading and route errors stay in `+page.svelte`
+- chart rendering errors should not affect data loading behavior
+
+## Testing
+
+Minimum verification for Phase 1:
+
+- `npm run typecheck`
+- one browser visual check for overview, assets, and liabilities chart rendering
+- confirm value privacy blur still hides chart tick values marked sensitive
+
+Minimum verification for Phase 2:
+
+- a small assert-based check or existing component-level check for sort/pagination helpers
+- `npm run typecheck`
+
+Minimum verification for Phase 3:
+
+- `npm run typecheck`
+- browser checks for modal open/close, focus behavior, Escape handling, and mobile layout
+
+## Rollout
+
+Start with Phase 1 only. If the LayerChart migration creates more code than it removes, stop and keep the existing SVG implementation.
+
+Proceed to Phase 2 only if table duplication grows or table behavior changes.
+
+Proceed to Phase 3 only when touching modal/control code for another concrete UI task.
+
+## References
+
+- shadcn-svelte docs: https://www.shadcn-svelte.com/docs
+- shadcn-svelte SvelteKit installation: https://www.shadcn-svelte.com/docs/installation/sveltekit
+- shadcn-svelte Data Table: https://www.shadcn-svelte.com/docs/components/data-table
+- shadcn-svelte Chart: https://www.shadcn-svelte.com/docs/components/chart
+- TanStack Table installation: https://tanstack.com/table/latest/docs/installation
+- LayerChart GitHub: https://github.com/techniq/layerchart

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@sveltejs/kit": "^2.68.0",
         "@types/node": "^26.0.0",
         "electron": "^43.0.0",
+        "layerchart": "^2.0.0",
         "svelte": "^5.56.4",
         "svelte-check": "^4.7.1",
         "typescript": "^5.9.0",
@@ -166,6 +167,23 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "3.0.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron-forge/cli": {
       "version": "7.11.2",
@@ -882,29 +900,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -1332,6 +1327,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1637,6 +1660,53 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@layerstack/svelte-actions": {
+      "version": "1.0.1-next.18",
+      "resolved": "https://registry.npmjs.org/@layerstack/svelte-actions/-/svelte-actions-1.0.1-next.18.tgz",
+      "integrity": "sha512-gxPzCnJ1c9LTfWtRqLUzefCx+k59ZpxDUQ2XB+LokveZQPe7IDSOwHaBOEMlaGoGrtwc3Ft8dSZq+2WT2o9u/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.0",
+        "@layerstack/utils": "2.0.0-next.18",
+        "d3-scale": "^4.0.2"
+      }
+    },
+    "node_modules/@layerstack/svelte-state": {
+      "version": "0.1.0-next.23",
+      "resolved": "https://registry.npmjs.org/@layerstack/svelte-state/-/svelte-state-0.1.0-next.23.tgz",
+      "integrity": "sha512-7O4umv+gXwFfs3/vjzFWYHNXGwYnnjBapWJ5Y+9u99F4eVk6rh4ocNwqkqQNkpMZ5tUJBlRTWjPE1So6+hEzIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@layerstack/utils": "2.0.0-next.18"
+      }
+    },
+    "node_modules/@layerstack/tailwind": {
+      "version": "2.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@layerstack/tailwind/-/tailwind-2.0.0-next.21.tgz",
+      "integrity": "sha512-Qgp2EpmEHmjtura8MQzWicR6ztBRSsRvddakFtx9ShrLMz6jWzd6bCMVVRu44Q3ZOrtXmSu4QxjCZWu1ytvuPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@layerstack/utils": "^2.0.0-next.18",
+        "clsx": "^2.1.1",
+        "d3-array": "^3.2.4",
+        "tailwind-merge": "^3.2.0"
+      }
+    },
+    "node_modules/@layerstack/utils": {
+      "version": "2.0.0-next.18",
+      "resolved": "https://registry.npmjs.org/@layerstack/utils/-/utils-2.0.0-next.18.tgz",
+      "integrity": "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-time": "^3.1.0",
+        "d3-time-format": "^4.1.0"
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
@@ -2246,10 +2316,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3541,6 +3636,387 @@
         "node": ">=12.10"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-voronoi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz",
+      "integrity": "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-delaunay": "6",
+        "d3-geo": "3",
+        "d3-tricontour": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate-path": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate-path/-/d3-interpolate-path-2.3.0.tgz",
+      "integrity": "sha512-tZYtGXxBmbgHsIc9Wms6LS5u4w6KbP8C09a4/ZYc4KLMYYqub57rRBUgpUr2CIarIrJEpdAWWxWQvofgaMpbKQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tile": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d3-tile/-/d3-tile-1.0.0.tgz",
+      "integrity": "sha512-79fnTKpPMPDS5xQ0xuS9ir0165NEwwkFpe/DSOmc2Gl9ldYzKKRDWogmTTE8wAJ8NA7PMapNfEcyKhI9Lxdu5Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-tricontour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
+      "integrity": "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-delaunay": "6",
+        "d3-scale": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3657,6 +4133,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3953,31 +4449,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5103,6 +5574,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -5404,6 +5885,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/layerchart": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/layerchart/-/layerchart-2.0.0.tgz",
+      "integrity": "sha512-QD1XxF2RL0A8YkkI6Gt1rh66h66Cr6MvAG1Ncb9tD9nzojbado+nqyljbR3R4AnDyg9rR4kS2P1Hoco6xTgGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/dagre": "^2.0.4",
+        "@layerstack/svelte-actions": "1.0.1-next.18",
+        "@layerstack/svelte-state": "0.1.0-next.23",
+        "@layerstack/tailwind": "2.0.0-next.21",
+        "@layerstack/utils": "2.0.0-next.18",
+        "@types/d3-contour": "^3.0.6",
+        "d3-array": "^3.2.4",
+        "d3-chord": "^3.0.1",
+        "d3-color": "^3.1.0",
+        "d3-contour": "^4.0.2",
+        "d3-delaunay": "^6.0.4",
+        "d3-dsv": "^3.0.1",
+        "d3-force": "^3.0.0",
+        "d3-geo": "^3.1.1",
+        "d3-geo-voronoi": "^2.1.0",
+        "d3-hierarchy": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-interpolate-path": "^2.3.0",
+        "d3-path": "^3.1.0",
+        "d3-quadtree": "^3.0.1",
+        "d3-random": "^3.0.1",
+        "d3-sankey": "^0.12.3",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "d3-tile": "^1.0.0",
+        "d3-time": "^3.1.0",
+        "memoize": "^10.2.0",
+        "runed": "^0.37.1"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/libretto": {
@@ -6028,6 +6550,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/macos-alias": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
@@ -6123,6 +6655,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
+      "integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6185,6 +6733,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -7525,6 +8086,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
@@ -7582,6 +8150,42 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/runed": {
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.37.1.tgz",
+      "integrity": "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "esm-env": "^1.0.0",
+        "lz-string": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.21.0",
+        "svelte": "^5.7.0",
+        "zod": "^4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sade": {
       "version": "1.8.1",
@@ -8150,6 +8754,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@sveltejs/kit": "^2.68.0",
     "@types/node": "^26.0.0",
     "electron": "^43.0.0",
+    "layerchart": "^2.0.0",
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",
     "typescript": "^5.9.0",

--- a/src/app.css
+++ b/src/app.css
@@ -644,26 +644,24 @@ a {
 
 .sparkline {
   width: 100%;
-  height: auto;
+  height: 220px;
   display: block;
   margin-bottom: var(--space-4);
 }
 
-.sparkline-grid {
-  fill: none;
+.sparkline .lc-layout-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.sparkline-grid line,
+.sparkline-grid path {
   stroke: var(--border);
-  stroke-width: 1;
 }
 
-.sparkline-axis-line,
-.sparkline-tick path {
-  fill: none;
-  stroke: var(--muted);
-  stroke-width: 1.5;
-}
-
-.sparkline-tick text {
-  fill: var(--muted);
+.sparkline-axis {
+  color: var(--muted);
   font-size: 11px;
   font-weight: 700;
 }
@@ -686,43 +684,32 @@ a {
   stroke-width: 3;
 }
 
-.sparkline-point {
-  outline: none;
-}
-
-.sparkline-point-hit {
-  fill: transparent;
-  pointer-events: all;
-}
-
-.sparkline-point:hover .sparkline-dot {
-  r: 7;
-}
-
-.sparkline-tooltip rect {
-  fill: var(--fg);
-  opacity: 0.92;
-}
-
 .sparkline-tooltip {
   pointer-events: none;
 }
 
-.sparkline-tooltip text {
-  fill: white;
+.sparkline-tooltip-body {
+  display: grid;
+  gap: 2px;
+  min-width: 132px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--fg) 92%, transparent);
+  color: white;
   font-size: 12px;
   font-weight: 800;
 }
 
-.sparkline-axis {
-  fill: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
-  text-transform: uppercase;
+.sparkline-tooltip-body strong {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
 }
 
 .sparkline-empty {
-  fill: var(--muted);
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
   font-size: 14px;
   font-weight: 700;
 }

--- a/src/lib/overview/components/SnapshotSparkline.svelte
+++ b/src/lib/overview/components/SnapshotSparkline.svelte
@@ -1,127 +1,71 @@
 <script lang="ts">
+  import { AreaChart, Tooltip } from "layerchart";
   import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
   import { formatMoney } from "$lib/shared-money/money.ts";
-  import { buildSparklineYAxis, formatSparklineTick } from "./sparkline-format.ts";
+  import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
 
-  type SparklinePoint = {
-    date: string;
-    value: number;
-    x: number;
-    y: number;
-  };
   type HistoryAmountKey = "netAssets" | "assets" | "liabilities";
 
   export let rows: DailyHistoryRowDto[] = [];
   export let currency = "TWD";
   export let amountKey: HistoryAmountKey = "netAssets";
   export let label = "Net position";
-  let activePoint: SparklinePoint | null = null;
-  let points: SparklinePoint[] = [];
 
-  const width = 720;
-  const height = 220;
-  const left = 54;
-  const right = 704;
-  const top = 36;
-  const bottom = 166;
+  $: points = buildSnapshotChartPoints(rows, currency, amountKey);
+  $: ariaLabel = `${label} trend ${currency}`;
 
-  $: items = rows
-    .map((row) => {
-      const amount = row[amountKey].find((item) => item.currency === currency);
-      return amount ? { date: row.date, value: amount.value } : null;
-    })
-    .filter((item): item is { date: string; value: number } => item !== null);
-  $: values = items.map((item) => item.value);
-  $: yAxis = buildSparklineYAxis(values);
-  $: points = items.map((item, index) => {
-    const x = values.length === 1 ? (left + right) / 2 : left + (index / (values.length - 1)) * (right - left);
-    const y = bottom - ((item.value - yAxis.min) / (yAxis.max - yAxis.min)) * (bottom - top);
-    return { ...item, x, y };
-  });
-  $: linePath = points.map((point, index) => `${index === 0 ? "M" : "L"}${point.x} ${point.y}`).join("");
-  $: areaPath =
-    points.length > 1
-      ? `${linePath}L${points[points.length - 1].x} ${bottom}L${points[0].x} ${bottom}Z`
-      : "";
-  $: gridPath = [`M${left} ${top}H${right}`, `M${left} ${(top + bottom) / 2}H${right}`, `M${left} ${bottom}H${right}`].join("");
-  $: yTicks = yAxis.ticks.map((value) => ({
-    value,
-    y: bottom - ((value - yAxis.min) / (yAxis.max - yAxis.min)) * (bottom - top),
-  }));
-  $: xTicks =
-    points.length <= 3
-      ? points
-      : [points[0], points[Math.floor((points.length - 1) / 2)], points[points.length - 1]];
-
-  function shortDate(value: string) {
-    return value.slice(5);
+  function shortDate(value: unknown) {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) return monthDay(value);
+    if (typeof value === "number") {
+      const date = new Date(value);
+      if (!Number.isNaN(date.getTime())) return monthDay(date);
+    }
+    const text = String(value);
+    return text.length >= 10 ? text.slice(5, 10) : text;
   }
 
-  function tooltipX(point: { x: number }) {
-    return Math.min(Math.max(point.x + 12, left), right - 150);
+  function monthDay(value: Date) {
+    const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(value.getUTCDate()).padStart(2, "0");
+    return `${month}-${day}`;
   }
 
-  function tooltipY(point: { y: number }) {
-    return Math.max(top, point.y - 62);
-  }
-
-  function pointLabel(point: { date: string; value: number }) {
-    return `Date: ${point.date}; ${label}: ${formatMoney({ currency, value: point.value })}`;
-  }
 </script>
 
-<svg class="sparkline" viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`${label} trend ${currency}`}>
-  <text class="sparkline-axis" x="16" y={(top + bottom) / 2} text-anchor="middle" transform={`rotate(-90 16 ${(top + bottom) / 2})`}>
-    {currency}
-  </text>
-  <text class="sparkline-axis" x={(left + right) / 2} y="204" text-anchor="middle">Date</text>
-  <path class="sparkline-axis-line" d={`M${left} ${top}V${bottom}H${right}`} />
-  {#each yTicks as tick}
-    <g class="sparkline-tick">
-      <path d={`M${left - 6} ${tick.y}H${left}`} />
-      <text data-sensitive x={left - 10} y={tick.y + 4} text-anchor="end">{formatSparklineTick(tick.value, yAxis.step)}</text>
-    </g>
-  {/each}
-  {#each xTicks as tick}
-    <g class="sparkline-tick">
-      <path d={`M${tick.x} ${bottom}V${bottom + 6}`} />
-      <text x={tick.x} y={bottom + 22} text-anchor="middle">{shortDate(tick.date)}</text>
-    </g>
-  {/each}
-  <path class="sparkline-grid" d={gridPath} />
-  {#if points.length > 1}
-    <path class="sparkline-area" d={areaPath} />
-    <path class="sparkline-line" d={linePath} />
-    {#each points as point}
-      <g
-        class="sparkline-point"
-        role="img"
-        aria-label={pointLabel(point)}
-        on:pointerenter={() => (activePoint = point)}
-        on:pointerleave={() => (activePoint = null)}
-      >
-        <circle class="sparkline-point-hit" cx={point.x} cy={point.y} r="14" />
-        <circle class="sparkline-dot" cx={point.x} cy={point.y} r="5" />
-      </g>
-    {/each}
-  {:else if points.length === 1}
-    <g
-      class="sparkline-point"
-      role="img"
-      aria-label={pointLabel(points[0])}
-      on:pointerenter={() => (activePoint = points[0])}
-      on:pointerleave={() => (activePoint = null)}
+{#if points.length > 0}
+  <div class="sparkline" role="img" aria-label={ariaLabel}>
+    <AreaChart
+      data={points}
+      x="date"
+      y="value"
+      yNice
+      axis={true}
+      grid={{ y: true }}
+      points={points.length === 1 ? { r: 5, class: "sparkline-dot" } : false}
+      height={220}
+      props={{
+        area: { class: "sparkline-area" },
+        line: { class: "sparkline-line" },
+        xAxis: { class: "sparkline-axis", format: shortDate },
+        yAxis: { class: "sparkline-axis", tickLabelProps: { "data-sensitive": "" } },
+        grid: { class: "sparkline-grid" },
+        highlight: { points: { r: 5, class: "sparkline-dot" } },
+      }}
     >
-      <circle class="sparkline-dot" cx={points[0].x} cy={points[0].y} r="6" />
-    </g>
-  {:else}
-    <text class="sparkline-empty" x="360" y="116" text-anchor="middle">No {currency} history</text>
-  {/if}
-  {#if activePoint}
-    <g class="sparkline-tooltip" transform={`translate(${tooltipX(activePoint)} ${tooltipY(activePoint)})`}>
-      <rect width="150" height="48" rx="8" />
-      <text x="10" y="19">{activePoint.date}</text>
-      <text x="10" y="36">{formatMoney({ currency, value: activePoint.value })}</text>
-    </g>
-  {/if}
-</svg>
+      {#snippet tooltip({ context })}
+        <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
+          {#snippet children({ data })}
+            <div class="sparkline-tooltip-body">
+              <span>{data.dateLabel}</span>
+              <strong data-sensitive>{formatMoney({ currency, value: data.value })}</strong>
+            </div>
+          {/snippet}
+        </Tooltip.Root>
+      {/snippet}
+    </AreaChart>
+  </div>
+{:else}
+  <div class="sparkline sparkline-empty" role="img" aria-label={ariaLabel}>
+    No {currency} history
+  </div>
+{/if}

--- a/src/lib/overview/components/snapshot-chart-data.check.ts
+++ b/src/lib/overview/components/snapshot-chart-data.check.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
+import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+const rows: DailyHistoryRowDto[] = [
+  {
+    date: "2026-07-02",
+    netAssets: [{ currency: "TWD", value: 120 }],
+    assets: [{ currency: "TWD", value: 160 }],
+    liabilities: [{ currency: "TWD", value: 40 }],
+    dailyChange: [{ currency: "TWD", value: -10 }],
+    accountChanges: [],
+    positionCount: 0,
+  },
+  {
+    date: "2026-07-01",
+    netAssets: [
+      { currency: "TWD", value: 100 },
+      { currency: "USD", value: 3 },
+    ],
+    assets: [{ currency: "TWD", value: 150 }],
+    liabilities: [{ currency: "TWD", value: 50 }],
+    dailyChange: [{ currency: "TWD", value: 5 }],
+    accountChanges: [],
+    positionCount: 0,
+  },
+  {
+    date: "2026-07-03",
+    netAssets: [{ currency: "USD", value: 4 }],
+    assets: [{ currency: "USD", value: 4 }],
+    liabilities: [],
+    dailyChange: [{ currency: "USD", value: 1 }],
+    accountChanges: [],
+    positionCount: 0,
+  },
+];
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "netAssets"), [
+  { date: new Date("2026-07-01T00:00:00.000Z"), dateLabel: "2026-07-01", value: 100 },
+  { date: new Date("2026-07-02T00:00:00.000Z"), dateLabel: "2026-07-02", value: 120 },
+]);
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "dailyChange"), [
+  { date: new Date("2026-07-01T00:00:00.000Z"), dateLabel: "2026-07-01", value: 5 },
+  { date: new Date("2026-07-02T00:00:00.000Z"), dateLabel: "2026-07-02", value: -10 },
+]);
+
+assert.deepEqual(buildSnapshotChartPoints(rows, "JPY", "netAssets"), []);

--- a/src/lib/overview/components/snapshot-chart-data.ts
+++ b/src/lib/overview/components/snapshot-chart-data.ts
@@ -1,0 +1,29 @@
+import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+type HistoryAmountKey = "netAssets" | "assets" | "liabilities" | "dailyChange";
+
+export type SnapshotChartPoint = {
+  date: Date;
+  dateLabel: string;
+  value: number;
+};
+
+export function buildSnapshotChartPoints(
+  rows: DailyHistoryRowDto[],
+  currency: string,
+  amountKey: HistoryAmountKey,
+): SnapshotChartPoint[] {
+  return rows
+    .map((row) => {
+      const amount = row[amountKey].find((item) => item.currency === currency);
+      return amount
+        ? {
+            date: new Date(`${row.date}T00:00:00.000Z`),
+            dateLabel: row.date,
+            value: amount.value,
+          }
+        : null;
+    })
+    .filter((item): item is SnapshotChartPoint => item !== null)
+    .sort((left, right) => left.dateLabel.localeCompare(right.dateLabel));
+}


### PR DESCRIPTION
## Summary
- Add LayerChart and a tested snapshot chart data mapper
- Replace custom SnapshotSparkline SVG internals with LayerChart
- Preserve chart privacy behavior for hidden values

## Test Plan
- npm run typecheck
- node --no-warnings --experimental-strip-types src/lib/overview/components/snapshot-chart-data.check.ts
- git diff --check 00523d93..HEAD

## Notes
- Plain Vite route rendering still cannot fully exercise dashboards because window.octopusBeak is supplied by Electron preload.