### PR TITLE
Filter Maicoin positions to latest sub-account capture

### DIFF
--- a/src/lib/shared-ledger/server/accounts.check.ts
+++ b/src/lib/shared-ledger/server/accounts.check.ts
@@ -6,6 +6,7 @@ import {
   emptyLedgerQueryData,
   type LedgerQueryData,
 } from "./accounts.ts";
+import { buildDailyHistoryByAccount } from "../../overview/server/daily-history.ts";
 
 type ForeignCurrencyTransaction = LedgerQueryData["foreignCurrencyTransactions"][number];
 type CreditCardStatementLine = LedgerQueryData["creditCardStatementLines"][number];
@@ -344,11 +345,16 @@ latestMaicoinData.maicoinAccountSnapshots = [
     priceAt: "2026-06-28T12:00:00.000Z",
   },
 ];
+const latestMaicoinAccounts = buildAccountOverview(latestMaicoinData)
+  .filter((row) => row.kind === "crypto" && row.group === "investment");
+const inactiveMaicoinAccount = latestMaicoinAccounts.find((row) => row.product === "M-wallet");
+assert.ok(inactiveMaicoinAccount);
+assert.deepEqual(inactiveMaicoinAccount.amountLines, [{ currency: "TWD", value: 0 }]);
+assert.equal(inactiveMaicoinAccount.lastUpdated, "2026-06-28");
 assert.deepEqual(
-  buildAccountOverview(latestMaicoinData)
-    .filter((row) => row.kind === "crypto" && row.group === "investment")
-    .map((row) => row.product),
-  ["Spot wallet"],
+  buildDailyHistoryByAccount(latestMaicoinData)[inactiveMaicoinAccount.id]
+    ?.map((row) => [row.date, row.assets[0]?.value]),
+  [["2026-06-27", 200], ["2026-06-28", 0]],
 );
 
 const maicoinHistoricalTradeData = emptyLedgerQueryData();

--- a/src/lib/shared-ledger/server/accounts.check.ts
+++ b/src/lib/shared-ledger/server/accounts.check.ts
@@ -334,6 +334,23 @@ const maicoinPosition = buildPositionsByAccount(maicoinData)[maicoinAsset.id]?.[
 assert.equal(maicoinPosition?.metricLabel, "Return");
 assert.equal(maicoinPosition?.change, "100.00%");
 
+const latestMaicoinData = emptyLedgerQueryData();
+latestMaicoinData.maicoinAccountSnapshots = [
+  maicoinSnapshot(),
+  {
+    ...maicoinSpotSnapshot(),
+    capturedAt: "2026-06-28T12:00:00.000Z",
+    createdAt: "2026-06-28T12:00:00.000Z",
+    priceAt: "2026-06-28T12:00:00.000Z",
+  },
+];
+assert.deepEqual(
+  buildAccountOverview(latestMaicoinData)
+    .filter((row) => row.kind === "crypto" && row.group === "investment")
+    .map((row) => row.product),
+  ["Spot wallet"],
+);
+
 const maicoinHistoricalTradeData = emptyLedgerQueryData();
 maicoinHistoricalTradeData.maicoinAccountSnapshots = [
   {

--- a/src/lib/shared-ledger/server/accounts.ts
+++ b/src/lib/shared-ledger/server/accounts.ts
@@ -443,6 +443,7 @@ function maicoinPositions(
   statementRows: MaicoinStatementRow[],
 ): RawPosition[] {
   // ponytail: desktop captures all MAX wallet types together; load sync-run coverage if partial captures need display support.
+  const walletKey = (row: MaicoinAccountSnapshot) => [row.subAccount, row.walletType].join("|");
   const latestCaptureBySubAccount = new Map(
     latestBy(rows, (row) => row.subAccount, (row) => row.capturedAt)
       .map((row) => [row.subAccount, row.capturedAt]),
@@ -455,8 +456,14 @@ function maicoinPositions(
     (row) => ["maicoin", row.subAccount, row.walletType, currency(row.currency)].join("|"),
     (row) => row.capturedAt,
   );
+  const activeAssetWallets = new Set(latestRows.filter((row) => row.totalQuantity > 0).map(walletKey));
+  const inactiveAssetRows = latestBy(
+    rows.filter((row) => row.totalQuantity > 0),
+    walletKey,
+    (row) => row.capturedAt,
+  ).filter((row) => !activeAssetWallets.has(walletKey(row)));
   const returns = maicoinReturnComponents(latestRows, statementRows);
-  return latestRows.flatMap((row) => {
+  const positions = latestRows.flatMap((row) => {
     const product = row.walletType === "m" ? "M-wallet" : "Spot wallet";
     const currencyCode = currency(row.currency);
     const returnComponents = returns.get(currencyCode) ?? [];
@@ -539,6 +546,26 @@ function maicoinPositions(
     }
     return positions;
   });
+  const inactiveAssets: RawPosition[] = inactiveAssetRows.map((row) => {
+    const product = row.walletType === "m" ? "M-wallet" : "Spot wallet";
+    const capturedAt = latestCaptureBySubAccount.get(row.subAccount) ?? row.capturedAt;
+    return {
+      id: stableId("maicoin-asset-zero", row.subAccount, row.walletType),
+      accountId: accountId("maicoin-asset", "maicoin", product, row.subAccount, "TWD"),
+      label: `MAX ${product}`,
+      institution: "MaiCoin MAX",
+      product,
+      group: "investment",
+      kind: "crypto",
+      typeLabel: "Crypto",
+      currency: "TWD",
+      value: 0,
+      asOfDate: capturedAt.slice(0, 10),
+      importedAt: capturedAt,
+      positionDetail: null,
+    };
+  });
+  return [...positions, ...inactiveAssets];
 }
 
 function maicoinDebtQuantity(row: MaicoinAccountSnapshot) {

--- a/src/lib/shared-ledger/server/accounts.ts
+++ b/src/lib/shared-ledger/server/accounts.ts
@@ -442,8 +442,16 @@ function maicoinPositions(
   rows: MaicoinAccountSnapshot[],
   statementRows: MaicoinStatementRow[],
 ): RawPosition[] {
+  // ponytail: desktop captures all MAX wallet types together; load sync-run coverage if partial captures need display support.
+  const latestCaptureBySubAccount = new Map(
+    latestBy(rows, (row) => row.subAccount, (row) => row.capturedAt)
+      .map((row) => [row.subAccount, row.capturedAt]),
+  );
   const latestRows = latestBy(
-    rows.filter((row) => row.totalQuantity > 0 || maicoinDebtQuantity(row) > 0),
+    rows.filter((row) => (
+      row.capturedAt === latestCaptureBySubAccount.get(row.subAccount)
+      && (row.totalQuantity > 0 || maicoinDebtQuantity(row) > 0)
+    )),
     (row) => ["maicoin", row.subAccount, row.walletType, currency(row.currency)].join("|"),
     (row) => row.capturedAt,
   );


### PR DESCRIPTION
## Summary
- Restrict Maicoin position rows to the latest capture per sub-account before building the overview.
- Prevent older wallet snapshots from surfacing duplicate investment rows when a newer capture exists.
- Add a regression check covering mixed snapshot timestamps for the Spot wallet.

## Testing
- Added unit coverage in `accounts.check.ts` for the latest-capture selection behavior.