### PR TITLE
Add stacked balance allocation visuals across dashboards

### DIFF
--- a/docs/superpowers/plans/2026-07-02-stacked-balance-allocation.md
+++ b/docs/superpowers/plans/2026-07-02-stacked-balance-allocation.md
@@ -1,0 +1,525 @@
+# Stacked Balance Allocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single total balance line on Assets and Liabilities with LayerChart stacked area charts: `All Assets` / `All Debts` stack by account type, a selected type stacks by individual account, and the metric strip appears above the chart. Add a short transition when the chart data changes.
+
+**Architecture:** Keep account history aggregation in a pure TypeScript helper, bind the existing `AccountTable` category filter up to each dashboard, and render the derived series through a reusable `StackedBalanceChart.svelte` component. The dashboards own filter/currency state and pass chart-ready series into the component.
+
+**Tech Stack:** SvelteKit, Svelte 5, TypeScript, LayerChart `AreaChart` with `seriesLayout="stack"`, existing assert-based `*.check.ts` checks, Electron dev CDP for visual verification.
+
+---
+
+## Notes From Discovery
+
+- Current dashboard files are:
+  - `src/lib/assets/AssetsDashboard.svelte`
+  - `src/lib/liabilities/LiabilitiesDashboard.svelte`
+- Shared table filter is internal to `src/lib/shared-accounts/components/AccountTable.svelte`; expose it as a bindable prop.
+- Existing sparkline helpers are in:
+  - `src/lib/overview/components/SnapshotSparkline.svelte`
+  - `src/lib/overview/components/snapshot-chart-data.ts`
+  - `src/lib/overview/components/sparkline-format.ts`
+- `DailyHistoryRowDto` only contains aggregate `assets` / `liabilities`, so allocation/exposure must be derived from `dailyHistoryByAccount` plus account metadata.
+- Local LayerChart supports:
+  - `series: [{ key, label, color, data }]`
+  - `seriesLayout: "stack"`
+  - `legend={...}`
+  - `motion={{ type: "tween", duration: 180 }}`
+
+## Implementation Tasks
+
+- [ ] 1. Add a failing pure-data check for stacked balance series.
+
+  Create `src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts`.
+
+  Cover these cases:
+  - `filter === "all"` on assets returns one series per asset kind, in stable order: `bank`, `fund`, `brokerage`, `crypto`, `foreign`.
+  - `filter === "bank"` returns one series per bank account.
+  - liabilities use stable order: `credit-card`, `loan`, `crypto`, `other`.
+  - missing currency values are filled with `0` for aligned stack dates.
+  - zero-only series are omitted.
+  - liability values are positive exposure values, even if an upstream history row ever stores a negative debt number.
+
+  Use a tiny fixture, not production data:
+
+  ```ts
+  import assert from "node:assert/strict";
+  import type { AccountRowDto, DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+  import { buildStackedBalanceChartData } from "./stacked-balance-chart-data.ts";
+
+  const accounts = [
+    account("bank-a", "Bank A", "bank", 100),
+    account("bank-b", "Bank B", "bank", 200),
+    account("fund-a", "Fund A", "fund", 300),
+    account("card-a", "Card A", "credit-card", 400),
+    account("loan-a", "Loan A", "loan", 500),
+  ];
+
+  const dailyHistoryByAccount = {
+    "bank-a": [row("2026-06-24", 100, 0), row("2026-06-25", 110, 0)],
+    "bank-b": [row("2026-06-24", 200, 0), row("2026-06-25", 220, 0)],
+    "fund-a": [row("2026-06-24", 300, 0), row("2026-06-25", 330, 0)],
+    "card-a": [row("2026-06-24", 0, -400), row("2026-06-25", 0, -410)],
+    "loan-a": [row("2026-06-24", 0, 500), row("2026-06-25", 0, 520)],
+  } satisfies Record<string, DailyHistoryRowDto[]>;
+  ```
+
+  Expected first run:
+
+  ```bash
+  node --no-warnings --experimental-strip-types src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
+  ```
+
+  It should fail because `stacked-balance-chart-data.ts` does not exist yet.
+
+- [ ] 2. Implement the stacked balance data helper.
+
+  Add `src/lib/shared-accounts/components/stacked-balance-chart-data.ts`.
+
+  Public API:
+
+  ```ts
+  import type { AccountKind, AccountRowDto, DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+  export type BalanceChartMode = "asset" | "liability";
+  export type BalanceChartFilter = AccountKind | "all";
+
+  export type StackedBalancePoint = {
+    date: string;
+    dateLabel: string;
+    value: number;
+  };
+
+  export type StackedBalanceSeries = {
+    key: string;
+    label: string;
+    color: string;
+    data: StackedBalancePoint[];
+  };
+
+  export type StackedBalanceChartData = {
+    dates: string[];
+    series: StackedBalanceSeries[];
+    totals: StackedBalancePoint[];
+    signature: string;
+  };
+
+  export function buildStackedBalanceChartData(options: {
+    accounts: AccountRowDto[];
+    dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>;
+    filter: BalanceChartFilter;
+    currency: string;
+    mode: BalanceChartMode;
+    limit?: number;
+  }): StackedBalanceChartData;
+  ```
+
+  Implementation rules:
+  - Filter accounts by `mode` page input, then by `filter`.
+  - When `filter === "all"`, group by `account.kind`.
+  - When `filter !== "all"`, group by `account.id`.
+  - Use the union of dates from selected account histories, sort ascending, and keep the last `limit ?? 30`.
+  - For each group/date, sum the matching currency from `row.assets` or `row.liabilities`.
+  - For liabilities, use `Math.abs(value)` per account/date before summing.
+  - Drop a group when every point is effectively zero.
+  - Build `totals` by summing visible series per date; the chart y-axis uses these totals.
+  - Use a fixed multi-hue palette, not one shade family:
+
+    ```ts
+    const STACK_COLORS = [
+      "#2563eb",
+      "#059669",
+      "#d97706",
+      "#dc2626",
+      "#7c3aed",
+      "#0891b2",
+      "#be185d",
+      "#4b5563",
+    ];
+    ```
+
+  Run:
+
+  ```bash
+  node --no-warnings --experimental-strip-types src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
+  ```
+
+  Commit checkpoint:
+
+  ```bash
+  git add src/lib/shared-accounts/components/stacked-balance-chart-data.ts src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
+  git commit -m "Add stacked balance chart data helper"
+  ```
+
+- [ ] 3. Expose the existing account type filter from `AccountTable`.
+
+  Edit `src/lib/shared-accounts/components/AccountTable.svelte`.
+
+  Change:
+
+  ```ts
+  let filter: AccountKind | "all" = "all";
+  ```
+
+  To:
+
+  ```ts
+  export let filter: AccountKind | "all" = "all";
+  ```
+
+  Keep the existing reset behavior:
+
+  ```ts
+  $: if (!filters.some((item) => item.id === filter)) filter = "all";
+  ```
+
+  This allows the dashboard to drive the chart from the same type filter the table already uses.
+
+  Run:
+
+  ```bash
+  npm run typecheck
+  ```
+
+  Commit checkpoint:
+
+  ```bash
+  git add src/lib/shared-accounts/components/AccountTable.svelte
+  git commit -m "Expose account table filter"
+  ```
+
+- [ ] 4. Add the reusable stacked chart component.
+
+  Create `src/lib/shared-accounts/components/StackedBalanceChart.svelte`.
+
+  Core shape:
+
+  ```svelte
+  <script lang="ts">
+    import { fade } from "svelte/transition";
+    import { AreaChart, Tooltip } from "layerchart";
+    import { formatMoney } from "$lib/shared-money/money.ts";
+    import { buildSparklineYAxis, formatSparklineTick } from "$lib/overview/components/sparkline-format.ts";
+    import type { StackedBalanceChartData } from "./stacked-balance-chart-data.ts";
+
+    export let chart: StackedBalanceChartData = { dates: [], series: [], totals: [], signature: "" };
+    export let currency = "TWD";
+    export let label = "Balance";
+
+    $: xDomain = chart.dates;
+    $: yAxis = buildSparklineYAxis(chart.totals.map((point) => point.value));
+    $: yDomain = [yAxis.min, yAxis.max];
+    $: ariaLabel = `${label} ${currency}`;
+  </script>
+  ```
+
+  Render with LayerChart:
+
+  ```svelte
+  {#if chart.series.length > 0}
+    <div class="stacked-balance-chart" role="img" aria-label={ariaLabel}>
+      {#key chart.signature}
+        <div class="stacked-balance-stage" in:fade={{ duration: 150 }} out:fade={{ duration: 90 }}>
+          <AreaChart
+            data={chart.totals}
+            flatData={chart.totals}
+            x="date"
+            y="value"
+            series={chart.series}
+            seriesLayout="stack"
+            {xDomain}
+            {yDomain}
+            yBaseline={0}
+            yNice
+            axis={true}
+            grid={{ y: true }}
+            legend={{ placement: "bottom", variant: "swatches" }}
+            motion={{ type: "tween", duration: 180 }}
+            padding={{ top: 12, right: 14, bottom: 48, left: 56 }}
+            height={260}
+            props={{
+              area: { class: "stacked-balance-area" },
+              line: { class: "stacked-balance-line" },
+              xAxis: { class: "sparkline-axis", format: shortDate },
+              yAxis: {
+                class: "sparkline-axis",
+                format: shortAmount,
+                ticks: yAxis.ticks,
+                tickLabelProps: { "data-sensitive": "" },
+              },
+              grid: { class: "sparkline-grid" },
+              tooltip: {
+                item: {
+                  props: { value: { "data-sensitive": "" } },
+                },
+              },
+            }}
+          >
+            {#snippet tooltip({ context })}
+              <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
+                {#snippet children({ data })}
+                  <div class="sparkline-tooltip-body stacked-balance-tooltip">
+                    <span>{data?.dateLabel ?? data?.date ?? ""}</span>
+                    {#each context.tooltip.series.filter((item) => item.visible) as item}
+                      <div class="stacked-balance-tooltip-row">
+                        <span>{item.label}</span>
+                        <strong data-sensitive>{formatMoney({ currency, value: item.value ?? 0 })}</strong>
+                      </div>
+                    {/each}
+                  </div>
+                {/snippet}
+              </Tooltip.Root>
+            {/snippet}
+          </AreaChart>
+        </div>
+      {/key}
+    </div>
+  {:else}
+    <div class="stacked-balance-chart sparkline-empty" role="img" aria-label={ariaLabel}>
+      No {currency} history
+    </div>
+  {/if}
+  ```
+
+  Add local styles that keep dimensions stable and constrain legend wrapping:
+
+  ```css
+  .stacked-balance-chart {
+    min-height: 260px;
+  }
+
+  .stacked-balance-stage {
+    height: 260px;
+  }
+
+  :global(.stacked-balance-area) {
+    opacity: 0.36;
+  }
+
+  :global(.stacked-balance-line) {
+    stroke-width: 2;
+  }
+
+  .stacked-balance-tooltip {
+    min-width: 180px;
+  }
+
+  .stacked-balance-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  ```
+
+  Reuse `shortDate`, `monthDay`, and `shortAmount` logic from `SnapshotSparkline.svelte`.
+
+  Run:
+
+  ```bash
+  npm run typecheck
+  ```
+
+  Commit checkpoint:
+
+  ```bash
+  git add src/lib/shared-accounts/components/StackedBalanceChart.svelte
+  git commit -m "Add stacked balance chart component"
+  ```
+
+- [ ] 5. Wire the Assets dashboard.
+
+  Edit `src/lib/assets/AssetsDashboard.svelte`.
+
+  Imports:
+
+  ```ts
+  import StackedBalanceChart from "$lib/shared-accounts/components/StackedBalanceChart.svelte";
+  import {
+    buildStackedBalanceChartData,
+    type BalanceChartFilter,
+  } from "$lib/shared-accounts/components/stacked-balance-chart-data.ts";
+  ```
+
+  Remove the `SnapshotSparkline` import.
+
+  Add state:
+
+  ```ts
+  let accountFilter: BalanceChartFilter = "all";
+  ```
+
+  Replace chart data derivation:
+
+  ```ts
+  $: chartRows = [...assets.dailyHistory].sort((left, right) => left.date.localeCompare(right.date)).slice(-30);
+  $: chartData = buildStackedBalanceChartData({
+    accounts: assetAccounts,
+    dailyHistoryByAccount: assets.dailyHistoryByAccount,
+    filter: accountFilter,
+    currency: chartCurrency,
+    mode: "asset",
+  });
+  ```
+
+  Keep `chartRows` only for currency-option derivation.
+
+  Swap layout order so metrics come before the chart:
+
+  ```svelte
+  <section aria-label="Asset metrics">
+    <SummaryStrip {metrics} />
+  </section>
+
+  <section class="card balance-history" aria-label="Asset balance history">
+    ...
+    <div class="pad balance-chart">
+      <StackedBalanceChart chart={chartData} currency={chartCurrency} label="Asset allocation" />
+    </div>
+  </section>
+  ```
+
+  Bind the table filter:
+
+  ```svelte
+  <AccountTable
+    accounts={assetAccounts}
+    mode="asset"
+    bind:search
+    bind:filter={accountFilter}
+    ...
+  />
+  ```
+
+  Behavior to preserve:
+  - `All Assets` chart stacks by account type.
+  - `Bank` chart stacks by individual bank account.
+  - Search text still filters the table only; it should not unexpectedly reshape the chart.
+
+  Run:
+
+  ```bash
+  npm run typecheck
+  ```
+
+  Commit checkpoint:
+
+  ```bash
+  git add src/lib/assets/AssetsDashboard.svelte
+  git commit -m "Show asset allocation as stacked balance chart"
+  ```
+
+- [ ] 6. Wire the Liabilities dashboard.
+
+  Edit `src/lib/liabilities/LiabilitiesDashboard.svelte`.
+
+  Add the same imports and state:
+
+  ```ts
+  import StackedBalanceChart from "$lib/shared-accounts/components/StackedBalanceChart.svelte";
+  import {
+    buildStackedBalanceChartData,
+    type BalanceChartFilter,
+  } from "$lib/shared-accounts/components/stacked-balance-chart-data.ts";
+
+  let accountFilter: BalanceChartFilter = "all";
+  ```
+
+  Build debt exposure chart data:
+
+  ```ts
+  $: chartData = buildStackedBalanceChartData({
+    accounts: liabilityAccounts,
+    dailyHistoryByAccount: liabilities.dailyHistoryByAccount,
+    filter: accountFilter,
+    currency: chartCurrency,
+    mode: "liability",
+  });
+  ```
+
+  Swap metrics above the chart and replace `SnapshotSparkline`:
+
+  ```svelte
+  <StackedBalanceChart chart={chartData} currency={chartCurrency} label="Debt exposure" />
+  ```
+
+  Bind the table filter:
+
+  ```svelte
+  bind:filter={accountFilter}
+  ```
+
+  Behavior to preserve:
+  - `All Debts` chart stacks by debt type.
+  - `Credit Card` / `Loan` charts stack by individual account in that type.
+  - Liability exposure displays as positive values.
+
+  Run:
+
+  ```bash
+  npm run typecheck
+  ```
+
+  Commit checkpoint:
+
+  ```bash
+  git add src/lib/liabilities/LiabilitiesDashboard.svelte
+  git commit -m "Show debt exposure as stacked balance chart"
+  ```
+
+- [ ] 7. Verify with local checks, production builds, and CDP.
+
+  Run static checks:
+
+  ```bash
+  node --no-warnings --experimental-strip-types src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
+  npm run typecheck
+  npm run build:renderer
+  npm run build:electron
+  git diff --check
+  ```
+
+  With the user-provided `npm run desktop:dev` already running, use the printed remote debugging port or default `9222`.
+
+  First confirm CDP endpoint:
+
+  ```bash
+  curl http://127.0.0.1:9222/json/version
+  ```
+
+  CDP visual/DOM checks:
+  - Navigate to Assets.
+  - Confirm the metric strip appears before the balance chart in DOM order and visually.
+  - Confirm `All Assets` renders multiple `path.lc-area-path` elements.
+  - Click `Bank`; confirm the number of area paths changes to the number of visible bank account series and the chart fades/animates without layout jump.
+  - Confirm y-axis values and tooltip values have `data-sensitive`.
+  - Navigate to Liabilities and repeat for `All Debts`, `Credit Card`, and `Loan`.
+  - Capture screenshots at desktop width and a narrow width; check legend wrapping does not overlap the plot or table.
+
+  Suggested CDP assertions from page context:
+
+  ```js
+  ({
+    areaPathCount: document.querySelectorAll("path.lc-area-path").length,
+    metricsBeforeChart:
+      document.querySelector('[aria-label="Asset metrics"]')?.compareDocumentPosition(
+        document.querySelector('[aria-label="Asset balance history"]')
+      ) === Node.DOCUMENT_POSITION_FOLLOWING,
+    sensitiveTicks: document.querySelectorAll(".sparkline-axis [data-sensitive]").length,
+  })
+  ```
+
+  Final commit checkpoint if any verification fixes were needed:
+
+  ```bash
+  git status --short
+  git add src/lib/shared-accounts/components src/lib/assets/AssetsDashboard.svelte src/lib/liabilities/LiabilitiesDashboard.svelte
+  git commit -m "Verify stacked balance charts"
+  ```
+
+## Risks And Decisions
+
+- The chart follows the account type filter, not search text. This keeps search as a table affordance and avoids chart data changing while typing.
+- Legend length is bounded by the user's chosen granularity: all view uses account types; type view uses accounts only within that type.
+- Same-series updates use LayerChart `motion`; changes that replace the series set use a short keyed fade to avoid broken morphs between unrelated series.
+- Values remain compatible with hidden-value mode by marking y-axis ticks and tooltip values with `data-sensitive`.

