### PR TITLE
ci: require pull request tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
       - name: Run tests
         run: npm run test:ci
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,57 @@
+name: PR Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: npm
+
+      - name: Check package lock
+        run: npm run check:package-lock
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          if [ ! -f reports/test-summary.txt ]; then
+            echo "Test report was not generated." >&2
+            exit 1
+          fi
+          echo '## Test and coverage report' >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat reports/test-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            reports/test-summary.txt
+            reports/junit.xml
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 build/
 /build-electron/
 out/
+/reports/
 .env
 /.env.local
 /settings.json

--- a/docs/superpowers/plans/2026-07-14-pr-test-ci.md
+++ b/docs/superpowers/plans/2026-07-14-pr-test-ci.md
@@ -1,0 +1,270 @@
+# PR Test CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run every repository test on pull requests, publish JUnit and coverage reports, and expose a stable required check that can block merging.
+
+**Architecture:** Reuse Node 25's built-in test runner, coverage, spec, and JUnit reporters. Package scripts own test discovery so local and CI execution stay identical; one GitHub Actions workflow installs locked dependencies, runs the CI script, and always publishes its reports.
+
+**Tech Stack:** npm, Node.js 25, Node built-in test runner, GitHub Actions
+
+## Global Constraints
+
+- Do not add a test framework or reporting dependency.
+- Cover the repository's existing `*.check.ts`, `*.test.ts`, `*.check.cjs`, and `*.check.mjs` test conventions.
+- Coverage is informational only; do not configure line, branch, or function thresholds.
+- Upload JUnit XML and a human-readable test/coverage summary even when tests fail.
+- Do not run credential-dependent live banking workflows.
+- Keep GitHub Actions permissions read-only.
+
+---
+
+## File Structure
+
+- Modify `package.json`: define the canonical local and CI test commands.
+- Modify `.gitignore`: keep generated local reports out of version control.
+- Create `.github/workflows/pr-tests.yml`: run tests for pull requests and publish reports.
+- No helper scripts or new dependencies are needed.
+
+### Task 1: Canonical Test and Report Commands
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Consumes: existing Node-based `*.check.*` and `*.test.*` files under `src`, `electron`, and `scripts`.
+- Produces: `npm test`, `npm run test:ci`, `reports/test-summary.txt`, and `reports/junit.xml`.
+
+- [ ] **Step 1: Verify the package scripts do not exist yet**
+
+Run:
+
+```bash
+node -e 'const p=require("./package.json"); if (p.scripts.test || p.scripts["test:ci"]) process.exit(1)'
+```
+
+Expected: PASS with exit code `0`, confirming the implementation has not already been added.
+
+- [ ] **Step 2: Add the minimal package scripts**
+
+Add these entries at the start of the existing `scripts` object in `package.json`:
+
+```json
+"test": "node --no-warnings --experimental-strip-types --test \"src/**/*.check.ts\" \"src/**/*.test.ts\" \"electron/**/*.check.ts\" \"electron/**/*.check.cjs\" \"scripts/**/*.check.mjs\"",
+"test:ci": "mkdir -p reports && node --no-warnings --experimental-strip-types --experimental-test-coverage --test --test-reporter=spec --test-reporter-destination=reports/test-summary.txt --test-reporter=junit --test-reporter-destination=reports/junit.xml \"src/**/*.check.ts\" \"src/**/*.test.ts\" \"electron/**/*.check.ts\" \"electron/**/*.check.cjs\" \"scripts/**/*.check.mjs\"",
+```
+
+Do not change dependencies or the lockfile.
+
+Append this generated directory to `.gitignore`:
+
+```gitignore
+/reports/
+```
+
+- [ ] **Step 3: Install locked dependencies**
+
+Run:
+
+```bash
+npm ci
+```
+
+Expected: exit code `0`; `package-lock.json` remains unchanged.
+
+- [ ] **Step 4: Run every test locally**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: exit code `0`; Node reports all 56 current test files with no failures.
+
+- [ ] **Step 5: Generate and validate both CI reports**
+
+Run:
+
+```bash
+npm run test:ci
+node -e 'const fs=require("node:fs"); const xml=fs.readFileSync("reports/junit.xml","utf8"); const summary=fs.readFileSync("reports/test-summary.txt","utf8"); if (!xml.includes("<testsuites>") || !summary.includes("coverage")) process.exit(1)'
+```
+
+Expected: all commands exit `0`; `reports/junit.xml` contains JUnit XML and `reports/test-summary.txt` contains the coverage table. The ignored report directory does not dirty the worktree.
+
+- [ ] **Step 6: Confirm generated reports are ignored**
+
+Run:
+
+```bash
+git status --short reports
+```
+
+Expected: no output because `/reports/` is ignored.
+
+- [ ] **Step 7: Commit the package script**
+
+```bash
+git add package.json .gitignore
+git commit -m "test: add canonical test commands"
+```
+
+### Task 2: Pull Request Test Workflow
+
+**Files:**
+- Create: `.github/workflows/pr-tests.yml`
+
+**Interfaces:**
+- Consumes: `npm run check:package-lock` and `npm run test:ci` from `package.json`.
+- Produces: the stable `Tests` status check, a GitHub Actions summary, and the `test-reports` artifact.
+
+- [ ] **Step 1: Verify the workflow does not exist yet**
+
+Run:
+
+```bash
+test ! -e .github/workflows/pr-tests.yml
+```
+
+Expected: PASS with exit code `0`.
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/pr-tests.yml` with exactly:
+
+```yaml
+name: PR Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: npm
+
+      - name: Check package lock
+        run: npm run check:package-lock
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          if [ ! -f reports/test-summary.txt ]; then
+            echo "Test report was not generated." >&2
+            exit 1
+          fi
+          echo '## Test and coverage report' >> "$GITHUB_STEP_SUMMARY"
+          echo '```text' >> "$GITHUB_STEP_SUMMARY"
+          cat reports/test-summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            reports/test-summary.txt
+            reports/junit.xml
+          if-no-files-found: error
+          retention-days: 14
+```
+
+- [ ] **Step 3: Check the workflow's required behavior statically**
+
+Run:
+
+```bash
+node -e 'const fs=require("node:fs"); const y=fs.readFileSync(".github/workflows/pr-tests.yml","utf8"); for (const value of ["pull_request:", "name: Tests", "npm run test:ci", "if: always()", "actions/upload-artifact@v4", "if-no-files-found: error"]) if (!y.includes(value)) throw new Error(`missing ${value}`)'
+git diff --check
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 4: Re-run the local quality gate**
+
+Run:
+
+```bash
+npm test
+npm run typecheck
+```
+
+Expected: both commands exit `0`; all tests pass and typecheck reports 0 errors and 0 warnings.
+
+- [ ] **Step 5: Commit the workflow**
+
+```bash
+git add .github/workflows/pr-tests.yml
+git commit -m "ci: require pull request tests"
+```
+
+### Task 3: Enable and Verify Merge Protection
+
+**Files:**
+- No repository files change.
+
+**Interfaces:**
+- Consumes: the `Tests` status check produced by `.github/workflows/pr-tests.yml` after it runs on GitHub.
+- Produces: a GitHub Ruleset or branch protection rule requiring `Tests` before merge.
+
+- [ ] **Step 1: Push the implementation branch and open or update its pull request**
+
+Run:
+
+```bash
+git switch -c codex/pr-test-ci
+git push -u origin codex/pr-test-ci
+gh pr create --base main --head codex/pr-test-ci --title "ci: require pull request tests" --body "Runs every Node test on pull requests and publishes JUnit plus coverage reports. Coverage is reported without a minimum threshold."
+gh pr checks codex/pr-test-ci --watch
+```
+
+Expected: the branch and pull request are created, and the `PR Tests / Tests` job completes successfully with a `test-reports` artifact and job summary. If the managed worktree prevents branch creation, use Codex's **Create branch** control with the same branch name, then continue with the push and PR commands.
+
+- [ ] **Step 2: Require the check in repository rules**
+
+In GitHub, open **Settings → Rules → Rulesets**, edit the ruleset targeting the default branch (or create one if none exists), enable **Require status checks to pass**, and add the `Tests` check. Do not remove or weaken existing rules.
+
+- [ ] **Step 3: Verify the protection**
+
+Re-run or inspect the pull request checks. Expected:
+
+- A failed or pending `Tests` check blocks merge.
+- A successful `Tests` check satisfies this rule.
+- The Actions summary contains test and coverage output.
+- The `test-reports` artifact contains `test-summary.txt` and valid `junit.xml`.
+
+- [ ] **Step 4: Final repository verification**
+
+Run:
+
+```bash
+git status --short
+git log -3 --oneline
+```
+
+Expected: the worktree is clean and the two implementation commits appear above the design and plan history.