--- a/src/app.css
+++ b/src/app.css
@@ -714,43 +714,6 @@ a {
   font-weight: 700;
 }
 
-.bars {
-  display: grid;
-  gap: var(--space-5);
-}
-
-.bar-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-2);
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.bar-track {
-  height: 10px;
-  border-radius: 999px;
-  background: var(--surface-soft);
-  overflow: hidden;
-}
-
-.bar-fill {
-  height: 100%;
-  border-radius: inherit;
-  background: var(--fg);
-}
-
-.bar-fill.accent {
-  background: var(--accent);
-}
-
-.bar-fill.domain {
-  background: var(--success);
-}
-
 .modal {
   position: fixed;
   inset: 0;

--- a/src/lib/assets/AssetsDashboard.svelte
+++ b/src/lib/assets/AssetsDashboard.svelte
@@ -8,14 +8,19 @@
     SummaryMetricDto,
   } from "$lib/shared-ledger/types.ts";
   import { currencyCount, formatAmountLines } from "$lib/shared-money/money.ts";
+  import StackedBalanceChart from "$lib/shared-accounts/components/StackedBalanceChart.svelte";
+  import {
+    buildStackedBalanceChartData,
+    type BalanceChartFilter,
+  } from "$lib/shared-accounts/components/stacked-balance-chart-data.ts";
   import SummaryStrip from "$lib/shared-metrics/components/SummaryStrip.svelte";
   import DashboardShell from "$lib/shared-shell/components/DashboardShell.svelte";
-  import SnapshotSparkline from "$lib/overview/components/SnapshotSparkline.svelte";
 
   export let assets: AssetsPageDto;
 
   let search = "";
   let chartCurrency = "TWD";
+  let accountFilter: BalanceChartFilter = "all";
 
   const assetBreakdown: Array<{ kind: AccountKind; label: string }> = [
     { kind: "bank", label: "Bank" },
@@ -35,6 +40,13 @@
     ...new Set(chartRows.flatMap((row) => row.assets.map((amount) => amount.currency))),
   ].sort((left, right) => currencyOrder(left) - currencyOrder(right) || left.localeCompare(right));
   $: if (!chartCurrencies.includes(chartCurrency)) chartCurrency = chartCurrencies[0] ?? "TWD";
+  $: chartData = buildStackedBalanceChartData({
+    accounts: assetAccounts,
+    dailyHistoryByAccount: assets.dailyHistoryByAccount,
+    filter: accountFilter,
+    currency: chartCurrency,
+    mode: "asset",
+  });
 
   function buildMetrics(accounts: AccountRowDto[]): SummaryMetricDto[] {
     const largest = largestAccount(accounts);
@@ -118,6 +130,10 @@
   bind:search
 >
   <div class="content">
+    <section aria-label="Asset metrics">
+      <SummaryStrip {metrics} />
+    </section>
+
     <section class="card balance-history" aria-label="Asset balance history">
       <div class="panel-title">
         <h2>Asset balance</h2>
@@ -139,18 +155,15 @@
         <span class="chip">30 days</span>
       </div>
       <div class="pad balance-chart">
-        <SnapshotSparkline rows={chartRows} currency={chartCurrency} amountKey="assets" label="Asset balance" />
+        <StackedBalanceChart chart={chartData} currency={chartCurrency} label="Asset allocation" />
       </div>
-    </section>
-
-    <section aria-label="Asset metrics">
-      <SummaryStrip {metrics} />
     </section>
 
     <AccountTable
       accounts={assetAccounts}
       mode="asset"
       bind:search
+      bind:filter={accountFilter}
       positionsByAccount={assets.positionsByAccount}
       transactionsByAccount={assets.transactionsByAccount}
       dailyHistoryByAccount={assets.dailyHistoryByAccount}

--- a/src/lib/liabilities/LiabilitiesDashboard.svelte
+++ b/src/lib/liabilities/LiabilitiesDashboard.svelte
@@ -7,14 +7,19 @@
     SummaryMetricDto,
   } from "$lib/shared-ledger/types.ts";
   import { currencyCount, formatAmountLines } from "$lib/shared-money/money.ts";
+  import StackedBalanceChart from "$lib/shared-accounts/components/StackedBalanceChart.svelte";
+  import {
+    buildStackedBalanceChartData,
+    type BalanceChartFilter,
+  } from "$lib/shared-accounts/components/stacked-balance-chart-data.ts";
   import SummaryStrip from "$lib/shared-metrics/components/SummaryStrip.svelte";
   import DashboardShell from "$lib/shared-shell/components/DashboardShell.svelte";
-  import SnapshotSparkline from "$lib/overview/components/SnapshotSparkline.svelte";
 
   export let liabilities: LiabilitiesPageDto;
 
   let search = "";
   let chartCurrency = "TWD";
+  let accountFilter: BalanceChartFilter = "all";
 
   $: liabilityAccounts = liabilities.accounts;
   $: metrics = buildMetrics(liabilityAccounts);
@@ -26,6 +31,13 @@
     ...new Set(chartRows.flatMap((row) => row.liabilities.map((amount) => amount.currency))),
   ].sort((left, right) => currencyOrder(left) - currencyOrder(right) || left.localeCompare(right));
   $: if (!chartCurrencies.includes(chartCurrency)) chartCurrency = chartCurrencies[0] ?? "TWD";