--- a/docs/superpowers/specs/2026-07-14-pr-test-ci-design.md
+++ b/docs/superpowers/specs/2026-07-14-pr-test-ci-design.md
@@ -1,0 +1,56 @@
+# PR Test CI Design
+
+## Goal
+
+Every pull request must run all repository tests and produce a readable test report before merge. Coverage is reported but has no minimum threshold.
+
+## Approach
+
+Use Node's built-in test runner and reporters. This matches the repository's existing `node:assert`-based `*.check.*` and `*.test.*` files and avoids adding a test framework or reporting dependency.
+
+## Test Commands
+
+Add package scripts that run every tracked test convention under `src`, `electron`, and `scripts`:
+
+- `test` prints the normal test result locally.
+- `test:ci` enables Node's built-in coverage, writes a human-readable summary, and writes JUnit XML.
+
+Both commands cover `*.check.ts`, `*.test.ts`, and the JavaScript module variants currently used by the repository. Coverage is informational only; no line, branch, or function threshold is configured.
+
+## GitHub Actions Workflow
+
+Add one pull-request workflow with one required job:
+
+1. Check out the pull request commit.
+2. Install the repository's supported Node version.
+3. Run `npm ci` from the committed lockfile.
+4. Create the report directory and run `npm run test:ci`.
+5. On success or failure, append the text report to the GitHub Actions job summary.
+6. On success or failure, upload the text report and JUnit XML as a downloadable artifact.
+
+The test step's exit status determines the job status. Report publishing uses `if: always()` so a failing suite still leaves diagnostic output. Workflow permissions remain read-only.
+
+## Merge Enforcement
+
+The workflow creates a stable status check. After the workflow exists and has run at least once, configure the repository's GitHub Ruleset or branch protection rule to require that check before merging. The workflow alone cannot enforce merge protection.
+
+## Error Handling
+
+- `npm ci` failure blocks the job and therefore the merge.
+- Any test failure blocks the job and therefore the merge.
+- Report upload must not conceal the original test failure.
+- If report generation itself fails, the CI job fails rather than passing without the required report.
+
+## Verification
+
+- Run the local test command and confirm every current test file is discovered.
+- Run the CI report command and confirm it creates valid JUnit XML and a coverage summary without enforcing a threshold.
+- Validate the workflow syntax and review the final diff.
+- After the first GitHub run, mark its job check as required in repository rules.
+
+## Non-goals
+
+- Migrating tests to Vitest, Jest, or another framework.
+- Adding a coverage service or PR annotation bot.
+- Enforcing a coverage minimum.
+- Running credential-dependent live banking workflows.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "main": "electron/main.cjs",
   "scripts": {
+    "test": "node --no-warnings --experimental-strip-types --test \"src/**/*.check.ts\" \"src/**/*.test.ts\" \"electron/**/*.check.ts\" \"electron/**/*.check.cjs\" \"scripts/**/*.check.mjs\"",
+    "test:ci": "mkdir -p reports && node --no-warnings --experimental-strip-types --experimental-test-coverage --test --test-reporter=spec --test-reporter-destination=reports/test-summary.txt --test-reporter=junit --test-reporter-destination=reports/junit.xml \"src/**/*.check.ts\" \"src/**/*.test.ts\" \"electron/**/*.check.ts\" \"electron/**/*.check.cjs\" \"scripts/**/*.check.mjs\"",
     "postinstall": "node scripts/patch-libretto-run-cdp.mjs",
     "build": "npm run build:renderer && npm run build:electron",
     "build:renderer": "vite build",


### PR DESCRIPTION
## Summary

- add canonical Node test commands covering all current `*.check.*` and `*.test.*` files
- run the full suite on every pull request
- publish a GitHub Actions summary plus downloadable JUnit and coverage reports
- report coverage without enforcing a minimum threshold

## Validation

- `npm test` — 56 passed, 0 failed
- `npm run test:ci` — JUnit XML and coverage summary generated
- `npm run typecheck` — 0 errors, 0 warnings