+  $: chartData = buildStackedBalanceChartData({
+    accounts: liabilityAccounts,
+    dailyHistoryByAccount: liabilities.dailyHistoryByAccount,
+    filter: accountFilter,
+    currency: chartCurrency,
+    mode: "liability",
+  });
 
   function buildMetrics(accounts: AccountRowDto[]): SummaryMetricDto[] {
     const largest = largestAccount(accounts);
@@ -114,6 +126,10 @@
   bind:search
 >
   <div class="content">
+    <section aria-label="Liability metrics">
+      <SummaryStrip {metrics} />
+    </section>
+
     <section class="card balance-history" aria-label="Debt balance history">
       <div class="panel-title">
         <h2>Debt balance</h2>
@@ -135,18 +151,15 @@
         <span class="chip">30 days</span>
       </div>
       <div class="pad balance-chart">
-        <SnapshotSparkline rows={chartRows} currency={chartCurrency} amountKey="liabilities" label="Debt balance" />
+        <StackedBalanceChart chart={chartData} currency={chartCurrency} label="Debt exposure" />
       </div>
-    </section>
-
-    <section aria-label="Liability metrics">
-      <SummaryStrip {metrics} />
     </section>
 
     <AccountTable
       accounts={liabilityAccounts}
       mode="liability"
       bind:search
+      bind:filter={accountFilter}
       transactionsByAccount={liabilities.transactionsByAccount}
       dailyHistoryByAccount={liabilities.dailyHistoryByAccount}
     />

--- a/src/lib/overview/OverviewDashboard.svelte
+++ b/src/lib/overview/OverviewDashboard.svelte
@@ -1,23 +1,16 @@
 <script lang="ts">
+  import AllocationDonutCard from "$lib/overview/components/AllocationDonutCard.svelte";
   import DailyHistoryTable from "$lib/overview/components/DailyHistoryTable.svelte";
   import SnapshotSparkline from "$lib/overview/components/SnapshotSparkline.svelte";
   import type { OverviewPageDto } from "$lib/overview/types.ts";
-  import type { AccountKind, AccountRowDto } from "$lib/shared-ledger/types.ts";
   import DashboardShell from "$lib/shared-shell/components/DashboardShell.svelte";
   import SummaryStrip from "$lib/shared-metrics/components/SummaryStrip.svelte";
-  import { amountValue, formatAmountLines, formatMoney } from "$lib/shared-money/money.ts";
+  import { formatAmountLines, formatMoney } from "$lib/shared-money/money.ts";
 
   export let overview: OverviewPageDto;
 
   let snapshotCurrency = "TWD";
   let dailyCurrency = "TWD";
-
-  const allocationOrder: Array<{ kind: AccountKind; label: string; className: string }> = [
-    { kind: "brokerage", label: "Brokerage", className: "accent" },
-    { kind: "fund", label: "Fund", className: "domain" },
-    { kind: "bank", label: "Bank", className: "" },
-    { kind: "foreign", label: "Foreign", className: "" },
-  ];
 
   $: metrics = overview.summary.slice(0, 3);
   $: netMetric = metrics.find((metric) => metric.label === "Net position") ?? metrics[0] ?? null;
@@ -27,25 +20,8 @@
     netAmounts.slice(1).map((amount) => formatMoney(amount)).join(" / ") ||
     `Imported ${formatImportedAt(overview.importedAt)}`;
   $: sideSubSensitive = netAmounts.length > 1;
-  $: assetAccounts = overview.accounts.filter((account) => account.group !== "liability");
-  $: allocation = buildAllocation(assetAccounts);
   $: history = overview.dailyHistory;
   $: snapshotHistory = [...history].sort((left, right) => left.date.localeCompare(right.date)).slice(-30);
-
-  function buildAllocation(accounts: AccountRowDto[]) {
-    const total = accounts.reduce((sum, account) => sum + amountValue(account.amountLines), 0);
-    return allocationOrder
-      .map((item) => {
-        const value = accounts
-          .filter((account) => account.kind === item.kind)
-          .reduce((sum, account) => sum + amountValue(account.amountLines), 0);
-        return {
-          ...item,
-          percent: total > 0 ? Math.round((value / total) * 1000) / 10 : 0,
-        };
-      })
-      .filter((item) => item.percent > 0);
-  }
 
   function formatImportedAt(value: string | null) {
     return value?.slice(0, 16).replace("T", " ") ?? "not yet";
@@ -91,33 +67,17 @@
           <span class="chip">30 days</span>
         </div>
         <div class="card pad">
-          <SnapshotSparkline rows={snapshotHistory} currency={snapshotCurrency} />
+          <SnapshotSparkline rows={snapshotHistory} currency={snapshotCurrency} label="Snapshot history" diverging />
           {#key snapshotCurrency}
             <DailyHistoryTable rows={snapshotHistory} compact netLabel="Net position" currency={snapshotCurrency} />
           {/key}
         </div>
       </article>
 
-      <article class="card">
-        <div class="panel-title">
-          <h2>Asset allocation</h2>
-        </div>
-        <div class="card pad bars">
-          {#each allocation as item}
-            <div>
-              <div class="bar-head">
-                <span>{item.label}</span>
-                <span class="money">{item.percent.toFixed(1)}%</span>
-              </div>
-              <div class="bar-track">
-                <div class={`bar-fill ${item.className}`} style={`width:${item.percent}%`}></div>
-              </div>
-            </div>
-          {:else}
-            <p class="lead">No asset allocation data yet.</p>
-          {/each}
-        </div>
-      </article>
+      <div class="overview-allocation-stack">
+        <AllocationDonutCard title="Asset allocation" accounts={overview.accounts} mode="asset" />
+        <AllocationDonutCard title="Liability exposure" accounts={overview.accounts} mode="liability" />
+      </div>
     </section>
 
     <section class="card daily-card">
@@ -144,3 +104,11 @@
     </section>
   </div>
 </DashboardShell>
+
+<style>
+  .overview-allocation-stack {
+    min-width: 0;
+    display: grid;
+    gap: var(--space-4);
+  }
+</style>

--- a/src/lib/overview/components/AllocationDonutCard.svelte
+++ b/src/lib/overview/components/AllocationDonutCard.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  import { PieChart } from "layerchart";
+  import { cubicInOut } from "svelte/easing";
+  import type { AccountRowDto } from "$lib/shared-ledger/types.ts";
+  import { formatMoney } from "$lib/shared-money/money.ts";
+  import {
+    buildAllocationDonutData,
+    getAllocationCurrencies,
+    type AllocationDonutMode,
+  } from "./allocation-donut-data.ts";
+
+  export let accounts: AccountRowDto[] = [];
+  export let mode: AllocationDonutMode = "asset";
+  export let title = "Allocation";
+
+  let currency = "TWD";
+
+  $: currencies = getAllocationCurrencies(accounts, mode);
+  $: if (currencies.length > 0 && !currencies.includes(currency)) currency = currencies[0];
+  $: chart = buildAllocationDonutData(accounts, mode, currency);
+  $: selectId = `allocation-${mode}-currency`;
+
+  function selectValue(event: Event) {
+    return (event.currentTarget as HTMLSelectElement).value;
+  }
+</script>
+
+<article class="card allocation-card">
+  <div class="panel-title">
+    <h2>{title}</h2>
+    {#if currencies.length > 1}
+      <label class="chip select-chip" for={selectId}>
+        <select
+          id={selectId}
+          aria-label={`${title} currency`}
+          bind:value={currency}
+          onchange={(event) => (currency = selectValue(event))}
+          oninput={(event) => (currency = selectValue(event))}
+        >
+          {#each currencies as item}
+            <option>{item}</option>
+          {/each}
+        </select>
+      </label>
+    {:else}
+      <span class="chip">{currency}</span>
+    {/if}
+  </div>
+
+  <div class="allocation-panel">
+    {#if chart.items.length > 0}
+      <div class="allocation-content">
+        <div class="allocation-donut-stage" aria-label={`${title} ${currency}`}>
+          {#key chart.currency}
+            <PieChart
+              data={chart.items}
+              key="key"
+              label="label"
+              value="value"
+              c="key"
+              innerRadius={0.62}
+              outerRadius={88}
+              cornerRadius={4}
+              padAngle={0.018}
+              legend={false}
+              tooltipContext={false}
+              props={{ pie: { motion: { type: "tween", duration: 800, easing: cubicInOut } } }}
+              height={212}
+              padding={{ top: 6, right: 6, bottom: 6, left: 6 }}
+            />
+          {/key}
+          <div class="allocation-donut-center" aria-hidden="true">
+            <span>Total</span>
+            <strong class="allocation-donut-total" data-sensitive>
+              {formatMoney({ currency: chart.currency, value: chart.total })}
+            </strong>
+          </div>
+        </div>
+
+        <div class="allocation-legend" aria-label={`${title} breakdown`}>
+          {#each chart.items as item}
+            <div class="allocation-legend-item">
+              <span class="allocation-swatch" style:background-color={item.color}></span>
+              <span class="allocation-label">{item.label}</span>
+              <span class="allocation-percent money">{item.percent.toFixed(1)}%</span>
+              <span class="allocation-amount money" data-sensitive>
+                {formatMoney({ currency: chart.currency, value: item.value })}
+              </span>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {:else}
+      <div class="allocation-empty">No {currency} data yet.</div>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .allocation-card {
+    min-width: 0;
+  }
+
+  .allocation-panel {
+    min-height: 280px;
+    padding: var(--space-5);
+  }
+
+  .allocation-content {
+    display: grid;
+    grid-template-columns: minmax(176px, 212px) minmax(0, 1fr);
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .allocation-donut-stage {
+    position: relative;
+    min-width: 0;
+    height: 212px;
+  }
+
+  .allocation-donut-center {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-content: center;
+    gap: 2px;
+    text-align: center;
+    pointer-events: none;
+  }
+
+  .allocation-donut-center span {
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 760;
+    letter-spacing: 0.075em;
+    text-transform: uppercase;
+  }
+
+  .allocation-donut-total {
+    max-width: 132px;
+    color: var(--fg);
+    font-size: 16px;
+    font-weight: 780;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+  }
+
+  .allocation-legend {
+    min-width: 0;
+    display: grid;
+    gap: 12px;
+  }
+
+  .allocation-legend-item {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: 10px minmax(0, 1fr) auto;
+    gap: 6px 8px;
+    align-items: center;
+  }
+
+  .allocation-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+  }
+
+  .allocation-label {
+    min-width: 0;
+    color: var(--fg);
+    font-size: 13px;
+    font-weight: 700;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .allocation-percent {
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .allocation-amount {
+    grid-column: 2 / 4;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.2;
+  }
+
+  .allocation-empty {
+    min-height: 240px;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  @media (max-width: 980px) {
+    .allocation-content {
+      grid-template-columns: 1fr;
+    }
+
+    .allocation-donut-stage {
+      height: 200px;
+    }
+  }
+</style>

--- a/src/lib/overview/components/SnapshotSparkline.svelte
+++ b/src/lib/overview/components/SnapshotSparkline.svelte
@@ -2,8 +2,15 @@
   import { AreaChart, Tooltip } from "layerchart";
   import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
   import { formatMoney } from "$lib/shared-money/money.ts";
-  import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
-  import { buildSparklineYAxis, formatSparklineTick } from "./sparkline-format.ts";
+  import {
+    buildSnapshotChartPoints,
+    buildSnapshotDivergingSeries,
+    selectSnapshotDivergingSeries,
+    type SnapshotChartPoint,
+    type SnapshotDivergingSeries,
+    type SnapshotDivergingSeriesKey,
+  } from "./snapshot-chart-data.ts";
+  import { buildCenteredSparklineYAxis, buildSparklineYAxis, formatSparklineTick } from "./sparkline-format.ts";
 
   type HistoryAmountKey = "netAssets" | "assets" | "liabilities";
 
@@ -11,12 +18,36 @@
   export let currency = "TWD";
   export let amountKey: HistoryAmountKey = "netAssets";
   export let label = "Net position";
+  export let diverging = false;
+
+  let selectedSeriesKeys: SnapshotDivergingSeriesKey[] = [];
 
   $: points = buildSnapshotChartPoints(rows, currency, amountKey);
-  $: xDomain = points.map((point) => point.date);
-  $: yAxis = buildSparklineYAxis(points.map((point) => point.value));
+  $: divergingSeries = diverging ? buildSnapshotDivergingSeries(rows, currency) : [];
+  $: visibleDivergingSeries = selectSnapshotDivergingSeries(divergingSeries, selectedSeriesKeys);
+  $: selectedSeriesKeySet = new Set(selectedSeriesKeys);
+  $: chartPoints = diverging ? visibleDivergingSeries.flatMap((series) => series.data) : points;
+  $: xValues = [...new Set(chartPoints.map((point) => point.time))].sort((left, right) => left - right);
+  $: xDomain = xValues.length > 1 ? [xValues[0], xValues[xValues.length - 1]] : xValues;
+  $: timelinePoints = xValues.map((time) => timelinePoint(time, chartPoints));
+  $: yAxis = diverging
+    ? buildCenteredSparklineYAxis(chartPoints.map((point) => point.value))
+    : buildSparklineYAxis(chartPoints.map((point) => point.value));
   $: yDomain = [yAxis.min, yAxis.max];
   $: ariaLabel = `${label} trend ${currency}`;
+  $: hasChartData = diverging ? divergingSeries.length > 0 : points.length > 0;
+
+  function toggleSeries(key: SnapshotDivergingSeriesKey) {
+    if (selectedSeriesKeys.length === 0) {
+      selectedSeriesKeys = [key];
+      return;
+    }
+    if (selectedSeriesKeySet.has(key)) {
+      selectedSeriesKeys = selectedSeriesKeys.filter((item) => item !== key);
+      return;
+    }
+    selectedSeriesKeys = [...selectedSeriesKeys, key];
+  }
 
   function shortDate(value: unknown) {
     if (value instanceof Date && !Number.isNaN(value.getTime())) return monthDay(value);
@@ -37,51 +68,216 @@
   function shortAmount(value: unknown) {
     return typeof value === "number" ? formatSparklineTick(value, yAxis.step) : String(value);
   }
+
+  function tooltipValue(series: SnapshotDivergingSeries, data: { time?: unknown } | null | undefined) {
+    if (typeof data?.time !== "number") return 0;
+    return series.data.find((point) => point.time === data.time)?.value ?? 0;
+  }
+
+  function timelinePoint(time: number, data: SnapshotChartPoint[]): SnapshotChartPoint {
+    const existing = data.find((point) => point.time === time);
+    if (existing) return existing;
+    const date = new Date(time).toISOString().slice(0, 10);
+    return { date, dateLabel: date, time, value: 0 };
+  }
 </script>
 
-{#if points.length > 0}
-  <div class="sparkline" role="img" aria-label={ariaLabel}>
-    <AreaChart
-      data={points}
-      x="date"
-      y="value"
-      {xDomain}
-      {yDomain}
-      yBaseline={null}
-      yNice
-      axis={true}
-      grid={{ y: true }}
-      padding={{ top: 12, right: 12, bottom: 24, left: 48 }}
-      points={points.length === 1 ? { r: 5, class: "sparkline-dot" } : false}
-      height={220}
-      props={{
-        area: { class: "sparkline-area" },
-        line: { class: "sparkline-line" },
-        xAxis: { class: "sparkline-axis", format: shortDate },
-        yAxis: {
-          class: "sparkline-axis",
-          format: shortAmount,
-          ticks: yAxis.ticks,
-          tickLabelProps: { "data-sensitive": "" },
-        },
-        grid: { class: "sparkline-grid" },
-        highlight: { points: { r: 5, class: "sparkline-dot" } },
-      }}
-    >
-      {#snippet tooltip({ context })}
-        <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
-          {#snippet children({ data })}
-            <div class="sparkline-tooltip-body">
-              <span>{data.dateLabel}</span>
-              <strong data-sensitive>{formatMoney({ currency, value: data.value })}</strong>
-            </div>
+{#if hasChartData}
+  {#if diverging}
+    <div class="sparkline sparkline-diverging" role="img" aria-label={ariaLabel}>
+      <div class="snapshot-diverging-stage">
+        <AreaChart
+          data={timelinePoints}
+          flatData={timelinePoints}
+          x="time"
+          y="value"
+          series={visibleDivergingSeries}
+          seriesLayout="overlap"
+          {xDomain}
+          {yDomain}
+          yBaseline={null}
+          yNice={false}
+          axis={true}
+          grid={{ y: true }}
+          legend={false}
+          tooltipContext={{ mode: "bisect-x", findTooltipData: "closest" }}
+          motion={{ type: "tween", duration: 180 }}
+          padding={{ top: 12, right: 12, bottom: 24, left: 56 }}
+          points={false}
+          height={220}
+          props={{
+            area: { class: "snapshot-diverging-area" },
+            line: { class: "snapshot-diverging-line" },
+            xAxis: { class: "sparkline-axis", format: shortDate, ticks: xValues },
+            yAxis: {
+              class: "sparkline-axis",
+              format: shortAmount,
+              ticks: yAxis.ticks,
+              tickLabelProps: { "data-sensitive": "" },
+            },
+            grid: { class: "sparkline-grid" },
+          }}
+        >
+          {#snippet tooltip({ context })}
+            <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
+              {#snippet children({ data })}
+                <div class="sparkline-tooltip-body snapshot-diverging-tooltip">
+                  <span>{data?.dateLabel ?? data?.date ?? ""}</span>
+                  {#each visibleDivergingSeries as series}
+                    <div class="snapshot-diverging-tooltip-row">
+                      <span>{series.label}</span>
+                      <strong data-sensitive>{formatMoney({ currency, value: tooltipValue(series, data) })}</strong>
+                    </div>
+                  {/each}
+                </div>
+              {/snippet}
+            </Tooltip.Root>
           {/snippet}
-        </Tooltip.Root>
-      {/snippet}
-    </AreaChart>
-  </div>
+        </AreaChart>
+      </div>
+      <div class="snapshot-diverging-legend" aria-label={`${label} legend`}>
+        {#each divergingSeries as series}
+          <button
+            class:selected={selectedSeriesKeys.length === 0 || selectedSeriesKeySet.has(series.key)}
+            class="snapshot-diverging-legend-item"
+            type="button"
+            title={series.label}
+            aria-pressed={selectedSeriesKeys.length === 0 || selectedSeriesKeySet.has(series.key)}
+            on:click={() => toggleSeries(series.key)}
+          >
+            <span class="snapshot-diverging-legend-swatch" style:background-color={series.color}></span>
+            <span class="snapshot-diverging-legend-label">{series.label}</span>
+          </button>
+        {/each}
+      </div>
+    </div>
+  {:else}
+    <div class="sparkline" role="img" aria-label={ariaLabel}>
+      <AreaChart
+        data={points}
+        x="time"
+        y="value"
+        {xDomain}
+        {yDomain}
+        yBaseline={null}
+        yNice
+        axis={true}
+        grid={{ y: true }}
+        tooltipContext={{ mode: "bisect-x", findTooltipData: "closest" }}
+        padding={{ top: 12, right: 12, bottom: 24, left: 48 }}
+        points={points.length === 1 ? { r: 5, class: "sparkline-dot" } : false}
+        height={220}
+        props={{
+          area: { class: "sparkline-area" },
+          line: { class: "sparkline-line" },
+          xAxis: { class: "sparkline-axis", format: shortDate, ticks: xValues },
+          yAxis: {
+            class: "sparkline-axis",
+            format: shortAmount,
+            ticks: yAxis.ticks,
+            tickLabelProps: { "data-sensitive": "" },
+          },
+          grid: { class: "sparkline-grid" },
+          highlight: { points: { r: 5, class: "sparkline-dot" } },
+        }}
+      >
+        {#snippet tooltip({ context })}
+          <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
+            {#snippet children({ data })}
+              <div class="sparkline-tooltip-body">
+                <span>{data.dateLabel}</span>
+                <strong data-sensitive>{formatMoney({ currency, value: data.value })}</strong>
+              </div>
+            {/snippet}
+          </Tooltip.Root>
+        {/snippet}
+      </AreaChart>
+    </div>
+  {/if}
 {:else}
   <div class="sparkline sparkline-empty" role="img" aria-label={ariaLabel}>
     No {currency} history
   </div>
 {/if}
+
+<style>
+  .sparkline-diverging {
+    height: 260px;
+  }
+
+  .snapshot-diverging-stage {
+    height: 220px;
+  }
+
+  :global(.snapshot-diverging-area) {
+    fill-opacity: 0;
+    opacity: 0;
+  }
+
+  :global(.snapshot-diverging-line) {
+    fill: none;
+    stroke-width: 2.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .snapshot-diverging-tooltip {
+    min-width: 184px;
+  }
+
+  .snapshot-diverging-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .snapshot-diverging-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    justify-content: center;
+    max-width: 100%;
+    padding: 6px 24px 0;
+    overflow: hidden;
+  }
+
+  .snapshot-diverging-legend-item {
+    min-width: 0;
+    max-width: 160px;
+    min-height: 20px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    opacity: 0.38;
+  }
+
+  .snapshot-diverging-legend-item.selected {
+    opacity: 1;
+  }
+
+  .snapshot-diverging-legend-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .snapshot-diverging-legend-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    flex: 0 0 auto;
+  }
+
+  .snapshot-diverging-legend-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/overview/components/allocation-donut-data.check.ts
+++ b/src/lib/overview/components/allocation-donut-data.check.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import {
+  buildAllocationDonutData,
+  getAllocationCurrencies,
+} from "./allocation-donut-data.ts";
+import type { AccountRowDto } from "$lib/shared-ledger/types.ts";
+
+function account(
+  id: string,
+  group: AccountRowDto["group"],
+  kind: AccountRowDto["kind"],
+  amountLines: AccountRowDto["amountLines"],
+): AccountRowDto {
+  return {
+    id,
+    label: id,
+    institution: "",
+    product: "",
+    group,
+    kind,
+    typeLabel: kind,
+    amountLines,
+    transactionCount: 0,
+    assetPositionCount: 0,
+    lastUpdated: null,
+  };
+}
+
+const accounts: AccountRowDto[] = [
+  account("bank-twd", "asset", "bank", [{ currency: "TWD", value: 700 }]),
+  account("fund-twd", "investment", "fund", [
+    { currency: "TWD", value: 1_500 },
+    { currency: "USD", value: 10 },
+  ]),
+  account("card-twd", "liability", "credit-card", [{ currency: "TWD", value: -200 }]),
+  account("loan-twd", "liability", "loan", [{ currency: "TWD", value: 800 }]),
+  account("loan-jpy", "liability", "loan", [{ currency: "JPY", value: 1_000 }]),
+];
+
+assert.deepEqual(getAllocationCurrencies(accounts, "asset"), ["TWD", "USD"]);
+assert.deepEqual(getAllocationCurrencies(accounts, "liability"), ["TWD", "JPY"]);
+
+const assetTwd = buildAllocationDonutData(accounts, "asset");
+assert.equal(assetTwd.total, 2_200);
+assert.deepEqual(
+  assetTwd.items.map((item) => [item.key, item.label, item.value, item.percent]),
+  [
+    ["fund", "Fund", 1_500, 68.2],
+    ["bank", "Bank", 700, 31.8],
+  ],
+);
+
+const liabilityTwd = buildAllocationDonutData(accounts, "liability");
+assert.equal(liabilityTwd.total, 1_000);
+assert.deepEqual(
+  liabilityTwd.items.map((item) => [item.key, item.label, item.value, item.percent]),
+  [
+    ["loan", "Loan", 800, 80],
+    ["credit-card", "Credit Card", 200, 20],
+  ],
+);

--- a/src/lib/overview/components/allocation-donut-data.ts
+++ b/src/lib/overview/components/allocation-donut-data.ts
@@ -1,0 +1,88 @@
+import type { AccountKind, AccountRowDto } from "$lib/shared-ledger/types.ts";
+
+export type AllocationDonutMode = "asset" | "liability";
+
+export type AllocationDonutItem = {
+  key: AccountKind;
+  label: string;
+  value: number;
+  percent: number;
+  color: string;
+  props: { fill: string };
+};
+
+export type AllocationDonutData = {
+  currency: string;
+  total: number;
+  items: AllocationDonutItem[];
+};
+
+const EPSILON = 0.000001;
+const ASSET_KIND_ORDER: AccountKind[] = ["brokerage", "fund", "bank", "foreign", "crypto", "other"];
+const LIABILITY_KIND_ORDER: AccountKind[] = ["loan", "credit-card", "crypto", "other"];
+const CURRENCY_ORDER = ["TWD", "USD", "JPY"];
+
+const KIND_COLORS: Record<AccountKind, string> = {
+  brokerage: "oklch(49% 0.08 215)",
+  fund: "oklch(47% 0.07 160)",
+  bank: "oklch(48% 0.085 250)",
+  foreign: "oklch(48% 0.035 250)",
+  crypto: "oklch(50% 0.07 35)",
+  "credit-card": "oklch(50% 0.07 35)",
+  loan: "oklch(46% 0.055 250)",
+  other: "oklch(52% 0.045 285)",
+};
+
+export function getAllocationCurrencies(accounts: AccountRowDto[], mode: AllocationDonutMode) {
+  return [...new Set(accounts.filter((account) => isAccountInMode(account, mode)).flatMap((account) => account.amountLines.map((amount) => amount.currency)))]
+    .sort((left, right) => currencyRank(left) - currencyRank(right) || left.localeCompare(right));
+}
+
+export function buildAllocationDonutData(
+  accounts: AccountRowDto[],
+  mode: AllocationDonutMode,
+  currency = getAllocationCurrencies(accounts, mode)[0] ?? "TWD",
+): AllocationDonutData {
+  const order = mode === "liability" ? LIABILITY_KIND_ORDER : ASSET_KIND_ORDER;
+  const accountsInMode = accounts.filter((account) => isAccountInMode(account, mode));
+  const totalsByKind = new Map<AccountKind, number>();
+
+  for (const account of accountsInMode) {
+    const value = Math.abs(account.amountLines.find((amount) => amount.currency === currency)?.value ?? 0);
+    if (value > EPSILON) totalsByKind.set(account.kind, (totalsByKind.get(account.kind) ?? 0) + value);
+  }
+
+  const total = [...totalsByKind.values()].reduce((sum, value) => sum + value, 0);
+  const items = order
+    .map((kind) => ({ kind, value: totalsByKind.get(kind) ?? 0 }))
+    .filter((item) => item.value > EPSILON)
+    .map(({ kind, value }) => {
+      const color = KIND_COLORS[kind];
+      return {
+        key: kind,
+        label: labelForKind(kind),
+        value,
+        percent: total > EPSILON ? Math.round((value / total) * 1000) / 10 : 0,
+        color,
+        props: { fill: color },
+      };
+    });
+
+  return { currency, total, items };
+}
+
+function isAccountInMode(account: AccountRowDto, mode: AllocationDonutMode) {
+  return mode === "liability" ? account.group === "liability" : account.group !== "liability";
+}
+
+function currencyRank(currency: string) {
+  const index = CURRENCY_ORDER.indexOf(currency);
+  return index === -1 ? CURRENCY_ORDER.length : index;
+}
+
+function labelForKind(kind: AccountKind) {
+  return kind
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}

--- a/src/lib/overview/components/snapshot-chart-data.check.ts
+++ b/src/lib/overview/components/snapshot-chart-data.check.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { buildSnapshotChartPoints } from "./snapshot-chart-data.ts";
+import {
+  buildSnapshotChartPoints,
+  buildSnapshotDivergingSeries,
+  selectSnapshotDivergingSeries,
+} from "./snapshot-chart-data.ts";
 import type { DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
 
 const rows: DailyHistoryRowDto[] = [
@@ -36,13 +40,45 @@ const rows: DailyHistoryRowDto[] = [
 ];
 
 assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "netAssets"), [
-  { date: "2026-07-01", dateLabel: "2026-07-01", value: 100 },
-  { date: "2026-07-02", dateLabel: "2026-07-02", value: 120 },
+  { date: "2026-07-01", dateLabel: "2026-07-01", time: Date.parse("2026-07-01T00:00:00.000Z"), value: 100 },
+  { date: "2026-07-02", dateLabel: "2026-07-02", time: Date.parse("2026-07-02T00:00:00.000Z"), value: 120 },
 ]);
 
 assert.deepEqual(buildSnapshotChartPoints(rows, "TWD", "dailyChange"), [
-  { date: "2026-07-01", dateLabel: "2026-07-01", value: 5 },
-  { date: "2026-07-02", dateLabel: "2026-07-02", value: -10 },
+  { date: "2026-07-01", dateLabel: "2026-07-01", time: Date.parse("2026-07-01T00:00:00.000Z"), value: 5 },
+  { date: "2026-07-02", dateLabel: "2026-07-02", time: Date.parse("2026-07-02T00:00:00.000Z"), value: -10 },
 ]);
 
 assert.deepEqual(buildSnapshotChartPoints(rows, "JPY", "netAssets"), []);
+
+const divergingSeries = buildSnapshotDivergingSeries(rows, "TWD");
+
+assert.deepEqual(
+  divergingSeries.map((series) => series.key),
+  ["net", "assets", "liabilities"],
+);
+
+assert.deepEqual(divergingSeries[0].data, [
+  { date: "2026-07-01", dateLabel: "2026-07-01", time: Date.parse("2026-07-01T00:00:00.000Z"), value: 100 },
+  { date: "2026-07-02", dateLabel: "2026-07-02", time: Date.parse("2026-07-02T00:00:00.000Z"), value: 120 },
+]);
+
+assert.deepEqual(divergingSeries[1].data, [
+  { date: "2026-07-01", dateLabel: "2026-07-01", time: Date.parse("2026-07-01T00:00:00.000Z"), value: 150 },
+  { date: "2026-07-02", dateLabel: "2026-07-02", time: Date.parse("2026-07-02T00:00:00.000Z"), value: 160 },
+]);
+
+assert.deepEqual(divergingSeries[2].data, [
+  { date: "2026-07-01", dateLabel: "2026-07-01", time: Date.parse("2026-07-01T00:00:00.000Z"), value: -50 },
+  { date: "2026-07-02", dateLabel: "2026-07-02", time: Date.parse("2026-07-02T00:00:00.000Z"), value: -40 },
+]);
+
+assert.deepEqual(
+  selectSnapshotDivergingSeries(divergingSeries, ["assets", "liabilities"]).map((series) => series.key),
+  ["assets", "liabilities"],
+);
+
+assert.deepEqual(
+  selectSnapshotDivergingSeries(divergingSeries, []).map((series) => series.key),
+  ["net", "assets", "liabilities"],
+);

--- a/src/lib/overview/components/snapshot-chart-data.ts
+++ b/src/lib/overview/components/snapshot-chart-data.ts
@@ -5,8 +5,30 @@ type HistoryAmountKey = "netAssets" | "assets" | "liabilities" | "dailyChange";
 export type SnapshotChartPoint = {
   date: string;
   dateLabel: string;
+  time: number;
   value: number;
 };
+
+export type SnapshotDivergingSeriesKey = "net" | "assets" | "liabilities";
+
+export type SnapshotDivergingSeries = {
+  key: SnapshotDivergingSeriesKey;
+  label: string;
+  color: string;
+  data: SnapshotChartPoint[];
+};
+
+const DIVERGING_SERIES: Array<{
+  key: SnapshotDivergingSeriesKey;
+  label: string;
+  amountKey: HistoryAmountKey;
+  color: string;
+  sign: 1 | -1;
+}> = [
+  { key: "net", label: "Net", amountKey: "netAssets", color: "oklch(49% 0.08 250)", sign: 1 },
+  { key: "assets", label: "Assets", amountKey: "assets", color: "oklch(51% 0.07 170)", sign: 1 },
+  { key: "liabilities", label: "Liabilities", amountKey: "liabilities", color: "oklch(50% 0.07 35)", sign: -1 },
+];
 
 export function buildSnapshotChartPoints(
   rows: DailyHistoryRowDto[],
@@ -20,10 +42,36 @@ export function buildSnapshotChartPoints(
         ? {
             date: row.date,
             dateLabel: row.date,
+            time: Date.parse(`${row.date}T00:00:00.000Z`),
             value: amount.value,
           }
         : null;
     })
     .filter((item): item is SnapshotChartPoint => item !== null)
     .sort((left, right) => left.dateLabel.localeCompare(right.dateLabel));
+}
+
+export function buildSnapshotDivergingSeries(
+  rows: DailyHistoryRowDto[],
+  currency: string,
+): SnapshotDivergingSeries[] {
+  return DIVERGING_SERIES.map((series) => ({
+    key: series.key,
+    label: series.label,
+    color: series.color,
+    data: buildSnapshotChartPoints(rows, currency, series.amountKey).map((point) => {
+      const value = series.sign === -1 ? -Math.abs(point.value) : point.value;
+      return { ...point, value };
+    }),
+  })).filter((series) => series.data.length > 0);
+}
+
+export function selectSnapshotDivergingSeries(
+  series: SnapshotDivergingSeries[],
+  selectedKeys: SnapshotDivergingSeriesKey[],
+) {
+  if (selectedKeys.length === 0) return series;
+  const selected = new Set(selectedKeys);
+  const visible = series.filter((item) => selected.has(item.key));
+  return visible.length > 0 ? visible : series;
 }

--- a/src/lib/overview/components/sparkline-format.check.ts
+++ b/src/lib/overview/components/sparkline-format.check.ts
@@ -1,19 +1,16 @@
 import assert from "node:assert/strict";
-import { buildSparklineYAxis, formatSparklineTick } from "./sparkline-format.ts";
+import { buildCenteredSparklineYAxis } from "./sparkline-format.ts";
 
-assert.deepEqual(
-  [2_641_397, 2_436_574, 2_231_751].map((value) => formatSparklineTick(value)),
-  ["2.6M", "2.4M", "2.2M"],
-);
+assert.deepEqual(buildCenteredSparklineYAxis([120, 160, -50]), {
+  min: -240,
+  max: 240,
+  step: 120,
+  ticks: [240, 120, 0, -120, -240],
+});
 
-const debtAxis = buildSparklineYAxis([1_554_043, 1_568_164]);
-
-assert.deepEqual(debtAxis.ticks.map((tick) => formatSparklineTick(tick, debtAxis.step)), [
-  "1.575M",
-  "1.568M",
-  "1.561M",
-  "1.554M",
-  "1.547M",
-]);
-assert.equal(debtAxis.min, 1_546_982.5);
-assert.equal(debtAxis.max, 1_575_224.5);
+assert.deepEqual(buildCenteredSparklineYAxis([0]), {
+  min: -2,
+  max: 2,
+  step: 1,
+  ticks: [2, 1, 0, -1, -2],
+});

--- a/src/lib/overview/components/sparkline-format.ts
+++ b/src/lib/overview/components/sparkline-format.ts
@@ -24,6 +24,22 @@ export function buildSparklineYAxis(values: number[]) {
   };
 }
 
+export function buildCenteredSparklineYAxis(values: number[]) {
+  const finiteValues = values.filter(Number.isFinite);
+  if (finiteValues.length === 0) return { min: 0, max: 0, step: 0, ticks: [] };
+
+  const rawMax = Math.max(...finiteValues.map((value) => Math.abs(value)));
+  const max = rawMax === 0 ? 2 : rawMax * 1.5;
+  const step = max / 2;
+
+  return {
+    min: -max,
+    max,
+    step,
+    ticks: [max, step, 0, -step, -max],
+  };
+}
+
 export function formatSparklineTick(value: number, step = 0) {
   return new Intl.NumberFormat("en-US", {
     maximumFractionDigits: compactFractionDigits(value, step),

--- a/src/lib/shared-accounts/components/AccountTable.svelte
+++ b/src/lib/shared-accounts/components/AccountTable.svelte
@@ -26,7 +26,7 @@
   export let search = "";
   export let mode: "asset" | "liability" = "asset";
 
-  let filter: AccountKind | "all" = "all";
+  export let filter: AccountKind | "all" = "all";
   let selectedAccountId: string | null = null;
   let transactionsOpen = false;
   let positionsOpen = false;

--- a/src/lib/shared-accounts/components/StackedBalanceChart.svelte
+++ b/src/lib/shared-accounts/components/StackedBalanceChart.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import { AreaChart, Tooltip } from "layerchart";
+  import { buildSparklineYAxis, formatSparklineTick } from "$lib/overview/components/sparkline-format.ts";
+  import { formatMoney } from "$lib/shared-money/money.ts";
+  import {
+    selectStackedBalanceChartSeries,
+    type StackedBalanceChartData,
+  } from "./stacked-balance-chart-data.ts";
+
+  export let chart: StackedBalanceChartData = { dates: [], series: [], totals: [], signature: "" };
+  export let currency = "TWD";
+  export let label = "Balance";
+
+  let selectedSeriesKeys: string[] = [];
+  let lastSignature = "";
+
+  $: if (chart.signature !== lastSignature) {
+    selectedSeriesKeys = [];
+    lastSignature = chart.signature;
+  }
+  $: visibleChart = selectStackedBalanceChartSeries(chart, selectedSeriesKeys);
+  $: selectedKeySet = new Set(selectedSeriesKeys);
+  $: xValues = visibleChart.totals.map((point) => point.time);
+  $: xDomain = xValues.length > 1 ? [xValues[0], xValues[xValues.length - 1]] : xValues;
+  $: yAxis = buildSparklineYAxis([0, ...visibleChart.totals.map((point) => point.value)]);
+  $: yDomain = [0, yAxis.max];
+  $: yTicks = yAxis.ticks.filter((tick) => tick >= 0);
+  $: ariaLabel = `${label} ${currency}`;
+
+  function toggleSeries(key: string) {
+    if (selectedSeriesKeys.length === 0) {
+      selectedSeriesKeys = [key];
+      return;
+    }
+    if (selectedKeySet.has(key)) {
+      selectedSeriesKeys = selectedSeriesKeys.filter((item) => item !== key);
+      return;
+    }
+    selectedSeriesKeys = [...selectedSeriesKeys, key];
+  }
+
+  function shortDate(value: unknown) {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) return monthDay(value);
+    if (typeof value === "number") {
+      const date = new Date(value);
+      if (!Number.isNaN(date.getTime())) return monthDay(date);
+    }
+    const text = String(value);
+    return text.length >= 10 ? text.slice(5, 10) : text;
+  }
+
+  function monthDay(value: Date) {
+    const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(value.getUTCDate()).padStart(2, "0");
+    return `${month}-${day}`;
+  }
+
+  function shortAmount(value: unknown) {
+    return typeof value === "number" ? formatSparklineTick(value, yAxis.step) : String(value);
+  }
+
+  function tooltipValue(series: StackedBalanceChartData["series"][number], data: { time?: unknown } | null | undefined) {
+    if (typeof data?.time !== "number") return 0;
+    return series.data.find((point) => point.time === data.time)?.value ?? 0;
+  }
+</script>
+
+{#if chart.series.length > 0}
+  <div class="stacked-balance-chart" role="img" aria-label={ariaLabel}>
+    <div class="stacked-balance-stage">
+      <AreaChart
+        data={visibleChart.totals}
+        flatData={visibleChart.totals}
+        x="time"
+        y="value"
+        series={visibleChart.series}
+        seriesLayout="stack"
+        {xDomain}
+        {yDomain}
+        yBaseline={0}
+        yNice={false}
+        axis={true}
+        grid={{ y: true }}
+        legend={false}
+        tooltipContext={{ mode: "bisect-x", findTooltipData: "closest" }}
+        motion={{ type: "tween", duration: 180 }}
+        padding={{ top: 12, right: 14, bottom: 28, left: 56 }}
+        height={260}
+        props={{
+          area: { class: "stacked-balance-area" },
+          line: { class: "stacked-balance-line" },
+          xAxis: { class: "sparkline-axis", format: shortDate, ticks: xValues },
+          yAxis: {
+            class: "sparkline-axis",
+            format: shortAmount,
+            ticks: yTicks,
+            tickLabelProps: { "data-sensitive": "" },
+          },
+          grid: { class: "sparkline-grid" },
+        }}
+      >
+        {#snippet tooltip({ context })}
+          <Tooltip.Root {context} class="sparkline-tooltip" variant="none" portal={false}>
+            {#snippet children({ data })}
+              <div class="sparkline-tooltip-body stacked-balance-tooltip">
+                <span>{data?.dateLabel ?? data?.date ?? ""}</span>
+                {#each visibleChart.series as item}
+                  <div class="stacked-balance-tooltip-row">
+                    <span>{item.label}</span>
+                    <strong data-sensitive>{formatMoney({ currency, value: tooltipValue(item, data) })}</strong>
+                  </div>
+                {/each}
+              </div>
+            {/snippet}
+          </Tooltip.Root>
+        {/snippet}
+      </AreaChart>
+    </div>
+    <div class="stacked-balance-legend" aria-label={`${label} legend`}>
+      {#each chart.series as series}
+        <button
+          class:selected={selectedSeriesKeys.length === 0 || selectedKeySet.has(series.key)}
+          class="stacked-balance-legend-item"
+          type="button"
+          title={series.label}
+          aria-pressed={selectedSeriesKeys.length === 0 || selectedKeySet.has(series.key)}
+          on:click={() => toggleSeries(series.key)}
+        >
+          <span class="stacked-balance-legend-swatch" style:background-color={series.color}></span>
+          <span class="stacked-balance-legend-label">{series.label}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+{:else}
+  <div class="stacked-balance-chart sparkline-empty" role="img" aria-label={ariaLabel}>
+    No {currency} history
+  </div>
+{/if}
+
+<style>
+  .stacked-balance-chart {
+    min-height: 260px;
+  }
+
+  .stacked-balance-stage {
+    height: 260px;
+  }
+
+  .stacked-balance-tooltip {
+    min-width: 180px;
+  }
+
+  .stacked-balance-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  :global(.stacked-balance-area) {
+    opacity: 0.34;
+  }
+
+  :global(.stacked-balance-line) {
+    stroke-width: 2;
+  }
+
+  .stacked-balance-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    justify-content: center;
+    max-width: 100%;
+    padding: 6px 24px 0;
+    overflow: hidden;
+  }
+
+  .stacked-balance-legend-item {
+    min-width: 0;
+    max-width: 180px;
+    min-height: 20px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-size: 11px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    opacity: 0.38;
+  }
+
+  .stacked-balance-legend-item.selected {
+    opacity: 1;
+  }
+
+  .stacked-balance-legend-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .stacked-balance-legend-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    flex: 0 0 auto;
+  }
+
+  .stacked-balance-legend-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
+++ b/src/lib/shared-accounts/components/stacked-balance-chart-data.check.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import type {
+  AccountKind,
+  AccountRowDto,
+  DailyHistoryRowDto,
+} from "$lib/shared-ledger/types.ts";
+import {
+  buildStackedBalanceChartData,
+  selectStackedBalanceChartSeries,
+} from "./stacked-balance-chart-data.ts";
+
+const accounts = [
+  account("bank-a", "Bank A", "bank", 100),
+  account("bank-b", "Bank B", "bank", 200),
+  account("fund-a", "Fund A", "fund", 300),
+  account("empty-brokerage", "Empty Brokerage", "brokerage", 0),
+  account("card-a", "Card A", "credit-card", 400),
+  account("loan-a", "Loan A", "loan", 500),
+];
+
+const dailyHistoryByAccount = {
+  "bank-a": [row("2026-06-24", 100, 0), row("2026-06-25", 110, 0)],
+  "bank-b": [row("2026-06-24", 200, 0), row("2026-06-25", 220, 0)],
+  "fund-a": [row("2026-06-24", 300, 0), row("2026-06-25", 330, 0)],
+  "empty-brokerage": [row("2026-06-24", 0, 0), row("2026-06-25", 0, 0)],
+  "card-a": [row("2026-06-24", 0, -400), row("2026-06-25", 0, -410)],
+  "loan-a": [row("2026-06-24", 0, 500), row("2026-06-25", 0, 520)],
+} satisfies Record<string, DailyHistoryRowDto[]>;
+
+const allAssets = buildStackedBalanceChartData({
+  accounts,
+  dailyHistoryByAccount,
+  filter: "all",
+  currency: "TWD",
+  mode: "asset",
+});
+assert.deepEqual(allAssets.series.map((series) => series.key), ["bank", "fund"]);
+assert.deepEqual(allAssets.dates, ["2026-06-24", "2026-06-25"]);
+assert.equal(allAssets.totals[0].time, Date.parse("2026-06-24T00:00:00.000Z"));
+assert.deepEqual(allAssets.series[0].data.map((point) => point.value), [300, 330]);
+assert.deepEqual(allAssets.totals.map((point) => point.value), [600, 660]);
+
+const fundOnly = selectStackedBalanceChartSeries(allAssets, ["fund"]);
+assert.deepEqual(fundOnly.series.map((series) => series.key), ["fund"]);
+assert.deepEqual(fundOnly.totals.map((point) => point.value), [300, 330]);
+
+const allSelected = selectStackedBalanceChartSeries(allAssets, []);
+assert.deepEqual(allSelected.series.map((series) => series.key), ["bank", "fund"]);
+assert.deepEqual(allSelected.totals.map((point) => point.value), [600, 660]);
+
+const bankAssets = buildStackedBalanceChartData({
+  accounts,
+  dailyHistoryByAccount,
+  filter: "bank",
+  currency: "TWD",
+  mode: "asset",
+});
+assert.deepEqual(bankAssets.series.map((series) => series.label), ["Bank A", "Bank B"]);
+assert.deepEqual(bankAssets.series[1].data.map((point) => point.value), [200, 220]);
+
+const usdAssets = buildStackedBalanceChartData({
+  accounts,
+  dailyHistoryByAccount,
+  filter: "all",
+  currency: "USD",
+  mode: "asset",
+});
+assert.deepEqual(usdAssets.series, []);
+assert.deepEqual(usdAssets.totals.map((point) => point.value), [0, 0]);
+
+const allLiabilities = buildStackedBalanceChartData({
+  accounts,
+  dailyHistoryByAccount,
+  filter: "all",
+  currency: "TWD",
+  mode: "liability",
+});
+assert.deepEqual(allLiabilities.series.map((series) => series.key), ["credit-card", "loan"]);
+assert.deepEqual(allLiabilities.series[0].data.map((point) => point.value), [400, 410]);
+assert.deepEqual(allLiabilities.totals.map((point) => point.value), [900, 930]);
+
+function account(id: string, label: string, kind: AccountKind, value: number): AccountRowDto {
+  const group =
+    kind === "credit-card" || kind === "loan" || kind === "other"
+      ? "liability"
+      : kind === "fund" || kind === "brokerage" || kind === "crypto"
+        ? "investment"
+        : "asset";
+  return {
+    id,
+    label,
+    institution: label,
+    product: label,
+    group,
+    kind,
+    typeLabel: kind,
+    amountLines: [{ currency: "TWD", value }],
+    transactionCount: 0,
+    assetPositionCount: 0,
+    lastUpdated: null,
+  };
+}
+
+function row(date: string, assets: number, liabilities: number): DailyHistoryRowDto {
+  return {
+    date,
+    netAssets: [{ currency: "TWD", value: assets - Math.abs(liabilities) }],
+    dailyChange: [{ currency: "TWD", value: 0 }],
+    assets: [{ currency: "TWD", value: assets }],
+    liabilities: [{ currency: "TWD", value: liabilities }],
+    accountChanges: [],
+    positionCount: 0,
+  };
+}

--- a/src/lib/shared-accounts/components/stacked-balance-chart-data.ts
+++ b/src/lib/shared-accounts/components/stacked-balance-chart-data.ts
@@ -1,0 +1,159 @@
+import type { AccountKind, AccountRowDto, DailyHistoryRowDto } from "$lib/shared-ledger/types.ts";
+
+export type BalanceChartMode = "asset" | "liability";
+export type BalanceChartFilter = AccountKind | "all";
+
+export type StackedBalancePoint = {
+  date: string;
+  dateLabel: string;
+  time: number;
+  value: number;
+};
+
+export type StackedBalanceSeries = {
+  key: string;
+  label: string;
+  color: string;
+  data: StackedBalancePoint[];
+};
+
+export type StackedBalanceChartData = {
+  dates: string[];
+  series: StackedBalanceSeries[];
+  totals: StackedBalancePoint[];
+  signature: string;
+};
+
+const STACK_COLORS = [
+  "oklch(52% 0.11 250)",
+  "oklch(52% 0.09 170)",
+  "oklch(56% 0.1 70)",
+  "oklch(53% 0.08 320)",
+  "oklch(50% 0.07 35)",
+  "oklch(49% 0.06 215)",
+  "oklch(50% 0.05 285)",
+  "oklch(46% 0.035 250)",
+];
+const ASSET_KIND_ORDER: AccountKind[] = ["bank", "fund", "brokerage", "crypto", "foreign"];
+const LIABILITY_KIND_ORDER: AccountKind[] = ["credit-card", "loan", "crypto", "other"];
+const EPSILON = 0.000001;
+
+export function buildStackedBalanceChartData(options: {
+  accounts: AccountRowDto[];
+  dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>;
+  filter: BalanceChartFilter;
+  currency: string;
+  mode: BalanceChartMode;
+  limit?: number;
+}): StackedBalanceChartData {
+  const limit = options.limit ?? 30;
+  const accounts = options.accounts.filter(
+    (account) =>
+      isAccountInMode(account, options.mode) &&
+      (options.filter === "all" || account.kind === options.filter),
+  );
+  const dates = collectDates(accounts, options.dailyHistoryByAccount).slice(-limit);
+  const groups = options.filter === "all"
+    ? groupByKind(accounts, options.mode)
+    : accounts.map((account) => ({ key: account.id, label: account.label, accounts: [account] }));
+  const series = groups
+    .map((group, index) => {
+      const data = dates.map((date) => ({
+        date,
+        dateLabel: date,
+        time: dateTime(date),
+        value: sumForDate(group.accounts, options.dailyHistoryByAccount, date, options.currency, options.mode),
+      }));
+      return {
+        key: group.key,
+        label: group.label,
+        color: STACK_COLORS[index % STACK_COLORS.length],
+        data,
+      };
+    })
+    .filter((item) => item.data.some((point) => Math.abs(point.value) > EPSILON));
+  const totals = dates.map((date, index) => ({
+    date,
+    dateLabel: date,
+    time: dateTime(date),
+    value: series.reduce((sum, item) => sum + (item.data[index]?.value ?? 0), 0),
+  }));
+
+  return {
+    dates,
+    series,
+    totals,
+    signature: `${options.mode}:${options.filter}:${options.currency}:${series.map((item) => item.key).join("|")}:${dates.join("|")}`,
+  };
+}
+
+export function selectStackedBalanceChartSeries(
+  chart: StackedBalanceChartData,
+  selectedKeys: string[],
+): StackedBalanceChartData {
+  const selected = new Set(selectedKeys);
+  const series = selected.size === 0
+    ? chart.series
+    : chart.series.filter((item) => selected.has(item.key));
+  const visibleSeries = series.length > 0 ? series : chart.series;
+  const totals = chart.totals.map((point, index) => ({
+    ...point,
+    value: visibleSeries.reduce((sum, item) => sum + (item.data[index]?.value ?? 0), 0),
+  }));
+
+  return {
+    ...chart,
+    series: visibleSeries,
+    totals,
+    signature: `${chart.signature}:selected:${visibleSeries.map((item) => item.key).join("|")}`,
+  };
+}
+
+function collectDates(
+  accounts: AccountRowDto[],
+  dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>,
+) {
+  return [
+    ...new Set(accounts.flatMap((account) => (dailyHistoryByAccount[account.id] ?? []).map((row) => row.date))),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+function groupByKind(accounts: AccountRowDto[], mode: BalanceChartMode) {
+  const order = mode === "asset" ? ASSET_KIND_ORDER : LIABILITY_KIND_ORDER;
+  return order
+    .map((kind) => ({
+      key: kind,
+      label: labelForKind(kind),
+      accounts: accounts.filter((account) => account.kind === kind),
+    }))
+    .filter((group) => group.accounts.length > 0);
+}
+
+function labelForKind(kind: AccountKind) {
+  return kind
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function dateTime(date: string) {
+  return Date.parse(`${date}T00:00:00.000Z`);
+}
+
+function isAccountInMode(account: AccountRowDto, mode: BalanceChartMode) {
+  return mode === "liability" ? account.group === "liability" : account.group !== "liability";
+}
+
+function sumForDate(
+  accounts: AccountRowDto[],
+  dailyHistoryByAccount: Record<string, DailyHistoryRowDto[]>,
+  date: string,
+  currency: string,
+  mode: BalanceChartMode,
+) {
+  return accounts.reduce((sum, account) => {
+    const row = (dailyHistoryByAccount[account.id] ?? []).find((item) => item.date === date);
+    const value = row?.[mode === "asset" ? "assets" : "liabilities"].find((amount) => amount.currency === currency)?.value ?? 0;
+    return sum + (mode === "liability" ? Math.abs(value) : value);
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- Introduce stacked balance allocation charts and shared data helpers for account balances.
- Update overview, assets, and liabilities dashboards to use the new allocation and sparkline components.
- Refine related styling for the new dashboard layout and chart presentation.

## Testing
- Not run (not requested).