### PR TITLE
Refactor credential setup and statement selection validation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,3 +16,9 @@ The set of statement types chosen for an enabled credential source to collect.
 **Automation session finalization**:
 The act of relinquishing an owned automation session after a run, including graceful close, daemon teardown when needed, and removal of the session's ownership record.
 _Avoid_: Session close (which names only the graceful close operation).
+
+**Automation task**:
+A reusable scheduled unit that can be started manually, in a batch, or as a resume.
+
+**Automation task run**:
+One persisted execution attempt of an automation task, including its output, status, and any retained session.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,13 @@ _Avoid_: Session close (which names only the graceful close operation).
 A reusable scheduled unit that can be started manually, in a batch, or as a resume.
 
 **Automation task run**:
-One persisted execution attempt of an automation task, including its output, status, and any retained session.
+One persisted execution attempt of an automation task, including its output, status, and any retained session. A run waiting for human input remains that run; resuming creates a new run for the subsequent outcome.
 
 **Automation task run finalization**:
 The act of deciding an automation task run's terminal outcome, recording its result, and relinquishing or retaining its automation session.
+
+**Automation task run finalization intent**:
+The stated outcome and session disposition that guide how an automation task run is finalized.
+
+**Automation session disposition**:
+The decision to retain an automation session for human assistance or relinquish it after a task run.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,9 @@ The act of enabling a credential source, entering its credentials, and choosing 
 **Statement selection**:
 The set of statement types chosen for an enabled credential source to collect.
 
+**Statement run summary**:
+A compact record of one automation task run's statement collection outcome, including each selected statement type's result and the overall outcome.
+
 **Automation session finalization**:
 The act of relinquishing an owned automation session after a run, including graceful close, daemon teardown when needed, and removal of the session's ownership record.
 _Avoid_: Session close (which names only the graceful close operation).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,3 +12,7 @@ The act of enabling a credential source, entering its credentials, and choosing 
 
 **Statement selection**:
 The set of statement types chosen for an enabled credential source to collect.
+
+**Automation session finalization**:
+The act of relinquishing an owned automation session after a run, including graceful close, daemon teardown when needed, and removal of the session's ownership record.
+_Avoid_: Session close (which names only the graceful close operation).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,3 +25,6 @@ A reusable scheduled unit that can be started manually, in a batch, or as a resu
 
 **Automation task run**:
 One persisted execution attempt of an automation task, including its output, status, and any retained session.
+
+**Automation task run finalization**:
+The act of deciding an automation task run's terminal outcome, recording its result, and relinquishing or retaining its automation session.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,3 +9,6 @@ The guided sequence that helps a new user configure a credential source, collect
 
 **Credential setup**:
 The act of enabling a credential source, entering its credentials, and choosing the statement types required before collection.
+
+**Statement selection**:
+The set of statement types chosen for an enabled credential source to collect.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,3 +34,6 @@ The stated outcome and session disposition that guide how an automation task run
 
 **Automation session disposition**:
 The decision to retain an automation session for human assistance or relinquish it after a task run.
+
+**Automation task run force-quit**:
+An operator-initiated action that ends a task run waiting for human input by relinquishing its exact automation session and finalizing the run as failed.

--- a/src/lib/automation/AutomationDashboard.check.ts
+++ b/src/lib/automation/AutomationDashboard.check.ts
@@ -146,7 +146,7 @@ assert.match(source, /import type \{ CredentialGroupDto \} from "\$lib\/desktop\
 assert.match(source, /function toggleStatementType\(groupId: string, typeId: string\)/);
 assert.match(source, /function selectAllStatementTypes\(group: CredentialGroupDto\)/);
 assert.match(source, /document\.getElementById\(`\$\{invalid\.id\}-statement-selection`\)\?\.focus\(\)/);
-assert.match(source, /updates\[group\.statementSelectionKey\] = statementSelectionDrafts\[group\.id\]\.join\(","\)/);
+assert.match(source, /buildCredentialSetupPlan/);
 assert.match(source, /aria-live="polite"/);
 assert.match(source, /\.statement-selection:focus\s*\{/);
 assert.match(source, /\.statement-type-option:focus-within\s*\{/);

--- a/src/lib/automation/AutomationDashboard.svelte
+++ b/src/lib/automation/AutomationDashboard.svelte
@@ -11,8 +11,11 @@
     onboardingTaskDisclosure,
     settleAssistDrag,
     settleAssistTextSubmission,
-    singleSourceUpdates,
   } from "$lib/onboarding/state.ts";
+  import {
+    buildCredentialSetupPlan,
+    firstInvalidCredentialGroup,
+  } from "$lib/automation/credential-setup.ts";
   import type { CredentialSetupResult, OnboardingStep } from "$lib/onboarding/progression.ts";
   import { systemTimezone } from "$lib/settings/system-timezone-store.ts";
   import DashboardShell from "$lib/shared-shell/components/DashboardShell.svelte";
@@ -584,10 +587,10 @@
   async function saveCredentials(event: SubmitEvent) {
     event.preventDefault();
     if (!canSubmitCredentials(onboardingSourceSelection, onboardingCredentialsReady)) return;
-    const invalid = credentialGroups.find((group) =>
-      group.statementTypes?.length
-      && groupEnabled[group.id] !== false
-      && !(statementSelectionDrafts[group.id]?.length)
+    const invalid = firstInvalidCredentialGroup(
+      credentialGroups,
+      groupEnabled,
+      statementSelectionDrafts,
     );
     if (invalid) {
       credentialSearch = "";
@@ -599,30 +602,19 @@
       return;
     }
     statementSelectionError = "";
-    const updates: Record<string, string> = {};
-    for (const group of credentialGroups) {
-      updates[group.enabledKey] = groupEnabled[group.id] !== false ? "true" : "false";
-      if (group.statementSelectionKey && statementSelectionDrafts[group.id]?.length) {
-        updates[group.statementSelectionKey] = statementSelectionDrafts[group.id].join(",");
-      }
-    }
-    for (const [key, value] of Object.entries(credentialDrafts)) {
-      if (value.trim()) updates[key] = value.trim();
-    }
-    if (onboardingSingleSource && selectedCredentialGroupId) {
-      Object.assign(
-        updates,
-        singleSourceUpdates(
-          credentialGroups,
-          selectedCredentialGroupId,
-          collectionGroupIds,
-        ),
-      );
-    }
+    const plan = buildCredentialSetupPlan({
+      groups: credentialGroups,
+      enabled: groupEnabled,
+      statementSelections: statementSelectionDrafts,
+      credentialDrafts,
+      selectedCredentialGroupId,
+      onboardingSingleSource,
+      collectionGroupIds,
+    });
     try {
       actionError = "";
-      const savedGroupId = selectedCredentialGroupId;
-      await window.octopusBeak.automation.saveCredentials(updates);
+      const savedGroupId = plan.selectedCredentialGroupId;
+      await window.octopusBeak.automation.saveCredentials(plan.updates);
       resetCredentialChanges();
       await reload();
       if (onboardingSourceSelection && savedGroupId) {

--- a/src/lib/automation/credential-setup.check.ts
+++ b/src/lib/automation/credential-setup.check.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCredentialSetupPlan,
+  firstInvalidCredentialGroup,
+  singleSourceUpdates,
+  type CredentialSetupGroup,
+} from "./credential-setup.ts";
+
+const groups: CredentialSetupGroup[] = [
+  {
+    id: "fubon",
+    label: "Fubon",
+    enabledKey: "FUBON_ENABLED",
+    statementSelectionKey: "FUBON_TYPES",
+    statementTypes: [{ id: "deposit" }, { id: "card" }],
+  },
+  {
+    id: "esun",
+    label: "E.SUN",
+    enabledKey: "ESUN_ENABLED",
+    statementSelectionKey: "ESUN_TYPES",
+    statementTypes: [{ id: "deposit" }],
+  },
+];
+
+test("credential setup rejects enabled groups without statement selections", () => {
+  assert.equal(
+    firstInvalidCredentialGroup(groups, { fubon: true, esun: false }, { fubon: [] })?.id,
+    "fubon",
+  );
+  assert.equal(
+    firstInvalidCredentialGroup(
+      groups,
+      { fubon: true, esun: true },
+      { fubon: ["deposit"], esun: ["deposit"] },
+    ),
+    null,
+  );
+});
+
+test("credential setup builds normalized updates and single-source policy", () => {
+  assert.deepEqual(
+    buildCredentialSetupPlan({
+      groups,
+      enabled: { fubon: true, esun: false },
+      statementSelections: { fubon: ["deposit", "card"], esun: [] },
+      credentialDrafts: { USER: " demo-user ", PASSWORD: "  " },
+      selectedCredentialGroupId: "fubon",
+      onboardingSingleSource: true,
+      collectionGroupIds: new Set(["fubon", "esun"]),
+    }),
+    {
+      updates: {
+        FUBON_ENABLED: "true",
+        FUBON_TYPES: "deposit,card",
+        ESUN_ENABLED: "false",
+        USER: "demo-user",
+      },
+      selectedCredentialGroupId: "fubon",
+    },
+  );
+  assert.deepEqual(
+    singleSourceUpdates(groups, "esun", new Set(["fubon", "esun"])),
+    { FUBON_ENABLED: "false", ESUN_ENABLED: "true" },
+  );
+});

--- a/src/lib/automation/credential-setup.ts
+++ b/src/lib/automation/credential-setup.ts
@@ -1,0 +1,71 @@
+import type { AutomationCredentialGroup } from "./types.ts";
+
+export type CredentialSetupGroup = Pick<
+  AutomationCredentialGroup,
+  "id" | "label" | "enabledKey" | "statementSelectionKey" | "statementTypes"
+>;
+
+export type CredentialSetupDraft = {
+  groups: readonly CredentialSetupGroup[];
+  enabled: Readonly<Record<string, boolean>>;
+  statementSelections: Readonly<Record<string, readonly string[]>>;
+  credentialDrafts: Readonly<Record<string, string>>;
+  selectedCredentialGroupId: string;
+  onboardingSingleSource: boolean;
+  collectionGroupIds: ReadonlySet<string>;
+};
+
+export function firstInvalidCredentialGroup(
+  groups: readonly CredentialSetupGroup[],
+  enabled: Readonly<Record<string, boolean>>,
+  statementSelections: Readonly<Record<string, readonly string[]>>,
+) {
+  return groups.find((group) =>
+    group.statementTypes?.length
+    && enabled[group.id] !== false
+    && !(statementSelections[group.id]?.length)
+  ) ?? null;
+}
+
+export function singleSourceUpdates(
+  groups: readonly CredentialSetupGroup[],
+  selectedGroupId: string,
+  collectionGroupIds: ReadonlySet<string>,
+) {
+  return Object.fromEntries(
+    groups
+      .filter((group) => collectionGroupIds.has(group.id))
+      .map((group) => [
+        group.enabledKey,
+        group.id === selectedGroupId ? "true" : "false",
+      ]),
+  );
+}
+
+export function buildCredentialSetupPlan(draft: CredentialSetupDraft) {
+  const updates: Record<string, string> = {};
+  for (const group of draft.groups) {
+    updates[group.enabledKey] = draft.enabled[group.id] !== false ? "true" : "false";
+    const selectedIds = draft.statementSelections[group.id] ?? [];
+    if (group.statementSelectionKey && selectedIds.length) {
+      updates[group.statementSelectionKey] = selectedIds.join(",");
+    }
+  }
+  for (const [key, value] of Object.entries(draft.credentialDrafts)) {
+    if (value.trim()) updates[key] = value.trim();
+  }
+  if (draft.onboardingSingleSource && draft.selectedCredentialGroupId) {
+    Object.assign(
+      updates,
+      singleSourceUpdates(
+        draft.groups,
+        draft.selectedCredentialGroupId,
+        draft.collectionGroupIds,
+      ),
+    );
+  }
+  return {
+    updates,
+    selectedCredentialGroupId: draft.selectedCredentialGroupId,
+  };
+}

--- a/src/lib/automation/server/automation-session-disposition.check.ts
+++ b/src/lib/automation/server/automation-session-disposition.check.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  automationSessionOwnerForRun,
+  claimAutomationTaskRunSession,
+  finalizeAutomationSessionForRun,
+  ownedAutomationSessionForTask,
+  refreshAutomationSession,
+  relinquishAutomationSessionForTask,
+  type OwnedAutomationSession,
+} from "./automation-session-disposition.ts";
+import { createTaskRun, taskRunById } from "./store.ts";
+
+function createRun(
+  db: ReturnType<typeof openLedgerDatabase>,
+  ledgerDir: string,
+  status: "running" | "waiting_for_human" = "running",
+  logTail = "",
+) {
+  const run = createTaskRun(db, {
+    taskId: "fubon-all-statements",
+    script: "run:fubon-all-statements",
+    kind: "crawler",
+    status,
+    attempt: 1,
+    maxAttempts: 1,
+    startedAt: new Date().toISOString(),
+    logPath: join(ledgerDir, `${status}-${Math.random()}.log`),
+    logTail,
+  });
+  return taskRunById(db, run.taskRunId)!;
+}
+
+function fakeFinalizeDeps() {
+  return {
+    async closeSession() {},
+    isExpectedDaemon() { return false; },
+    signalProcessGroup() {},
+    async wait() {},
+  };
+}
+
+test("session owner resolution reads the bounded log prefix before the tail", () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-session-disposition-owner-"));
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const run = createRun(db, ledgerDir, "running", "tail does not contain the identity");
+    writeFileSync(run.logPath, "automation-session: ses-prefix\n" + "x".repeat(10_000));
+    assert.deepEqual(automationSessionOwnerForRun(run), {
+      taskId: run.taskId,
+      taskRunId: run.taskRunId,
+      session: "ses-prefix",
+      pid: null,
+    });
+    db.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("resume handoff finalizes the old run and claims the new session atomically", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-session-disposition-handoff-"));
+  let owner: OwnedAutomationSession | null = null;
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const waiting = createRun(
+      db,
+      ledgerDir,
+      "waiting_for_human",
+      "Workflow paused. run `npx libretto resume --session ses-handoff`.",
+    );
+    const next = createRun(db, ledgerDir, "running");
+    owner = {
+      taskId: next.taskId,
+      taskRunId: next.taskRunId,
+      session: "ses-handoff",
+      pid: null,
+    };
+    refreshAutomationSession({
+      taskId: waiting.taskId,
+      taskRunId: waiting.taskRunId,
+      session: "ses-handoff",
+      pid: null,
+    });
+
+    assert.equal(
+      claimAutomationTaskRunSession(db, next.taskRunId, owner, {
+        resumeSession: owner.session,
+        resumeFrom: waiting,
+      }),
+      true,
+    );
+    assert.equal(taskRunById(db, waiting.taskRunId)?.status, "failed");
+    assert.equal(ownedAutomationSessionForTask(next.taskId)?.taskRunId, next.taskRunId);
+    db.close();
+  } finally {
+    if (owner) await relinquishAutomationSessionForTask(owner.taskId, fakeFinalizeDeps());
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("recovery reports missing identity without guessing a session", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-session-disposition-recovery-"));
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const run = createRun(db, ledgerDir, "running", "workflow failed without session metadata");
+    const result = await finalizeAutomationSessionForRun(run, "workflow failed", "recovery");
+    assert.deepEqual(result, {
+      session: null,
+      pid: null,
+      errorMessage: "workflow failed\nSession cleanup failed: Missing Libretto session identity",
+      cleanupFailed: true,
+    });
+    db.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("exact finalization refuses a changed owner without cleanup", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-session-disposition-owner-race-"));
+  const owner = {
+    taskId: "fubon-all-statements",
+    taskRunId: "new-owner",
+    session: "ses-new-owner",
+    pid: null,
+  } satisfies OwnedAutomationSession;
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const run = createRun(db, ledgerDir, "running", "automation-session: ses-old-owner");
+    refreshAutomationSession(owner);
+    const result = await finalizeAutomationSessionForRun(run, "workflow completed", "exact");
+    assert.equal(result.cleanupFailed, true);
+    assert.match(result.errorMessage ?? "", /ownership changed/);
+    assert.equal(ownedAutomationSessionForTask(owner.taskId)?.taskRunId, owner.taskRunId);
+    db.close();
+  } finally {
+    await relinquishAutomationSessionForTask(owner.taskId, fakeFinalizeDeps());
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});

--- a/src/lib/automation/server/automation-session-disposition.ts
+++ b/src/lib/automation/server/automation-session-disposition.ts
@@ -1,0 +1,315 @@
+import { appendFileSync, closeSync, mkdirSync, openSync, readSync } from "node:fs";
+import { dirname } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { readLibrettoSessionState } from "./libretto-session.ts";
+import {
+  armAutomationSessionTimeout,
+  claimAutomationSessionForCleanup,
+  disarmAutomationSessionTimeout,
+  finalizeExactOwnedAutomationSession,
+  finalizeOwnedAutomationSession,
+  ownAutomationSession,
+  ownedAutomationSession,
+  restoreAutomationSessionOwnership,
+  type FinalizeSessionDeps,
+  type OwnedAutomationSession,
+  type TimerDeps,
+} from "./session-lifecycle.ts";
+import { updateTaskRun, type AutomationTaskRun } from "./store.ts";
+
+const SESSION_LOG_PREFIX_BYTES = 4_000;
+
+export type { FinalizeSessionDeps, OwnedAutomationSession, TimerDeps } from "./session-lifecycle.ts";
+
+export type AutomationSessionDisposition = "retain" | "relinquish";
+
+export type ForceQuitFinalizationDependencies = Partial<{
+  readSessionState: typeof readLibrettoSessionState;
+  claimSession: typeof claimAutomationSessionForCleanup;
+  finalizeSession: typeof finalizeExactOwnedAutomationSession;
+}>;
+
+export type AutomationSessionCleanupResult = {
+  session: string | null;
+  pid: number | null;
+  errorMessage: string | null;
+  cleanupFailed: boolean;
+};
+
+export type ForceQuitAutomationSessionResult = AutomationSessionCleanupResult & {
+  operationalError: unknown | null;
+};
+
+export function appendLog(logPath: string, chunk: string) {
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, chunk);
+}
+
+export function tail(value: string) {
+  return value.slice(-4_000);
+}
+
+export function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function appendCleanupError(message: string | null, cleanup: string) {
+  const suffix = "Session cleanup failed: " + cleanup;
+  return message ? message + "\n" + suffix : suffix;
+}
+
+export function automationCleanupFailureDetails(
+  owner: OwnedAutomationSession,
+  error: unknown,
+) {
+  return {
+    taskRunId: owner.taskRunId,
+    sessionId: owner.session,
+    retainedPid: owner.pid,
+    error: errorMessage(error),
+  };
+}
+
+export function automationSessionFromLog(output: string) {
+  return output.match(/automation-session:\s+([A-Za-z0-9._-]+)/i)?.[1] ?? null;
+}
+
+export function resumeSessionFromLog(output: string) {
+  return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
+}
+
+export function sessionFromRun(run: AutomationTaskRun) {
+  try {
+    const buffer = Buffer.alloc(SESSION_LOG_PREFIX_BYTES);
+    const descriptor = openSync(run.logPath, "r");
+    let length: number;
+    try {
+      length = readSync(descriptor, buffer, 0, SESSION_LOG_PREFIX_BYTES, 0);
+    } finally {
+      closeSync(descriptor);
+    }
+    const output = buffer.toString("utf8", 0, length);
+    const session = automationSessionFromLog(output) ?? resumeSessionFromLog(output);
+    if (session) return session;
+  } catch {
+    // The bounded log tail remains the recovery source when the log file is unavailable.
+  }
+  return automationSessionFromLog(run.logTail) ?? resumeSessionFromLog(run.logTail);
+}
+
+export function sessionPid(session: string) {
+  try {
+    return readLibrettoSessionState(session)?.pid ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function automationSessionOwnerForRun(run: AutomationTaskRun): OwnedAutomationSession | null {
+  const session = sessionFromRun(run);
+  return session
+    ? { taskId: run.taskId, taskRunId: run.taskRunId, session, pid: sessionPid(session) }
+    : null;
+}
+
+export function refreshAutomationSession(owner: OwnedAutomationSession) {
+  return ownAutomationSession({ ...owner, pid: sessionPid(owner.session) });
+}
+
+export function ownedAutomationSessionForTask(taskId: string) {
+  return ownedAutomationSession(taskId);
+}
+
+export function armAutomationSessionDispositionTimeout(
+  taskId: string,
+  onTimeout: () => void | Promise<void>,
+  timerDeps?: TimerDeps,
+) {
+  return armAutomationSessionTimeout(taskId, onTimeout, timerDeps);
+}
+
+export function disarmAutomationSessionDispositionTimeout(taskId: string) {
+  return disarmAutomationSessionTimeout(taskId);
+}
+
+export async function relinquishAutomationSessionForTask(
+  taskId: string,
+  deps?: FinalizeSessionDeps,
+) {
+  return finalizeOwnedAutomationSession(taskId, deps);
+}
+
+export function claimAutomationTaskRunSession(
+  db: ReturnType<typeof openLedgerDatabase>,
+  taskRunId: string,
+  owner: OwnedAutomationSession,
+  options: { resumeSession?: string; resumeFrom?: AutomationTaskRun } = {},
+) {
+  const current = ownedAutomationSession(owner.taskId);
+  const resumeFrom = options.resumeFrom;
+  let claimError: unknown = null;
+  const isResumeHandoff = Boolean(
+    options.resumeSession
+      && options.resumeSession === owner.session
+      && resumeFrom?.status === "waiting_for_human"
+      && resumeFrom.taskId === owner.taskId
+      && resumeFrom.taskRunId !== taskRunId
+      && sessionFromRun(resumeFrom) === owner.session
+      && (!current
+        || (current.taskRunId === resumeFrom.taskRunId && current.session === owner.session)),
+  );
+  if ((!options.resumeSession || isResumeHandoff) && (!current || isResumeHandoff)) {
+    if (resumeFrom) {
+      const claimRejected = new Error("Automation session registry claim rejected");
+      let registryClaimed = false;
+      db.exec("BEGIN");
+      try {
+        updateTaskRun(db, resumeFrom.taskRunId, {
+          status: "failed",
+          finishedAt: new Date().toISOString(),
+          errorMessage: `Superseded by resume handoff: ${taskRunId}`,
+          logTail: tail(`${resumeFrom.logTail}\nautomation-resume-handoff: ${taskRunId}\n`),
+        });
+        if (!ownAutomationSession(owner)) throw claimRejected;
+        registryClaimed = true;
+        db.exec("COMMIT");
+        disarmAutomationSessionTimeout(owner.taskId);
+        return true;
+      } catch (error) {
+        try {
+          db.exec("ROLLBACK");
+        } finally {
+          if (registryClaimed) restoreAutomationSessionOwnership(owner, current ?? null);
+        }
+        claimError = error;
+      }
+    } else if (ownAutomationSession(owner)) {
+      disarmAutomationSessionTimeout(owner.taskId);
+      return true;
+    }
+  }
+  updateTaskRun(db, taskRunId, {
+    status: "failed",
+    finishedAt: new Date().toISOString(),
+    exitCode: null,
+    signal: null,
+    errorMessage: claimError && errorMessage(claimError) !== "Automation session registry claim rejected"
+      ? `Automation session handoff failed: ${errorMessage(claimError)}`
+      : "Automation session is still closing. Try again after cleanup finishes.",
+  });
+  return false;
+}
+
+export async function finalizeAutomationSession(
+  owner: OwnedAutomationSession,
+  workflowError: string | null,
+  finalize: () => Promise<unknown> = async () => {
+    if (!await finalizeExactOwnedAutomationSession(owner)) {
+      throw new Error(`Automation session ownership changed for task: ${owner.taskId}`);
+    }
+  },
+) {
+  try {
+    await finalize();
+    return { errorMessage: workflowError, cleanupFailed: false };
+  } catch (error) {
+    console.error(
+      "automation-session-cleanup-failed",
+      automationCleanupFailureDetails(owner, error),
+    );
+    return {
+      errorMessage: appendCleanupError(workflowError, errorMessage(error)),
+      cleanupFailed: true,
+    };
+  }
+}
+
+export async function finalizeAutomationSessionForRun(
+  run: AutomationTaskRun,
+  workflowError: string | null,
+  mode: "exact" | "recovery",
+): Promise<AutomationSessionCleanupResult> {
+  const owner = automationSessionOwnerForRun(run);
+  if (!owner) {
+    return {
+      session: null,
+      pid: null,
+      errorMessage: appendCleanupError(workflowError, "Missing Libretto session identity"),
+      cleanupFailed: true,
+    };
+  }
+
+  if (mode === "recovery" && !ownAutomationSession(owner)) {
+    return {
+      session: owner.session,
+      pid: owner.pid,
+      errorMessage: appendCleanupError(
+        workflowError,
+        `Automation session ownership changed for task: ${run.taskId}`,
+      ),
+      cleanupFailed: true,
+    };
+  }
+
+  const result = await finalizeAutomationSession(owner, workflowError, async () => {
+    const finalized = await finalizeExactOwnedAutomationSession(owner);
+    if (!finalized) {
+      throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
+    }
+  });
+  return { ...result, session: owner.session, pid: owner.pid };
+}
+
+export async function forceQuitAutomationSessionForRun(
+  run: AutomationTaskRun,
+  dependencies: ForceQuitFinalizationDependencies = {},
+): Promise<ForceQuitAutomationSessionResult> {
+  const session = sessionFromRun(run);
+  if (!session) throw new Error(`Missing Libretto resume session for automation task: ${run.taskId}`);
+  const deps = {
+    readSessionState: readLibrettoSessionState,
+    claimSession: claimAutomationSessionForCleanup,
+    finalizeSession: finalizeExactOwnedAutomationSession,
+    ...dependencies,
+  };
+  let owner: OwnedAutomationSession = {
+    taskId: run.taskId,
+    taskRunId: run.taskRunId,
+    session,
+    pid: null,
+  };
+  let operationalError: unknown | null = null;
+  let result: AutomationSessionCleanupResult;
+  try {
+    owner = { ...owner, pid: deps.readSessionState(session)?.pid ?? null };
+    if (!deps.claimSession(owner)) {
+      throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
+    }
+    let finalizeFailure: unknown = null;
+    const cleanupResult = await finalizeAutomationSession(
+      owner,
+      "Browser session force quit.",
+      async () => {
+        try {
+          if (!await deps.finalizeSession(owner)) {
+            throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
+          }
+        } catch (error) {
+          finalizeFailure = error;
+          throw error;
+        }
+      },
+    );
+    operationalError = finalizeFailure;
+    result = { ...cleanupResult, session, pid: owner.pid };
+  } catch (error) {
+    operationalError = error;
+    result = {
+      session,
+      pid: owner.pid,
+      errorMessage: appendCleanupError("Browser session force quit.", errorMessage(error)),
+      cleanupFailed: true,
+    };
+  }
+  return { ...result, operationalError };
+}

--- a/src/lib/automation/server/desktop-api.check.ts
+++ b/src/lib/automation/server/desktop-api.check.ts
@@ -27,6 +27,7 @@ try {
     LIBRETTO_CLOUD_SINOPAC_ENABLED: false,
     LIBRETTO_CLOUD_LINEBANK_ENABLED: false,
   }, null, 2));
+  const initialSettingsText = readFileSync("settings.json", "utf8");
   writeFileSync("credentials.json", JSON.stringify({
     [userIdKey]: "user",
     [accountKey]: "acct",
@@ -72,6 +73,32 @@ try {
     () => api.assertAutomationTaskCanStart("fubon-all-statements", dir),
     /Select at least one Fubon/,
   );
+  const modelWithDisabledFubon = {
+    ...model,
+    credentialGroups: model.credentialGroups.map((group) => group.id === "fubon"
+      ? { ...group, enabled: false }
+      : group),
+  };
+  assert.equal(
+    api.assertAutomationTasksCanStart(["fubon-all-statements"], modelWithDisabledFubon)[0]?.id,
+    "fubon-all-statements",
+  );
+
+  const previousEnabledEnv = process.env[enabledKey];
+  const settingsWithoutEnabledKey = JSON.parse(initialSettingsText) as Record<string, unknown>;
+  delete settingsWithoutEnabledKey[enabledKey];
+  process.env[enabledKey] = "false";
+  writeFileSync("settings.json", `${JSON.stringify(settingsWithoutEnabledKey, null, 2)}\n`);
+  try {
+    const envOverrideModel = api.loadAutomationDesktopModel(dir);
+    const envOverrideGroup = envOverrideModel.credentialGroups.find((group) => group.id === "fubon");
+    assert.equal(envOverrideGroup?.enabled, false);
+    assert.equal(envOverrideGroup?.statementSetupRequired, false);
+  } finally {
+    if (previousEnabledEnv === undefined) delete process.env[enabledKey];
+    else process.env[enabledKey] = previousEnabledEnv;
+    writeFileSync("settings.json", initialSettingsText);
+  }
 
   const settingsBeforeInvalidSave = readFileSync("settings.json", "utf8");
   const credentialsBeforeInvalidSave = readFileSync("credentials.json", "utf8");

--- a/src/lib/automation/server/desktop-api.ts
+++ b/src/lib/automation/server/desktop-api.ts
@@ -66,6 +66,7 @@ export function loadAutomationDesktopModel(ledgerDir = process.env.LEDGER_DIR ??
     });
     const credentialGroups = AUTOMATION_CREDENTIAL_GROUPS.map((group) => {
       const enabled = enabledGroups[group.id] !== false;
+      const selectionSettings = { ...settings, [group.enabledKey]: enabled };
       const selection = group.statementSelectionKey && group.statementTypes
         ? selectStatementTypes({
           id: group.id,
@@ -73,7 +74,7 @@ export function loadAutomationDesktopModel(ledgerDir = process.env.LEDGER_DIR ??
           enabledKey: group.enabledKey,
           statementSelectionKey: group.statementSelectionKey,
           statementTypes: group.statementTypes,
-        }, settings, "display")
+        }, selectionSettings, "display")
         : { selectedIds: [], needsSetup: false };
       return { ...group, enabled, selectedStatementTypeIds: selection.selectedIds, statementSetupRequired: selection.needsSetup };
     });
@@ -120,13 +121,18 @@ function assertAutomationTaskCanStartInModel(taskId: string, model: AutomationDe
     ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
     : null;
   if (group?.statementSelectionKey && group.statementTypes) {
+    const modelGroup = model.credentialGroups.find((candidate) => candidate.id === group.id);
+    const selectionSettings = {
+      ...readAutomationSettings(),
+      ...(modelGroup ? { [group.enabledKey]: modelGroup.enabled } : {}),
+    };
     selectStatementTypes({
       id: group.id,
       label: group.label,
       enabledKey: group.enabledKey,
       statementSelectionKey: group.statementSelectionKey,
       statementTypes: group.statementTypes,
-    }, readAutomationSettings(), "strict");
+    }, selectionSettings, "strict");
   }
   const missing = missingCredentialKeys(taskId, model.automation.credentials);
   if (missing.length > 0) throw new Error(`Missing credentials: ${missing.join(", ")}`);

--- a/src/lib/automation/server/desktop-api.ts
+++ b/src/lib/automation/server/desktop-api.ts
@@ -3,13 +3,10 @@ import {
   AUTOMATION_CREDENTIAL_KEYS,
   enabledAutomationTasks,
   enabledCsvImportDependencyIds,
-  assertTaskStatementSelection,
   taskById,
 } from "./tasks.ts";
 import {
-  assertValidStatementSelections,
-  resolveStatementSelection,
-  serializeStatementSelection,
+  selectStatementTypes,
 } from "../statement-selection.ts";
 import {
   credentialStatusFromValues,
@@ -70,12 +67,13 @@ export function loadAutomationDesktopModel(ledgerDir = process.env.LEDGER_DIR ??
     const credentialGroups = AUTOMATION_CREDENTIAL_GROUPS.map((group) => {
       const enabled = enabledGroups[group.id] !== false;
       const selection = group.statementSelectionKey && group.statementTypes
-        ? resolveStatementSelection(
-          { label: group.label, statementSelectionKey: group.statementSelectionKey, statementTypes: group.statementTypes },
-          settings,
-          enabled,
-          { tolerateUnknown: true },
-        )
+        ? selectStatementTypes({
+          id: group.id,
+          label: group.label,
+          enabledKey: group.enabledKey,
+          statementSelectionKey: group.statementSelectionKey,
+          statementTypes: group.statementTypes,
+        }, settings, "display")
         : { selectedIds: [], needsSetup: false };
       return { ...group, enabled, selectedStatementTypeIds: selection.selectedIds, statementSetupRequired: selection.needsSetup };
     });
@@ -118,7 +116,18 @@ function assertAutomationTaskCanStartInModel(taskId: string, model: AutomationDe
   if (row.status === "locked") {
     throw new Error("Import is locked until all crawler dependencies complete for the business day.");
   }
-  assertTaskStatementSelection(task, readAutomationSettings());
+  const group = task.credentialGroupId
+    ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
+    : null;
+  if (group?.statementSelectionKey && group.statementTypes) {
+    selectStatementTypes({
+      id: group.id,
+      label: group.label,
+      enabledKey: group.enabledKey,
+      statementSelectionKey: group.statementSelectionKey,
+      statementTypes: group.statementTypes,
+    }, readAutomationSettings(), "strict");
+  }
   const missing = missingCredentialKeys(taskId, model.automation.credentials);
   if (missing.length > 0) throw new Error(`Missing credentials: ${missing.join(", ")}`);
   return task;
@@ -136,25 +145,18 @@ export function automationSaveCredentials(updates: Record<string, string>) {
   const split = splitAutomationUpdates(updates);
   const nextSettings = { ...readAutomationSettings(), ...split.settings };
   for (const group of AUTOMATION_CREDENTIAL_GROUPS) {
-    if (
-      !group.statementSelectionKey ||
-      !group.statementTypes ||
-      !Object.hasOwn(split.settings, group.statementSelectionKey)
-    ) continue;
-    const selection = resolveStatementSelection(
-      {
-        label: group.label,
-        statementSelectionKey: group.statementSelectionKey,
-        statementTypes: group.statementTypes,
-      },
-      nextSettings,
-      nextSettings[group.enabledKey] !== false,
-    );
-    nextSettings[group.statementSelectionKey] = serializeStatementSelection(
-      selection.selectedIds,
-    );
+    if (!group.statementSelectionKey || !group.statementTypes) continue;
+    const selection = selectStatementTypes({
+      id: group.id,
+      label: group.label,
+      enabledKey: group.enabledKey,
+      statementSelectionKey: group.statementSelectionKey,
+      statementTypes: group.statementTypes,
+    }, nextSettings, "strict");
+    if (Object.hasOwn(split.settings, group.statementSelectionKey)) {
+      nextSettings[group.statementSelectionKey] = selection.selectedIds.join(",");
+    }
   }
-  assertValidStatementSelections(AUTOMATION_CREDENTIAL_GROUPS, nextSettings);
   const nextCredentials = Object.keys(split.credentials).length > 0
     ? {
       ...readAutomationCredentialsFile(),

--- a/src/lib/automation/server/desktop-api.ts
+++ b/src/lib/automation/server/desktop-api.ts
@@ -6,6 +6,7 @@ import {
   taskById,
 } from "./tasks.ts";
 import {
+  isStatementSelectionGroup,
   selectStatementTypes,
 } from "../statement-selection.ts";
 import {
@@ -67,14 +68,8 @@ export function loadAutomationDesktopModel(ledgerDir = process.env.LEDGER_DIR ??
     const credentialGroups = AUTOMATION_CREDENTIAL_GROUPS.map((group) => {
       const enabled = enabledGroups[group.id] !== false;
       const selectionSettings = { ...settings, [group.enabledKey]: enabled };
-      const selection = group.statementSelectionKey && group.statementTypes
-        ? selectStatementTypes({
-          id: group.id,
-          label: group.label,
-          enabledKey: group.enabledKey,
-          statementSelectionKey: group.statementSelectionKey,
-          statementTypes: group.statementTypes,
-        }, selectionSettings, "display")
+      const selection = isStatementSelectionGroup(group)
+        ? selectStatementTypes(group, selectionSettings, "display")
         : { selectedIds: [], needsSetup: false };
       return { ...group, enabled, selectedStatementTypeIds: selection.selectedIds, statementSetupRequired: selection.needsSetup };
     });
@@ -120,19 +115,13 @@ function assertAutomationTaskCanStartInModel(taskId: string, model: AutomationDe
   const group = task.credentialGroupId
     ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
     : null;
-  if (group?.statementSelectionKey && group.statementTypes) {
+  if (group && isStatementSelectionGroup(group)) {
     const modelGroup = model.credentialGroups.find((candidate) => candidate.id === group.id);
     const selectionSettings = {
       ...readAutomationSettings(),
       ...(modelGroup ? { [group.enabledKey]: modelGroup.enabled } : {}),
     };
-    selectStatementTypes({
-      id: group.id,
-      label: group.label,
-      enabledKey: group.enabledKey,
-      statementSelectionKey: group.statementSelectionKey,
-      statementTypes: group.statementTypes,
-    }, selectionSettings, "strict");
+    selectStatementTypes(group, selectionSettings, "strict");
   }
   const missing = missingCredentialKeys(taskId, model.automation.credentials);
   if (missing.length > 0) throw new Error(`Missing credentials: ${missing.join(", ")}`);
@@ -151,14 +140,8 @@ export function automationSaveCredentials(updates: Record<string, string>) {
   const split = splitAutomationUpdates(updates);
   const nextSettings = { ...readAutomationSettings(), ...split.settings };
   for (const group of AUTOMATION_CREDENTIAL_GROUPS) {
-    if (!group.statementSelectionKey || !group.statementTypes) continue;
-    const selection = selectStatementTypes({
-      id: group.id,
-      label: group.label,
-      enabledKey: group.enabledKey,
-      statementSelectionKey: group.statementSelectionKey,
-      statementTypes: group.statementTypes,
-    }, nextSettings, "strict");
+    if (!isStatementSelectionGroup(group)) continue;
+    const selection = selectStatementTypes(group, nextSettings, "strict");
     if (Object.hasOwn(split.settings, group.statementSelectionKey)) {
       nextSettings[group.statementSelectionKey] = selection.selectedIds.join(",");
     }

--- a/src/lib/automation/server/human-session.check.ts
+++ b/src/lib/automation/server/human-session.check.ts
@@ -65,6 +65,70 @@ test("force quit persists failure before surfacing cleanup failure", async () =>
   }
 });
 
+test("force quit finalizes the exact waiting run without appending a log", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-force-quit-success-"));
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const run = createTaskRun(db, {
+      taskId: "fubon-all-statements",
+      script: "run:fubon-all-statements",
+      kind: "crawler",
+      status: "waiting_for_human",
+      attempt: 1,
+      maxAttempts: 1,
+      startedAt: new Date().toISOString(),
+      logPath: join(ledgerDir, "force-quit-success.log"),
+      logTail: "Workflow paused. run `npx libretto resume --session ses-force-quit`.",
+    });
+    db.close();
+
+    assert.deepEqual(
+      await forceQuitHumanSessionForTask("fubon-all-statements", ledgerDir, {
+        readSessionState() { return null; },
+        claimSession() { return true; },
+        async finalizeSession() { return true; },
+      }),
+      { session: "ses-force-quit" },
+    );
+
+    const verifiedDb = openLedgerDatabase(ledgerDir, { readOnly: true });
+    assert.equal(taskRunById(verifiedDb, run.taskRunId)?.status, "failed");
+    verifiedDb.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("force quit leaves a waiting run when its session identity is missing", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-force-quit-missing-session-"));
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const run = createTaskRun(db, {
+      taskId: "fubon-all-statements",
+      script: "run:fubon-all-statements",
+      kind: "crawler",
+      status: "waiting_for_human",
+      attempt: 1,
+      maxAttempts: 1,
+      startedAt: new Date().toISOString(),
+      logPath: join(ledgerDir, "force-quit-missing-session.log"),
+      logTail: "Workflow paused.",
+    });
+    db.close();
+
+    await assert.rejects(
+      forceQuitHumanSessionForTask("fubon-all-statements", ledgerDir),
+      /Missing Libretto resume session/,
+    );
+
+    const verifiedDb = openLedgerDatabase(ledgerDir, { readOnly: true });
+    assert.equal(taskRunById(verifiedDb, run.taskRunId)?.status, "waiting_for_human");
+    verifiedDb.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
 test("force quit leaves a resumed owner untouched", async () => {
   const ledgerDir = mkdtempSync(join(tmpdir(), "automation-force-quit-owner-"));
   const newer = {

--- a/src/lib/automation/server/human-session.ts
+++ b/src/lib/automation/server/human-session.ts
@@ -1,13 +1,11 @@
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
-import { readLibrettoSessionState } from "./libretto-session.ts";
-import { appendCleanupError, resumeSessionFromLog } from "./runner.ts";
+import { resumeSessionFromLog } from "./runner.ts";
 import {
-  claimAutomationSessionForCleanup,
-  finalizeExactOwnedAutomationSession,
-} from "./session-lifecycle.ts";
+  finalizeForceQuitTaskRun,
+  type ForceQuitFinalizationDependencies,
+} from "./task-run-finalization.ts";
 import {
   latestTaskRuns,
-  updateTaskRun,
   type AutomationTaskRun,
 } from "./store.ts";
 import { taskById } from "./tasks.ts";
@@ -39,11 +37,7 @@ export function humanSessionForTask(taskId: string, ledgerDir = process.env.LEDG
 export async function forceQuitHumanSessionForTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
-  dependencies: Partial<{
-    readSessionState: typeof readLibrettoSessionState;
-    claimSession: typeof claimAutomationSessionForCleanup;
-    finalizeSession: typeof finalizeExactOwnedAutomationSession;
-  }> = {},
+  dependencies: ForceQuitFinalizationDependencies = {},
 ) {
   if (!taskById(taskId)) throw new Error(`Unknown automation task: ${taskId}`);
 
@@ -52,46 +46,7 @@ export async function forceQuitHumanSessionForTask(
     const run = latestTaskRuns(db)[taskId];
     if (!run) throw new Error(`Automation task is not waiting for human input: ${taskId}`);
     const session = humanSessionFromRun(run, taskId);
-    const deps = {
-      readSessionState: readLibrettoSessionState,
-      claimSession: claimAutomationSessionForCleanup,
-      finalizeSession: finalizeExactOwnedAutomationSession,
-      ...dependencies,
-    };
-    let cleanupFailure: unknown = null;
-    try {
-      const owner = {
-        taskId,
-        taskRunId: run.taskRunId,
-        session,
-        pid: deps.readSessionState(session)?.pid ?? null,
-      };
-      if (!deps.claimSession(owner)) {
-        throw new Error(`Automation session ownership changed for task: ${taskId}`);
-      }
-      if (!await deps.finalizeSession(owner)) {
-        throw new Error(`Automation session ownership changed for task: ${taskId}`);
-      }
-    } catch (error) {
-      cleanupFailure = error;
-    }
-
-    updateTaskRun(db, run.taskRunId, {
-      status: "failed",
-      finishedAt: new Date().toISOString(),
-      exitCode: null,
-      signal: null,
-      errorMessage: cleanupFailure
-        ? appendCleanupError(
-          "Browser session force quit.",
-          cleanupFailure instanceof Error ? cleanupFailure.message : String(cleanupFailure),
-        )
-        : "Browser session force quit.",
-      logTail: run.logTail,
-    });
-
-    if (cleanupFailure) throw cleanupFailure;
-    return { session };
+    return await finalizeForceQuitTaskRun(db, run, session, dependencies);
   } finally {
     db.close();
   }

--- a/src/lib/automation/server/human-session.ts
+++ b/src/lib/automation/server/human-session.ts
@@ -1,9 +1,9 @@
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
-import { resumeSessionFromLog } from "./runner.ts";
 import {
   finalizeForceQuitTaskRun,
   type ForceQuitFinalizationDependencies,
 } from "./task-run-finalization.ts";
+import { resumeSessionFromLog } from "./automation-session-disposition.ts";
 import {
   latestTaskRuns,
   type AutomationTaskRun,
@@ -45,8 +45,7 @@ export async function forceQuitHumanSessionForTask(
   try {
     const run = latestTaskRuns(db)[taskId];
     if (!run) throw new Error(`Automation task is not waiting for human input: ${taskId}`);
-    const session = humanSessionFromRun(run, taskId);
-    return await finalizeForceQuitTaskRun(db, run, session, dependencies);
+    return await finalizeForceQuitTaskRun(db, run, dependencies);
   } finally {
     db.close();
   }

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -50,21 +50,6 @@ import {
   startAutomationTask,
   startAutomationTasks,
 } from "./runner.ts";
-import { assertTaskStatementSelection, taskById } from "./tasks.ts";
-
-test("fresh statement tasks require a saved selection", () => {
-  const task = taskById("fubon-all-statements");
-  assert.ok(task);
-  assert.throws(
-    () => assertTaskStatementSelection(task, { LIBRETTO_CLOUD_FUBON_ENABLED: true }),
-    /Select at least one Fubon/,
-  );
-  assert.doesNotThrow(() => assertTaskStatementSelection(task, {
-    LIBRETTO_CLOUD_FUBON_ENABLED: true,
-    LIBRETTO_CLOUD_FUBON_STATEMENT_TYPES: "deposit",
-  }));
-});
-
 test("manual and scheduled fresh starts require a saved selection", () => {
   const dir = mkdtempSync(join(tmpdir(), "automation-start-selection-"));
   const originalCwd = process.cwd();

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -145,7 +145,7 @@ assert.deepEqual(
 );
 
 test("persisted session recovery uses a bounded log read", () => {
-  const source = readFileSync(new URL("./runner.ts", import.meta.url), "utf8");
+  const source = readFileSync(new URL("./task-run-finalization.ts", import.meta.url), "utf8");
   assert.doesNotMatch(source, /readFileSync\(run\.logPath/);
   assert.match(source, /readSync\([^;]+SESSION_LOG_PREFIX_BYTES/s);
 });

--- a/src/lib/automation/server/runner.check.ts
+++ b/src/lib/automation/server/runner.check.ts
@@ -145,7 +145,7 @@ assert.deepEqual(
 );
 
 test("persisted session recovery uses a bounded log read", () => {
-  const source = readFileSync(new URL("./task-run-finalization.ts", import.meta.url), "utf8");
+  const source = readFileSync(new URL("./automation-session-disposition.ts", import.meta.url), "utf8");
   assert.doesNotMatch(source, /readFileSync\(run\.logPath/);
   assert.match(source, /readSync\([^;]+SESSION_LOG_PREFIX_BYTES/s);
 });

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -36,10 +36,11 @@ import {
   type AutomationTaskStatus,
 } from "./store.ts";
 import {
-  assertTaskStatementSelection,
+  AUTOMATION_CREDENTIAL_GROUPS,
   taskById,
   type AutomationTaskKind,
 } from "./tasks.ts";
+import { selectStatementTypes } from "../statement-selection.ts";
 import { readAutomationSettings } from "./settings.ts";
 
 export { closeLibrettoSession };
@@ -357,7 +358,18 @@ export function startAutomationTask(
   const task = taskById(taskId);
   if (!task) throw new Error(`Unknown automation task: ${taskId}`);
   validateScheduledAtUtc(options.scheduledAtUtc);
-  assertTaskStatementSelection(task, readAutomationSettings());
+  const group = task.credentialGroupId
+    ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
+    : null;
+  if (group?.statementSelectionKey && group.statementTypes) {
+    selectStatementTypes({
+      id: group.id,
+      label: group.label,
+      enabledKey: group.enabledKey,
+      statementSelectionKey: group.statementSelectionKey,
+      statementTypes: group.statementTypes,
+    }, readAutomationSettings(), "strict");
+  }
   claimTask(taskId);
   void runAutomationTask(taskId, ledgerDir, {
     claimed: true,
@@ -375,7 +387,18 @@ export function startAutomationTasks(
   for (const taskId of uniqueTaskIds) {
     const task = taskById(taskId);
     if (!task) throw new Error(`Unknown automation task: ${taskId}`);
-    assertTaskStatementSelection(task, readAutomationSettings());
+    const group = task.credentialGroupId
+      ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
+      : null;
+    if (group?.statementSelectionKey && group.statementTypes) {
+      selectStatementTypes({
+        id: group.id,
+        label: group.label,
+        enabledKey: group.enabledKey,
+        statementSelectionKey: group.statementSelectionKey,
+        statementTypes: group.statementTypes,
+      }, readAutomationSettings(), "strict");
+    }
     if (activeTaskRunIds.has(taskId)) throw new Error(`Automation task is already running: ${taskId}`);
   }
   for (const taskId of uniqueTaskIds) {

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -599,6 +599,260 @@ export async function shutdownAutomationSessions(
   if (errors.length) throw new AggregateError(errors, "Failed to shut down automation sessions");
 }
 
+type AutomationTaskRunExecution = {
+  task: NonNullable<ReturnType<typeof taskById>>;
+  taskDb: ReturnType<typeof openLedgerDatabase>;
+  run: Pick<AutomationTaskRun, "taskRunId">;
+  logPath: string;
+  command: ReturnType<typeof resolveTaskCommand>;
+  session: string | null;
+  owner: OwnedAutomationSession | null;
+};
+
+type AutomationTaskProcessResult = {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  error: Error | null;
+  logTail: string;
+  resumeFailure: string | null;
+  statementSummary: StatementRunSummary | null;
+  outputPersistenceWarnings: string[];
+};
+
+function createAutomationTaskRunExecution(
+  task: NonNullable<ReturnType<typeof taskById>>,
+  taskDb: ReturnType<typeof openLedgerDatabase>,
+  options: StartAutomationTaskOptions & { resumeSession?: string },
+): AutomationTaskRunExecution | null {
+  const attempt = 1;
+  const maxAttempts = 1;
+  const startedAt = new Date().toISOString();
+  const logPath = join(
+    "data",
+    "automation",
+    "logs",
+    `${task.id}-${Date.now()}-${attempt}.log`,
+  );
+  const env = automationProcessEnv();
+  const isLibrettoTask = task.command[0] === "libretto";
+  const session = isLibrettoTask
+    ? options.resumeSession ?? createAutomationSessionId()
+    : null;
+  const command = resolveTaskCommand(task, {
+    resumeSession: options.resumeSession,
+    session: options.resumeSession ? undefined : session ?? undefined,
+  }, env);
+  if (task.id === "exchange-rates" && options.scheduledAtUtc) {
+    if (command.command === "npm") command.args.push("--");
+    command.args.push("--scheduled-at-utc", options.scheduledAtUtc);
+    command.display += ` --scheduled-at-utc ${options.scheduledAtUtc}`;
+  }
+  const run = createTaskRun(taskDb, {
+    taskId: task.id,
+    script: command.display,
+    kind: task.kind,
+    status: "running",
+    attempt,
+    maxAttempts,
+    startedAt,
+    logPath,
+  });
+  activeTaskRunIds.set(task.id, run.taskRunId);
+  const owner = session ? {
+    taskId: task.id,
+    taskRunId: run.taskRunId,
+    session,
+    pid: sessionPid(session),
+  } : null;
+  if (session) {
+    appendLog(logPath, "automation-session: " + session + "\n");
+    const resumeFrom = options.resumeSession
+      ? activeTaskRuns(taskDb).find((candidate) =>
+        candidate.taskId === task.id
+        && candidate.taskRunId !== run.taskRunId
+        && candidate.status === "waiting_for_human"
+        && sessionFromRun(candidate) === options.resumeSession
+      )
+      : undefined;
+    if (!claimRunAutomationSession(taskDb, run.taskRunId, owner!, {
+      resumeSession: options.resumeSession,
+      resumeFrom,
+    })) return null;
+  }
+  return { task, taskDb, run, logPath, command, session, owner };
+}
+
+async function executeAutomationTaskProcess(
+  execution: AutomationTaskRunExecution,
+): Promise<AutomationTaskProcessResult> {
+  let logTail = "";
+  let detectedResumeFailure: string | null = null;
+  let statementSummary: StatementRunSummary | null = null;
+  const outputPersistenceWarnings: string[] = [];
+  const result = await new Promise<Pick<AutomationTaskProcessResult, "exitCode" | "signal" | "error">>((resolve) => {
+    const recordOutputPersistenceError = (error: unknown) => {
+      const line = `automation-output-write-failed: ${errorMessage(error)}`;
+      console.error(line);
+      logTail = tail(`${logTail}\n${line}\n`);
+      outputPersistenceWarnings.push(line);
+    };
+    const outputBuffer = createAutomationOutputBuffer(
+      () => {
+        if (!isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) {
+          updateTaskRun(execution.taskDb, execution.run.taskRunId, liveTaskRunUpdate(logTail));
+        }
+      },
+      500,
+      recordOutputPersistenceError,
+    );
+    const onOutput = (chunk: Buffer) => {
+      const output = accumulateAutomationOutput(
+        { logTail, resumeFailure: detectedResumeFailure },
+        chunk.toString("utf8"),
+      );
+      statementSummary = parseStatementRunSummary(`${logTail}${output.logChunk}`)
+        ?? statementSummary;
+      logTail = output.logTail;
+      detectedResumeFailure = output.resumeFailure;
+      try {
+        appendLog(execution.logPath, output.logChunk);
+      } catch (error) {
+        recordOutputPersistenceError(error);
+      }
+      outputBuffer.push(output.logChunk);
+      if (execution.owner) {
+        ownAutomationSession({ ...execution.owner, pid: sessionPid(execution.owner.session) });
+      }
+    };
+    const child = spawn(execution.command.command, execution.command.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: execution.command.env,
+    });
+    activeTaskChildren.set(execution.task.id, child);
+    child.stdout.on("data", onOutput);
+    child.stderr.on("data", onOutput);
+    child.on("error", (error) => {
+      activeTaskChildren.delete(execution.task.id);
+      outputBuffer.flush();
+      resolve({ exitCode: null, signal: null, error });
+    });
+    child.on("close", (exitCode, signal) => {
+      activeTaskChildren.delete(execution.task.id);
+      outputBuffer.flush();
+      resolve({ exitCode, signal, error: null });
+    });
+  });
+  return {
+    ...result,
+    logTail,
+    resumeFailure: detectedResumeFailure ?? resumeFailureMessage(logTail),
+    statementSummary,
+    outputPersistenceWarnings,
+  };
+}
+
+function scheduleAutomationTaskRunTimeout(
+  execution: AutomationTaskRunExecution,
+  ledgerDir: string,
+) {
+  if (!execution.session) return;
+  const timeoutOwner = {
+    taskId: execution.task.id,
+    taskRunId: execution.run.taskRunId,
+    session: execution.session,
+  };
+  armAutomationSessionTimeout(execution.task.id, async () => {
+    const timeoutDb = openLedgerDatabase(ledgerDir);
+    try {
+      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
+      let timeoutError: string | null = null;
+      try {
+        await finalizeExactOwnedAutomationSession(timeoutOwner);
+      } catch (error) {
+        timeoutError = errorMessage(error);
+      }
+      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
+      updateTaskRun(timeoutDb, execution.run.taskRunId, {
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        exitCode: null,
+        signal: null,
+        errorMessage: timeoutError
+          ? appendCleanupError("等待人工操作超過 20 分鐘", timeoutError)
+          : "等待人工操作超過 20 分鐘",
+      });
+    } catch (error) {
+      console.error("automation-session-timeout-failed", error);
+    } finally {
+      timeoutDb.close();
+    }
+  });
+}
+
+async function finalizeAutomationTaskRun(
+  execution: AutomationTaskRunExecution,
+  result: AutomationTaskProcessResult,
+  ledgerDir: string,
+) {
+  const resumeFailure = result.resumeFailure;
+  let status: AutomationTaskStatus = result.error || resumeFailure
+    ? "failed"
+    : nextAttemptStatus({
+      kind: execution.task.kind,
+      attempt: 1,
+      maxAttempts: 1,
+      exitCode: result.exitCode,
+      waitingForHuman: shouldMarkWaitingForHuman(result.logTail),
+    });
+  if (status === "completed" && result.statementSummary) status = result.statementSummary.status;
+  const statementFailure = result.statementSummary?.status === "failed"
+    ? result.statementSummary.results
+      .filter((component) => component.status === "failed")
+      .map((component) => `${component.typeId}: ${component.error ?? "Failed"}`)
+      .join("\n") || "No statement components completed."
+    : null;
+  let taskError = result.error?.message
+    ?? resumeFailure
+    ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
+  taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
+  if (execution.owner && !shouldRetainAutomationSession(status)) {
+    const retainedOwner = ownedAutomationSession(execution.task.id) ?? execution.owner;
+    const cleanup = await finalizeTerminalAutomationSession(
+      retainedOwner,
+      taskError,
+      () => finalizeExactOwnedAutomationSession(execution.owner!),
+    );
+    taskError = cleanup.errorMessage;
+    if (cleanup.cleanupFailed && (status === "completed" || status === "partial")) status = "failed";
+  }
+  if (isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) return { status: "failed" as const };
+  let logTail = result.logTail;
+  if (result.statementSummary) {
+    const summaryLine = statementRunSummaryLine(result.statementSummary.results);
+    try {
+      appendLog(execution.logPath, `\n${summaryLine}\n`);
+    } catch (error) {
+      const warning = `automation-output-write-failed: ${errorMessage(error)}`;
+      console.error(warning);
+      taskError = [taskError, warning].filter(Boolean).join("\n") || null;
+      logTail = tail(`${logTail}\n${warning}\n`);
+    }
+    logTail = tail(`${logTail}\n${summaryLine}\n`);
+  }
+  updateTaskRun(execution.taskDb, execution.run.taskRunId, {
+    status,
+    finishedAt: new Date().toISOString(),
+    exitCode: result.exitCode,
+    signal: result.signal,
+    logTail,
+    errorMessage: taskError,
+  });
+  if (execution.session && shouldRetainAutomationSession(status)) {
+    scheduleAutomationTaskRunTimeout(execution, ledgerDir);
+  }
+  return { status };
+}
+
 export async function runAutomationTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
@@ -612,226 +866,10 @@ export async function runAutomationTask(
   let db: ReturnType<typeof openLedgerDatabase> | null = null;
   try {
     db = openLedgerDatabase(ledgerDir);
-    const taskDb = db;
-    const maxAttempts = 1;
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      const startedAt = new Date().toISOString();
-      const logPath = join(
-        "data",
-        "automation",
-        "logs",
-        `${task.id}-${Date.now()}-${attempt}.log`,
-      );
-      const env = automationProcessEnv();
-      const isLibrettoTask = task.command[0] === "libretto";
-      const session = isLibrettoTask
-        ? options.resumeSession ?? createAutomationSessionId()
-        : null;
-      const command = resolveTaskCommand(task, {
-        resumeSession: options.resumeSession,
-        session: options.resumeSession ? undefined : session ?? undefined,
-      }, env);
-      if (task.id === "exchange-rates" && options.scheduledAtUtc) {
-        if (command.command === "npm") command.args.push("--");
-        command.args.push("--scheduled-at-utc", options.scheduledAtUtc);
-        command.display += ` --scheduled-at-utc ${options.scheduledAtUtc}`;
-      }
-      const script = command.display;
-      const run = createTaskRun(taskDb, {
-        taskId: task.id,
-        script,
-        kind: task.kind,
-        status: "running",
-        attempt,
-        maxAttempts,
-        startedAt,
-        logPath,
-      });
-      activeTaskRunIds.set(task.id, run.taskRunId);
-      const owner = session ? {
-        taskId: task.id,
-        taskRunId: run.taskRunId,
-        session,
-        pid: sessionPid(session),
-      } : null;
-      if (session) {
-        appendLog(logPath, "automation-session: " + session + "\n");
-        const resumeFrom = options.resumeSession
-          ? activeTaskRuns(taskDb).find((candidate) =>
-            candidate.taskId === task.id
-            && candidate.taskRunId !== run.taskRunId
-            && candidate.status === "waiting_for_human"
-            && sessionFromRun(candidate) === options.resumeSession
-          )
-          : undefined;
-        if (!claimRunAutomationSession(taskDb, run.taskRunId, owner!, {
-          resumeSession: options.resumeSession,
-          resumeFrom,
-        })) {
-          return { status: "failed" as const };
-        }
-      }
-      let logTail = "";
-      let detectedResumeFailure: string | null = null;
-      const detectedStatementSummary: { value: StatementRunSummary | null } = { value: null };
-      const outputPersistenceWarnings: string[] = [];
-
-      const result = await new Promise<{
-        exitCode: number | null;
-        signal: NodeJS.Signals | null;
-        error: Error | null;
-      }>((resolve) => {
-        const recordOutputPersistenceError = (error: unknown) => {
-          const line = `automation-output-write-failed: ${errorMessage(error)}`;
-          console.error(line);
-          logTail = tail(`${logTail}\n${line}\n`);
-          outputPersistenceWarnings.push(line);
-        };
-        const outputBuffer = createAutomationOutputBuffer(
-          () => {
-            if (!isForceQuitRun(taskRunById(taskDb, run.taskRunId))) {
-              updateTaskRun(taskDb, run.taskRunId, liveTaskRunUpdate(logTail));
-            }
-          },
-          500,
-          recordOutputPersistenceError,
-        );
-        const onOutput = (chunk: Buffer) => {
-          const output = accumulateAutomationOutput(
-            { logTail, resumeFailure: detectedResumeFailure },
-            chunk.toString("utf8"),
-          );
-          detectedStatementSummary.value = parseStatementRunSummary(`${logTail}${output.logChunk}`)
-            ?? detectedStatementSummary.value;
-          logTail = output.logTail;
-          detectedResumeFailure = output.resumeFailure;
-          try {
-            appendLog(logPath, output.logChunk);
-          } catch (error) {
-            recordOutputPersistenceError(error);
-          }
-          outputBuffer.push(output.logChunk);
-          if (session) {
-            ownAutomationSession({
-              taskId: task.id,
-              taskRunId: run.taskRunId,
-              session,
-              pid: sessionPid(session),
-            });
-          }
-        };
-        const child = spawn(command.command, command.args, {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: command.env,
-        });
-        activeTaskChildren.set(task.id, child);
-        child.stdout.on("data", onOutput);
-        child.stderr.on("data", onOutput);
-        child.on("error", (error) => {
-          activeTaskChildren.delete(task.id);
-          outputBuffer.flush();
-          resolve({ exitCode: null, signal: null, error });
-        });
-        child.on("close", (exitCode, signal) => {
-          activeTaskChildren.delete(task.id);
-          outputBuffer.flush();
-          resolve({ exitCode, signal, error: null });
-        });
-      });
-
-      const resumeFailure = detectedResumeFailure ?? resumeFailureMessage(logTail);
-      let status: AutomationTaskStatus = result.error || resumeFailure
-        ? "failed"
-        : nextAttemptStatus({
-          kind: task.kind,
-          attempt,
-          maxAttempts,
-          exitCode: result.exitCode,
-          waitingForHuman: shouldMarkWaitingForHuman(logTail),
-        });
-      if (status === "completed" && detectedStatementSummary.value) {
-        status = detectedStatementSummary.value.status;
-      }
-      const statementFailure = detectedStatementSummary.value?.status === "failed"
-        ? detectedStatementSummary.value.results
-          .filter((component) => component.status === "failed")
-          .map((component) => `${component.typeId}: ${component.error ?? "Failed"}`)
-          .join("\n") || "No statement components completed."
-        : null;
-      let taskError = result.error?.message
-        ?? resumeFailure
-        ?? (status === "failed" ? statementFailure || finalFailureMessage(logTail, result.exitCode) : null);
-      taskError = [taskError, ...outputPersistenceWarnings].filter(Boolean).join("\n") || null;
-      if (owner && !shouldRetainAutomationSession(status)) {
-        const retainedOwner = ownedAutomationSession(task.id) ?? owner;
-        const cleanup = await finalizeTerminalAutomationSession(
-          retainedOwner,
-          taskError,
-          () => finalizeExactOwnedAutomationSession(owner),
-        );
-        taskError = cleanup.errorMessage;
-        if (cleanup.cleanupFailed && (status === "completed" || status === "partial")) {
-          status = "failed";
-        }
-      }
-      if (isForceQuitRun(taskRunById(taskDb, run.taskRunId))) return { status: "failed" };
-      if (detectedStatementSummary.value) {
-        const summaryLine = statementRunSummaryLine(detectedStatementSummary.value.results);
-        try {
-          appendLog(logPath, `\n${summaryLine}\n`);
-        } catch (error) {
-          const warning = `automation-output-write-failed: ${errorMessage(error)}`;
-          console.error(warning);
-          taskError = [taskError, warning].filter(Boolean).join("\n") || null;
-          logTail = tail(`${logTail}\n${warning}\n`);
-        }
-        logTail = tail(`${logTail}\n${summaryLine}\n`);
-      }
-      updateTaskRun(taskDb, run.taskRunId, {
-        status,
-        finishedAt: new Date().toISOString(),
-        exitCode: result.exitCode,
-        signal: result.signal,
-        logTail,
-        errorMessage: taskError,
-      });
-      if (session && shouldRetainAutomationSession(status)) {
-        const timeoutOwner = {
-          taskId: task.id,
-          taskRunId: run.taskRunId,
-          session,
-        };
-        armAutomationSessionTimeout(task.id, async () => {
-          const timeoutDb = openLedgerDatabase(ledgerDir);
-          try {
-            if (taskRunById(timeoutDb, run.taskRunId)?.status !== "waiting_for_human") return;
-            let timeoutError: string | null = null;
-            try {
-              await finalizeExactOwnedAutomationSession(timeoutOwner);
-            } catch (error) {
-              timeoutError = errorMessage(error);
-            }
-            if (taskRunById(timeoutDb, run.taskRunId)?.status !== "waiting_for_human") return;
-            updateTaskRun(timeoutDb, run.taskRunId, {
-              status: "failed",
-              finishedAt: new Date().toISOString(),
-              exitCode: null,
-              signal: null,
-              errorMessage: timeoutError
-                ? appendCleanupError("等待人工操作超過 20 分鐘", timeoutError)
-                : "等待人工操作超過 20 分鐘",
-            });
-          } catch (error) {
-            console.error("automation-session-timeout-failed", error);
-          } finally {
-            timeoutDb.close();
-          }
-        });
-      }
-      if (status !== "completed") return { status };
-      return { status };
-    }
-    return { status: "failed" as const };
+    const execution = createAutomationTaskRunExecution(task, db, options);
+    if (!execution) return { status: "failed" as const };
+    const result = await executeAutomationTaskProcess(execution);
+    return await finalizeAutomationTaskRun(execution, result, ledgerDir);
   } finally {
     activeTaskRunIds.delete(taskId);
     activeTaskChildren.delete(taskId);

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -1,32 +1,23 @@
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { stripVTControlCharacters } from "node:util";
+import { spawnSync } from "node:child_process";
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { resolvePatchCommand } from "./desktop-command.ts";
 import {
-  parseStatementRunSummary,
-  type StatementRunSummary,
-} from "../statement-run-summary.ts";
-import {
-  resolvePatchCommand,
-  resolveTaskCommand,
-} from "./desktop-command.ts";
-import { automationConfigEnv } from "./config-files.ts";
-import { validateLibrettoSessionName } from "./libretto-session.ts";
-import {
-  appendLog,
-  errorMessage,
-  finalizeAutomationTaskRun,
   finalizePersistedActiveRuns,
   finalizePersistedRun,
-  isForceQuitRun,
-  sessionFromRun,
-  sessionPid,
-  shouldMarkWaitingForHuman,
-  tail,
-  type AutomationTaskProcessResult,
-  type AutomationTaskRunExecution,
 } from "./task-run-finalization.ts";
+import {
+  accumulateAutomationOutput,
+  automationProcessEnv,
+  automationTaskChild,
+  claimRunAutomationSession,
+  createAutomationOutputBuffer,
+  createAutomationSessionId,
+  liveTaskRunUpdate,
+  parseAutomationProgress,
+  resumeFailureMessage,
+  runAutomationTaskExecution,
+  terminateAutomationTaskProcesses,
+} from "./task-run-execution.ts";
 export {
   appendCleanupError,
   automationCleanupFailureDetails,
@@ -39,22 +30,22 @@ export {
   shouldMarkWaitingForHuman,
   shouldRetainAutomationSession,
 } from "./task-run-finalization.ts";
+export {
+  accumulateAutomationOutput,
+  automationProcessEnv,
+  claimRunAutomationSession,
+  createAutomationOutputBuffer,
+  createAutomationSessionId,
+  liveTaskRunUpdate,
+  parseAutomationProgress,
+  resumeFailureMessage,
+} from "./task-run-execution.ts";
 import {
   closeLibrettoSession,
-  disarmAutomationSessionTimeout,
   finalizeAllOwnedAutomationSessions,
   finalizeOwnedAutomationSession,
-  ownAutomationSession,
-  ownedAutomationSession,
-  restoreAutomationSessionOwnership,
-  type OwnedAutomationSession,
 } from "./session-lifecycle.ts";
 import {
-  activeTaskRuns,
-  createTaskRun,
-  taskRunById,
-  updateTaskRun,
-  type AutomationTaskRun,
   type AutomationTaskStatus,
 } from "./store.ts";
 import {
@@ -70,7 +61,6 @@ import { readAutomationSettings } from "./settings.ts";
 export { closeLibrettoSession };
 
 const activeTaskRunIds = new Map<string, string>();
-const activeTaskChildren = new Map<string, ChildProcess>();
 let librettoRunCdpPatched = false;
 
 export type StartAutomationTaskOptions = {
@@ -83,38 +73,6 @@ function validateScheduledAtUtc(value: string | undefined) {
   )) {
     throw new Error(`Invalid scheduledAtUtc: ${value}`);
   }
-}
-
-export function createAutomationSessionId(uuid: () => string = randomUUID): string {
-  return validateLibrettoSessionName("ses-octopus-" + uuid());
-}
-
-export function resumeFailureMessage(output: string) {
-  return output.match(/Workflow failed after resume:\s*([^\r\n]+)/i)?.[1]?.trim() ?? null;
-}
-
-export function parseAutomationProgress(output: string) {
-  let progress: number | null = null;
-  for (const match of output.matchAll(/automation-progress:\s*(\d+(?:\.\d+)?)/gi)) {
-    const value = Math.round(Number(match[1]));
-    progress = Math.max(0, Math.min(100, value));
-  }
-  return progress;
-}
-
-export function automationProcessEnv(baseEnv: NodeJS.ProcessEnv = process.env) {
-  return automationConfigEnv({ baseEnv });
-}
-
-export function liveTaskRunUpdate(logTail: string) {
-  const resumeFailure = resumeFailureMessage(logTail);
-  if (resumeFailure) {
-    return { status: "failed" as const, errorMessage: resumeFailure, logTail };
-  }
-  if (shouldMarkWaitingForHuman(logTail)) {
-    return { status: "waiting_for_human" as const, logTail };
-  }
-  return { logTail };
 }
 
 export function shouldCloseResumeSession(input: {
@@ -162,42 +120,6 @@ function claimTask(taskId: string) {
   activeTaskRunIds.set(taskId, "pending");
 }
 
-export function createAutomationOutputBuffer(
-  write: (chunk: string) => void,
-  delayMs = 500,
-  onError: (error: unknown) => void = (error) => {
-    console.error("automation-output-write-failed", error);
-  },
-) {
-  let pending = "";
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  const flush = (retry: boolean) => {
-    if (timer) clearTimeout(timer);
-    timer = null;
-    if (!pending) return;
-    const chunk = pending;
-    pending = "";
-    try {
-      write(chunk);
-    } catch (error) {
-      pending = tail(chunk + pending);
-      if (retry) timer = setTimeout(() => flush(true), delayMs);
-      try {
-        onError(error);
-      } catch (handlerError) {
-        console.error("automation-output-error-handler-failed", handlerError);
-      }
-    }
-  };
-  return {
-    push(chunk: string) {
-      pending = tail(pending + chunk);
-      if (!timer) timer = setTimeout(() => flush(true), delayMs);
-    },
-    flush: () => flush(false),
-  };
-}
-
 export async function runWithConcurrency<T>(
   items: readonly T[],
   limit: number,
@@ -233,80 +155,6 @@ export async function runAutomationBatch(
     await execute("import-downloads-csv").catch((error) => { errors.push(error); });
   }
   if (errors.length) throw errors[0];
-}
-
-export function claimRunAutomationSession(
-  db: ReturnType<typeof openLedgerDatabase>,
-  taskRunId: string,
-  owner: OwnedAutomationSession,
-  options: { resumeSession?: string; resumeFrom?: AutomationTaskRun } = {},
-) {
-  const current = ownedAutomationSession(owner.taskId);
-  const resumeFrom = options.resumeFrom;
-  let claimError: unknown = null;
-  const isResumeHandoff = Boolean(
-    options.resumeSession
-      && options.resumeSession === owner.session
-      && resumeFrom?.status === "waiting_for_human"
-      && resumeFrom.taskId === owner.taskId
-      && resumeFrom.taskRunId !== taskRunId
-      && sessionFromRun(resumeFrom) === owner.session
-      && (!current
-        || (current.taskRunId === resumeFrom.taskRunId && current.session === owner.session)),
-  );
-  if ((!options.resumeSession || isResumeHandoff) && (!current || isResumeHandoff)) {
-    if (resumeFrom) {
-      const claimRejected = new Error("Automation session registry claim rejected");
-      let registryClaimed = false;
-      db.exec("BEGIN");
-      try {
-        updateTaskRun(db, resumeFrom.taskRunId, {
-          status: "failed",
-          finishedAt: new Date().toISOString(),
-          errorMessage: `Superseded by resume handoff: ${taskRunId}`,
-          logTail: tail(`${resumeFrom.logTail}\nautomation-resume-handoff: ${taskRunId}\n`),
-        });
-        if (!ownAutomationSession(owner)) throw claimRejected;
-        registryClaimed = true;
-        db.exec("COMMIT");
-        disarmAutomationSessionTimeout(owner.taskId);
-        return true;
-      } catch (error) {
-        try {
-          db.exec("ROLLBACK");
-        } finally {
-          if (registryClaimed) restoreAutomationSessionOwnership(owner, current);
-        }
-        claimError = error;
-      }
-    } else if (ownAutomationSession(owner)) {
-      disarmAutomationSessionTimeout(owner.taskId);
-      return true;
-    }
-  }
-  updateTaskRun(db, taskRunId, {
-    status: "failed",
-    finishedAt: new Date().toISOString(),
-    exitCode: null,
-    signal: null,
-    errorMessage: claimError && errorMessage(claimError) !== "Automation session registry claim rejected"
-      ? `Automation session handoff failed: ${errorMessage(claimError)}`
-      : "Automation session is still closing. Try again after cleanup finishes.",
-  });
-  return false;
-}
-
-export function accumulateAutomationOutput(
-  state: { logTail: string; resumeFailure: string | null },
-  chunk: string,
-) {
-  const logChunk = stripVTControlCharacters(chunk);
-  const combined = state.logTail + logChunk;
-  return {
-    logChunk,
-    logTail: tail(combined),
-    resumeFailure: state.resumeFailure ?? resumeFailureMessage(combined),
-  };
 }
 
 export function startAutomationTask(
@@ -394,7 +242,7 @@ export async function cancelAutomationTask(taskId: string) {
     activeTaskRunIds.delete(taskId);
     return { cancelled: taskId };
   }
-  const child = activeTaskChildren.get(taskId);
+  const child = automationTaskChild(taskId);
   if (!child) throw new Error(`Automation task has not started a process yet: ${taskId}`);
   child.kill("SIGTERM");
   await finalizeOwnedAutomationSession(taskId);
@@ -419,7 +267,7 @@ export async function shutdownAutomationSessions(
     finalizePersistedRuns: typeof finalizePersistedActiveRuns;
   }> = {},
 ) {
-  for (const child of activeTaskChildren.values()) child.kill("SIGTERM");
+  terminateAutomationTaskProcesses();
   const errors: unknown[] = [];
   const finalizeOwnedSessions = dependencies.finalizeOwnedSessions
     ?? finalizeAllOwnedAutomationSessions;
@@ -438,138 +286,6 @@ export async function shutdownAutomationSessions(
   if (errors.length) throw new AggregateError(errors, "Failed to shut down automation sessions");
 }
 
-function createAutomationTaskRunExecution(
-  task: NonNullable<ReturnType<typeof taskById>>,
-  taskDb: ReturnType<typeof openLedgerDatabase>,
-  options: StartAutomationTaskOptions & { resumeSession?: string },
-): AutomationTaskRunExecution | null {
-  const attempt = 1;
-  const maxAttempts = 1;
-  const startedAt = new Date().toISOString();
-  const logPath = join(
-    "data",
-    "automation",
-    "logs",
-    `${task.id}-${Date.now()}-${attempt}.log`,
-  );
-  const env = automationProcessEnv();
-  const isLibrettoTask = task.command[0] === "libretto";
-  const session = isLibrettoTask
-    ? options.resumeSession ?? createAutomationSessionId()
-    : null;
-  const command = resolveTaskCommand(task, {
-    resumeSession: options.resumeSession,
-    session: options.resumeSession ? undefined : session ?? undefined,
-  }, env);
-  if (task.id === "exchange-rates" && options.scheduledAtUtc) {
-    if (command.command === "npm") command.args.push("--");
-    command.args.push("--scheduled-at-utc", options.scheduledAtUtc);
-    command.display += ` --scheduled-at-utc ${options.scheduledAtUtc}`;
-  }
-  const run = createTaskRun(taskDb, {
-    taskId: task.id,
-    script: command.display,
-    kind: task.kind,
-    status: "running",
-    attempt,
-    maxAttempts,
-    startedAt,
-    logPath,
-  });
-  activeTaskRunIds.set(task.id, run.taskRunId);
-  const owner = session ? {
-    taskId: task.id,
-    taskRunId: run.taskRunId,
-    session,
-    pid: sessionPid(session),
-  } : null;
-  if (session) {
-    appendLog(logPath, "automation-session: " + session + "\n");
-    const resumeFrom = options.resumeSession
-      ? activeTaskRuns(taskDb).find((candidate) =>
-        candidate.taskId === task.id
-        && candidate.taskRunId !== run.taskRunId
-        && candidate.status === "waiting_for_human"
-        && sessionFromRun(candidate) === options.resumeSession
-      )
-      : undefined;
-    if (!claimRunAutomationSession(taskDb, run.taskRunId, owner!, {
-      resumeSession: options.resumeSession,
-      resumeFrom,
-    })) return null;
-  }
-  return { task, taskDb, run, logPath, command, session, owner };
-}
-
-async function executeAutomationTaskProcess(
-  execution: AutomationTaskRunExecution,
-): Promise<AutomationTaskProcessResult> {
-  let logTail = "";
-  let detectedResumeFailure: string | null = null;
-  let statementSummary: StatementRunSummary | null = null;
-  const outputPersistenceWarnings: string[] = [];
-  const result = await new Promise<Pick<AutomationTaskProcessResult, "exitCode" | "signal" | "error">>((resolve) => {
-    const recordOutputPersistenceError = (error: unknown) => {
-      const line = `automation-output-write-failed: ${errorMessage(error)}`;
-      console.error(line);
-      logTail = tail(`${logTail}\n${line}\n`);
-      outputPersistenceWarnings.push(line);
-    };
-    const outputBuffer = createAutomationOutputBuffer(
-      () => {
-        if (!isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) {
-          updateTaskRun(execution.taskDb, execution.run.taskRunId, liveTaskRunUpdate(logTail));
-        }
-      },
-      500,
-      recordOutputPersistenceError,
-    );
-    const onOutput = (chunk: Buffer) => {
-      const output = accumulateAutomationOutput(
-        { logTail, resumeFailure: detectedResumeFailure },
-        chunk.toString("utf8"),
-      );
-      statementSummary = parseStatementRunSummary(`${logTail}${output.logChunk}`)
-        ?? statementSummary;
-      logTail = output.logTail;
-      detectedResumeFailure = output.resumeFailure;
-      try {
-        appendLog(execution.logPath, output.logChunk);
-      } catch (error) {
-        recordOutputPersistenceError(error);
-      }
-      outputBuffer.push(output.logChunk);
-      if (execution.owner) {
-        ownAutomationSession({ ...execution.owner, pid: sessionPid(execution.owner.session) });
-      }
-    };
-    const child = spawn(execution.command.command, execution.command.args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: execution.command.env,
-    });
-    activeTaskChildren.set(execution.task.id, child);
-    child.stdout.on("data", onOutput);
-    child.stderr.on("data", onOutput);
-    child.on("error", (error) => {
-      activeTaskChildren.delete(execution.task.id);
-      outputBuffer.flush();
-      resolve({ exitCode: null, signal: null, error });
-    });
-    child.on("close", (exitCode, signal) => {
-      activeTaskChildren.delete(execution.task.id);
-      outputBuffer.flush();
-      resolve({ exitCode, signal, error: null });
-    });
-  });
-  return {
-    ...result,
-    logTail,
-    resumeFailure: detectedResumeFailure ?? resumeFailureMessage(logTail),
-    statementSummary,
-    outputPersistenceWarnings,
-  };
-}
-
 export async function runAutomationTask(
   taskId: string,
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
@@ -583,13 +299,11 @@ export async function runAutomationTask(
   let db: ReturnType<typeof openLedgerDatabase> | null = null;
   try {
     db = openLedgerDatabase(ledgerDir);
-    const execution = createAutomationTaskRunExecution(task, db, options);
-    if (!execution) return { status: "failed" as const };
-    const result = await executeAutomationTaskProcess(execution);
-    return await finalizeAutomationTaskRun(execution, result, ledgerDir);
+    return await runAutomationTaskExecution(task, db, ledgerDir, options, (taskRunId) => {
+      activeTaskRunIds.set(taskId, taskRunId);
+    });
   } finally {
     activeTaskRunIds.delete(taskId);
-    activeTaskChildren.delete(taskId);
     db?.close();
   }
 }

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -43,8 +43,8 @@ export {
 import {
   closeLibrettoSession,
   finalizeAllOwnedAutomationSessions,
-  finalizeOwnedAutomationSession,
 } from "./session-lifecycle.ts";
+import { relinquishAutomationSessionForTask } from "./automation-session-disposition.ts";
 import {
   type AutomationTaskStatus,
 } from "./store.ts";
@@ -245,7 +245,7 @@ export async function cancelAutomationTask(taskId: string) {
   const child = automationTaskChild(taskId);
   if (!child) throw new Error(`Automation task has not started a process yet: ${taskId}`);
   child.kill("SIGTERM");
-  await finalizeOwnedAutomationSession(taskId);
+  await relinquishAutomationSessionForTask(taskId);
   return { cancelled: taskId };
 }
 

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -1,12 +1,10 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { appendFileSync, closeSync, mkdirSync, openSync, readSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
 import {
   parseStatementRunSummary,
-  statementRunSummaryLine,
   type StatementRunSummary,
 } from "../statement-run-summary.ts";
 import {
@@ -14,13 +12,37 @@ import {
   resolveTaskCommand,
 } from "./desktop-command.ts";
 import { automationConfigEnv } from "./config-files.ts";
-import { readLibrettoSessionState, validateLibrettoSessionName } from "./libretto-session.ts";
+import { validateLibrettoSessionName } from "./libretto-session.ts";
 import {
-  armAutomationSessionTimeout,
+  appendLog,
+  errorMessage,
+  finalizeAutomationTaskRun,
+  finalizePersistedActiveRuns,
+  finalizePersistedRun,
+  isForceQuitRun,
+  sessionFromRun,
+  sessionPid,
+  shouldMarkWaitingForHuman,
+  tail,
+  type AutomationTaskProcessResult,
+  type AutomationTaskRunExecution,
+} from "./task-run-finalization.ts";
+export {
+  appendCleanupError,
+  automationCleanupFailureDetails,
+  automationSessionFromLog,
+  finalFailureMessage,
+  finalizeTerminalAutomationSession,
+  isForceQuitRun,
+  nextAttemptStatus,
+  resumeSessionFromLog,
+  shouldMarkWaitingForHuman,
+  shouldRetainAutomationSession,
+} from "./task-run-finalization.ts";
+import {
   closeLibrettoSession,
   disarmAutomationSessionTimeout,
   finalizeAllOwnedAutomationSessions,
-  finalizeExactOwnedAutomationSession,
   finalizeOwnedAutomationSession,
   ownAutomationSession,
   ownedAutomationSession,
@@ -38,7 +60,6 @@ import {
 import {
   AUTOMATION_CREDENTIAL_GROUPS,
   taskById,
-  type AutomationTaskKind,
 } from "./tasks.ts";
 import {
   isStatementSelectionGroup,
@@ -50,7 +71,6 @@ export { closeLibrettoSession };
 
 const activeTaskRunIds = new Map<string, string>();
 const activeTaskChildren = new Map<string, ChildProcess>();
-const SESSION_LOG_PREFIX_BYTES = 4_000;
 let librettoRunCdpPatched = false;
 
 export type StartAutomationTaskOptions = {
@@ -67,27 +87,6 @@ function validateScheduledAtUtc(value: string | undefined) {
 
 export function createAutomationSessionId(uuid: () => string = randomUUID): string {
   return validateLibrettoSessionName("ses-octopus-" + uuid());
-}
-
-export function automationSessionFromLog(output: string) {
-  return output.match(/automation-session:\s+([A-Za-z0-9._-]+)/i)?.[1] ?? null;
-}
-
-export function shouldRetainAutomationSession(status: AutomationTaskStatus) {
-  return status === "waiting_for_human";
-}
-
-export function appendCleanupError(message: string | null, cleanup: string) {
-  const suffix = "Session cleanup failed: " + cleanup;
-  return message ? message + "\n" + suffix : suffix;
-}
-
-export function shouldMarkWaitingForHuman(output: string) {
-  return /manual-(?:auth|otp)-required|workflow paused|resume --session|\benter\b[^\r\n]*(?:captcha|otp|verification|certificate)/i.test(output);
-}
-
-export function resumeSessionFromLog(output: string) {
-  return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
 }
 
 export function resumeFailureMessage(output: string) {
@@ -116,40 +115,6 @@ export function liveTaskRunUpdate(logTail: string) {
     return { status: "waiting_for_human" as const, logTail };
   }
   return { logTail };
-}
-
-export function finalFailureMessage(logTail: string, exitCode: number | null) {
-  const message = logTail
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .toReversed()
-    .find((line) =>
-      !/^automation-progress:/i.test(line) &&
-      !/^automation-output-write-failed:/i.test(line) &&
-      !/^libretto run CDP patch/i.test(line) &&
-      !/^Running workflow /i.test(line) &&
-      !/^Browser is still open\./i.test(line)
-    );
-  return message ?? `Task exited with code ${exitCode}`;
-}
-
-export function isForceQuitRun(
-  run: Pick<AutomationTaskRun, "status" | "errorMessage"> | null | undefined,
-) {
-  return run?.status === "failed" && run.errorMessage?.startsWith("Browser session force quit") === true;
-}
-
-export function nextAttemptStatus(input: {
-  kind: AutomationTaskKind;
-  attempt: number;
-  maxAttempts: number;
-  exitCode: number | null;
-  waitingForHuman?: boolean;
-}): AutomationTaskStatus {
-  if (input.exitCode === 0 && input.waitingForHuman) return "waiting_for_human";
-  if (input.exitCode === 0) return "completed";
-  return "failed";
 }
 
 export function shouldCloseResumeSession(input: {
@@ -195,11 +160,6 @@ function claimTask(taskId: string) {
     throw new Error(`Automation task is already running: ${taskId}`);
   }
   activeTaskRunIds.set(taskId, "pending");
-}
-
-function appendLog(logPath: string, chunk: string) {
-  mkdirSync(dirname(logPath), { recursive: true });
-  appendFileSync(logPath, chunk);
 }
 
 export function createAutomationOutputBuffer(
@@ -336,10 +296,6 @@ export function claimRunAutomationSession(
   return false;
 }
 
-function tail(value: string) {
-  return value.slice(-4000);
-}
-
 export function accumulateAutomationOutput(
   state: { logTail: string; resumeFailure: string | null },
   chunk: string,
@@ -445,123 +401,6 @@ export async function cancelAutomationTask(taskId: string) {
   return { cancelled: taskId };
 }
 
-function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
-
-export function automationCleanupFailureDetails(
-  owner: OwnedAutomationSession,
-  error: unknown,
-) {
-  return {
-    taskRunId: owner.taskRunId,
-    sessionId: owner.session,
-    retainedPid: owner.pid,
-    error: errorMessage(error),
-  };
-}
-
-export async function finalizeTerminalAutomationSession(
-  owner: OwnedAutomationSession,
-  workflowError: string | null,
-  finalize: () => Promise<unknown> = () => finalizeExactOwnedAutomationSession(owner),
-) {
-  try {
-    await finalize();
-    return { errorMessage: workflowError, cleanupFailed: false };
-  } catch (error) {
-    console.error(
-      "automation-session-cleanup-failed",
-      automationCleanupFailureDetails(owner, error),
-    );
-    return {
-      errorMessage: appendCleanupError(workflowError, errorMessage(error)),
-      cleanupFailed: true,
-    };
-  }
-}
-
-function sessionPid(session: string) {
-  try {
-    return readLibrettoSessionState(session)?.pid ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function sessionFromRun(run: AutomationTaskRun) {
-  try {
-    const buffer = Buffer.alloc(SESSION_LOG_PREFIX_BYTES);
-    const descriptor = openSync(run.logPath, "r");
-    let length: number;
-    try {
-      length = readSync(descriptor, buffer, 0, SESSION_LOG_PREFIX_BYTES, 0);
-    } finally {
-      closeSync(descriptor);
-    }
-    const output = buffer.toString("utf8", 0, length);
-    const session = automationSessionFromLog(output) ?? resumeSessionFromLog(output);
-    if (session) return session;
-  } catch {
-    // The bounded log tail remains the recovery source when the log file is unavailable.
-  }
-  return automationSessionFromLog(run.logTail) ?? resumeSessionFromLog(run.logTail);
-}
-
-async function finalizePersistedRun(
-  db: ReturnType<typeof openLedgerDatabase>,
-  run: AutomationTaskRun,
-  reason: string,
-) {
-  const session = sessionFromRun(run);
-  const pid = session ? sessionPid(session) : null;
-  let cleanupError: string | null = null;
-  if (!session) {
-    cleanupError = "Missing Libretto session identity";
-  } else {
-    ownAutomationSession({ taskId: run.taskId, taskRunId: run.taskRunId, session, pid });
-    try {
-      await finalizeOwnedAutomationSession(run.taskId);
-    } catch (error) {
-      cleanupError = errorMessage(error);
-    }
-  }
-  updateTaskRun(db, run.taskRunId, {
-    status: "failed",
-    finishedAt: new Date().toISOString(),
-    exitCode: null,
-    signal: null,
-    errorMessage: cleanupError
-      ? appendCleanupError(run.errorMessage ?? reason, cleanupError)
-      : run.errorMessage ?? reason,
-  });
-  appendLog(
-    run.logPath,
-    `automation-session-finalize: session=${session ?? "unknown"} pid=${pid ?? "unknown"} cleanup-error=${cleanupError ?? "none"}\n`,
-  );
-}
-
-async function finalizePersistedActiveRuns(
-  ledgerDir: string,
-  reason: string,
-  finalizeRun: typeof finalizePersistedRun = finalizePersistedRun,
-) {
-  const db = openLedgerDatabase(ledgerDir);
-  const errors: unknown[] = [];
-  try {
-    for (const run of activeTaskRuns(db)) {
-      try {
-        await finalizeRun(db, run, reason);
-      } catch (error) {
-        errors.push(error);
-      }
-    }
-  } finally {
-    db.close();
-  }
-  if (errors.length) throw new AggregateError(errors, "Failed to finalize persisted automation runs");
-}
-
 export async function recoverAbandonedAutomationSessions(
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
   dependencies: { finalizeRun?: typeof finalizePersistedRun } = {},
@@ -598,26 +437,6 @@ export async function shutdownAutomationSessions(
   }
   if (errors.length) throw new AggregateError(errors, "Failed to shut down automation sessions");
 }
-
-type AutomationTaskRunExecution = {
-  task: NonNullable<ReturnType<typeof taskById>>;
-  taskDb: ReturnType<typeof openLedgerDatabase>;
-  run: Pick<AutomationTaskRun, "taskRunId">;
-  logPath: string;
-  command: ReturnType<typeof resolveTaskCommand>;
-  session: string | null;
-  owner: OwnedAutomationSession | null;
-};
-
-type AutomationTaskProcessResult = {
-  exitCode: number | null;
-  signal: NodeJS.Signals | null;
-  error: Error | null;
-  logTail: string;
-  resumeFailure: string | null;
-  statementSummary: StatementRunSummary | null;
-  outputPersistenceWarnings: string[];
-};
 
 function createAutomationTaskRunExecution(
   task: NonNullable<ReturnType<typeof taskById>>,
@@ -749,108 +568,6 @@ async function executeAutomationTaskProcess(
     statementSummary,
     outputPersistenceWarnings,
   };
-}
-
-function scheduleAutomationTaskRunTimeout(
-  execution: AutomationTaskRunExecution,
-  ledgerDir: string,
-) {
-  if (!execution.session) return;
-  const timeoutOwner = {
-    taskId: execution.task.id,
-    taskRunId: execution.run.taskRunId,
-    session: execution.session,
-  };
-  armAutomationSessionTimeout(execution.task.id, async () => {
-    const timeoutDb = openLedgerDatabase(ledgerDir);
-    try {
-      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
-      let timeoutError: string | null = null;
-      try {
-        await finalizeExactOwnedAutomationSession(timeoutOwner);
-      } catch (error) {
-        timeoutError = errorMessage(error);
-      }
-      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
-      updateTaskRun(timeoutDb, execution.run.taskRunId, {
-        status: "failed",
-        finishedAt: new Date().toISOString(),
-        exitCode: null,
-        signal: null,
-        errorMessage: timeoutError
-          ? appendCleanupError("等待人工操作超過 20 分鐘", timeoutError)
-          : "等待人工操作超過 20 分鐘",
-      });
-    } catch (error) {
-      console.error("automation-session-timeout-failed", error);
-    } finally {
-      timeoutDb.close();
-    }
-  });
-}
-
-async function finalizeAutomationTaskRun(
-  execution: AutomationTaskRunExecution,
-  result: AutomationTaskProcessResult,
-  ledgerDir: string,
-) {
-  const resumeFailure = result.resumeFailure;
-  let status: AutomationTaskStatus = result.error || resumeFailure
-    ? "failed"
-    : nextAttemptStatus({
-      kind: execution.task.kind,
-      attempt: 1,
-      maxAttempts: 1,
-      exitCode: result.exitCode,
-      waitingForHuman: shouldMarkWaitingForHuman(result.logTail),
-    });
-  if (status === "completed" && result.statementSummary) status = result.statementSummary.status;
-  const statementFailure = result.statementSummary?.status === "failed"
-    ? result.statementSummary.results
-      .filter((component) => component.status === "failed")
-      .map((component) => `${component.typeId}: ${component.error ?? "Failed"}`)
-      .join("\n") || "No statement components completed."
-    : null;
-  let taskError = result.error?.message
-    ?? resumeFailure
-    ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
-  taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
-  if (execution.owner && !shouldRetainAutomationSession(status)) {
-    const retainedOwner = ownedAutomationSession(execution.task.id) ?? execution.owner;
-    const cleanup = await finalizeTerminalAutomationSession(
-      retainedOwner,
-      taskError,
-      () => finalizeExactOwnedAutomationSession(execution.owner!),
-    );
-    taskError = cleanup.errorMessage;
-    if (cleanup.cleanupFailed && (status === "completed" || status === "partial")) status = "failed";
-  }
-  if (isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) return { status: "failed" as const };
-  let logTail = result.logTail;
-  if (result.statementSummary) {
-    const summaryLine = statementRunSummaryLine(result.statementSummary.results);
-    try {
-      appendLog(execution.logPath, `\n${summaryLine}\n`);
-    } catch (error) {
-      const warning = `automation-output-write-failed: ${errorMessage(error)}`;
-      console.error(warning);
-      taskError = [taskError, warning].filter(Boolean).join("\n") || null;
-      logTail = tail(`${logTail}\n${warning}\n`);
-    }
-    logTail = tail(`${logTail}\n${summaryLine}\n`);
-  }
-  updateTaskRun(execution.taskDb, execution.run.taskRunId, {
-    status,
-    finishedAt: new Date().toISOString(),
-    exitCode: result.exitCode,
-    signal: result.signal,
-    logTail,
-    errorMessage: taskError,
-  });
-  if (execution.session && shouldRetainAutomationSession(status)) {
-    scheduleAutomationTaskRunTimeout(execution, ledgerDir);
-  }
-  return { status };
 }
 
 export async function runAutomationTask(

--- a/src/lib/automation/server/runner.ts
+++ b/src/lib/automation/server/runner.ts
@@ -40,7 +40,10 @@ import {
   taskById,
   type AutomationTaskKind,
 } from "./tasks.ts";
-import { selectStatementTypes } from "../statement-selection.ts";
+import {
+  isStatementSelectionGroup,
+  selectStatementTypes,
+} from "../statement-selection.ts";
 import { readAutomationSettings } from "./settings.ts";
 
 export { closeLibrettoSession };
@@ -361,14 +364,8 @@ export function startAutomationTask(
   const group = task.credentialGroupId
     ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
     : null;
-  if (group?.statementSelectionKey && group.statementTypes) {
-    selectStatementTypes({
-      id: group.id,
-      label: group.label,
-      enabledKey: group.enabledKey,
-      statementSelectionKey: group.statementSelectionKey,
-      statementTypes: group.statementTypes,
-    }, readAutomationSettings(), "strict");
+  if (group && isStatementSelectionGroup(group)) {
+    selectStatementTypes(group, readAutomationSettings(), "strict");
   }
   claimTask(taskId);
   void runAutomationTask(taskId, ledgerDir, {
@@ -384,20 +381,16 @@ export function startAutomationTasks(
   ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
 ) {
   const uniqueTaskIds = [...new Set(taskIds)];
+  let settings: ReturnType<typeof readAutomationSettings> | undefined;
   for (const taskId of uniqueTaskIds) {
     const task = taskById(taskId);
     if (!task) throw new Error(`Unknown automation task: ${taskId}`);
     const group = task.credentialGroupId
       ? AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId)
       : null;
-    if (group?.statementSelectionKey && group.statementTypes) {
-      selectStatementTypes({
-        id: group.id,
-        label: group.label,
-        enabledKey: group.enabledKey,
-        statementSelectionKey: group.statementSelectionKey,
-        statementTypes: group.statementTypes,
-      }, readAutomationSettings(), "strict");
+    if (group && isStatementSelectionGroup(group)) {
+      settings ??= readAutomationSettings();
+      selectStatementTypes(group, settings, "strict");
     }
     if (activeTaskRunIds.has(taskId)) throw new Error(`Automation task is already running: ${taskId}`);
   }

--- a/src/lib/automation/server/session-lifecycle.ts
+++ b/src/lib/automation/server/session-lifecycle.ts
@@ -170,22 +170,46 @@ async function closeOwnedSession(
   owned: OwnedAutomationSession,
   deps: FinalizeSessionDeps,
 ): Promise<void> {
-  let pid = owned.pid;
-  let readError: unknown = null;
+  const { pid, readError } = readOwnedSessionPid(owned);
+  const { closeError, helperTerminationError } = await closeSessionHelper(owned.session, deps);
+
   if (pid === null) {
-    try {
-      pid = readLibrettoSessionState(owned.session)?.pid ?? null;
-    } catch (error) {
-      readError = error;
+    if (closeError) {
+      const readContext = readError ? ` state read: ${String(readError)};` : "";
+      throw new Error(
+        `Could not close Libretto session ${owned.session}:${readContext} graceful close: ${String(closeError)}`,
+      );
     }
+    return;
   }
-  let closeError: unknown = null;
-  const closeHandle = deps.startCloseSession?.(owned.session) ?? {
-    completion: deps.closeSession(owned.session),
-    terminate: async () => { await deps.terminateCloseSession?.(owned.session); },
+
+  const daemonError = await terminateOwnedDaemon(pid, owned.session, deps);
+  throwSessionFinalizationErrors(helperTerminationError, daemonError);
+}
+
+function readOwnedSessionPid(owned: OwnedAutomationSession): {
+  pid: number | null;
+  readError: unknown;
+} {
+  if (owned.pid !== null) return { pid: owned.pid, readError: null };
+  try {
+    return { pid: readLibrettoSessionState(owned.session)?.pid ?? null, readError: null };
+  } catch (readError) {
+    return { pid: null, readError };
+  }
+}
+
+async function closeSessionHelper(
+  session: string,
+  deps: FinalizeSessionDeps,
+): Promise<{ closeError: unknown; helperTerminationError: Error | null }> {
+  const closeHandle = deps.startCloseSession?.(session) ?? {
+    completion: deps.closeSession(session),
+    terminate: async () => { await deps.terminateCloseSession?.(session); },
   };
   const timerDeps = deps.timerDeps ?? defaultTimerDeps;
   const closeResult = await settleWithin(closeHandle.completion, CLOSE_TIMEOUT_MS, timerDeps);
+  let closeError: unknown;
   let helperTerminationError: Error | null = null;
   if (closeResult.timedOut) {
     const termination = await settleWithin(
@@ -204,30 +228,35 @@ async function closeOwnedSession(
   } else {
     closeError = closeResult.error ?? null;
   }
+  return { closeError, helperTerminationError };
+}
 
-  if (pid === null) {
-    if (closeError) {
-      const readContext = readError ? ` state read: ${String(readError)};` : "";
-      throw new Error(
-        `Could not close Libretto session ${owned.session}:${readContext} graceful close: ${String(closeError)}`,
-      );
-    }
-    return;
-  }
+async function terminateOwnedDaemon(
+  pid: number,
+  session: string,
+  deps: FinalizeSessionDeps,
+): Promise<Error | null> {
   let daemonError: Error | null = null;
-  if (deps.isExpectedDaemon(pid, owned.session)) {
+  if (deps.isExpectedDaemon(pid, session)) {
     deps.signalProcessGroup(pid, "SIGTERM");
     await deps.wait(TERM_GRACE_MS);
-    if (deps.isExpectedDaemon(pid, owned.session)) {
+    if (deps.isExpectedDaemon(pid, session)) {
       deps.signalProcessGroup(pid, "SIGKILL");
       await deps.wait(KILL_GRACE_MS);
-      if (deps.isExpectedDaemon(pid, owned.session)) {
+      if (deps.isExpectedDaemon(pid, session)) {
         daemonError = new Error(
-          `Libretto session ${owned.session} daemon ${pid} remained after SIGKILL`,
+          `Libretto session ${session} daemon ${pid} remained after SIGKILL`,
         );
       }
     }
   }
+  return daemonError;
+}
+
+function throwSessionFinalizationErrors(
+  helperTerminationError: Error | null,
+  daemonError: Error | null,
+): void {
   if (helperTerminationError && daemonError) {
     throw new AggregateError([helperTerminationError, daemonError], helperTerminationError.message);
   }

--- a/src/lib/automation/server/settings.ts
+++ b/src/lib/automation/server/settings.ts
@@ -7,6 +7,7 @@ import {
   type AutomationSettingsFile,
 } from "./config-files.ts";
 import { AUTOMATION_CREDENTIAL_GROUPS } from "./tasks.ts";
+import { automationFlagEnabled } from "../statement-selection.ts";
 import { systemSettings } from "../../settings/system-settings.ts";
 
 export const AUTOMATION_ENV_PATH = ".env";
@@ -16,9 +17,7 @@ export function readAutomationEnvText(envPath = AUTOMATION_ENV_PATH) {
 }
 
 export function envFlagEnabled(value: string | boolean | undefined) {
-  if (value === undefined) return true;
-  if (typeof value === "boolean") return value;
-  return !new Set(["0", "false", "no", "off", "disabled"]).has(value.trim().toLowerCase());
+  return automationFlagEnabled(value);
 }
 
 export function readAutomationSettings(settingsPath = AUTOMATION_SETTINGS_PATH) {

--- a/src/lib/automation/server/task-run-execution.ts
+++ b/src/lib/automation/server/task-run-execution.ts
@@ -1,0 +1,343 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  parseStatementRunSummary,
+  type StatementRunSummary,
+} from "../statement-run-summary.ts";
+import { resolveTaskCommand } from "./desktop-command.ts";
+import { automationConfigEnv } from "./config-files.ts";
+import { validateLibrettoSessionName } from "./libretto-session.ts";
+import {
+  appendLog,
+  errorMessage,
+  finalizeAutomationTaskRun,
+  isForceQuitRun,
+  sessionFromRun,
+  sessionPid,
+  shouldMarkWaitingForHuman,
+  tail,
+  type AutomationTaskProcessResult,
+  type AutomationTaskRunExecution,
+} from "./task-run-finalization.ts";
+import {
+  disarmAutomationSessionTimeout,
+  ownAutomationSession,
+  ownedAutomationSession,
+  restoreAutomationSessionOwnership,
+  type OwnedAutomationSession,
+} from "./session-lifecycle.ts";
+import {
+  activeTaskRuns,
+  createTaskRun,
+  taskRunById,
+  updateTaskRun,
+  type AutomationTaskRun,
+} from "./store.ts";
+import { taskById } from "./tasks.ts";
+
+const activeTaskChildren = new Map<string, ChildProcess>();
+
+export type AutomationTaskExecutionOptions = {
+  scheduledAtUtc?: string;
+  resumeSession?: string;
+};
+
+export function createAutomationSessionId(uuid: () => string = randomUUID): string {
+  return validateLibrettoSessionName("ses-octopus-" + uuid());
+}
+
+export function resumeFailureMessage(output: string) {
+  return output.match(/Workflow failed after resume:\s*([^\r\n]+)/i)?.[1]?.trim() ?? null;
+}
+
+export function parseAutomationProgress(output: string) {
+  let progress: number | null = null;
+  for (const match of output.matchAll(/automation-progress:\s*(\d+(?:\.\d+)?)/gi)) {
+    const value = Math.round(Number(match[1]));
+    progress = Math.max(0, Math.min(100, value));
+  }
+  return progress;
+}
+
+export function automationProcessEnv(baseEnv: NodeJS.ProcessEnv = process.env) {
+  return automationConfigEnv({ baseEnv });
+}
+
+export function createAutomationOutputBuffer(
+  write: (chunk: string) => void,
+  delayMs = 500,
+  onError: (error: unknown) => void = (error) => {
+    console.error("automation-output-write-failed", error);
+  },
+) {
+  let pending = "";
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const flush = (retry: boolean) => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    if (!pending) return;
+    const chunk = pending;
+    pending = "";
+    try {
+      write(chunk);
+    } catch (error) {
+      pending = tail(chunk + pending);
+      if (retry) timer = setTimeout(() => flush(true), delayMs);
+      try {
+        onError(error);
+      } catch (handlerError) {
+        console.error("automation-output-error-handler-failed", handlerError);
+      }
+    }
+  };
+  return {
+    push(chunk: string) {
+      pending = tail(pending + chunk);
+      if (!timer) timer = setTimeout(() => flush(true), delayMs);
+    },
+    flush: () => flush(false),
+  };
+}
+
+export function claimRunAutomationSession(
+  db: ReturnType<typeof openLedgerDatabase>,
+  taskRunId: string,
+  owner: OwnedAutomationSession,
+  options: { resumeSession?: string; resumeFrom?: AutomationTaskRun } = {},
+) {
+  const current = ownedAutomationSession(owner.taskId);
+  const resumeFrom = options.resumeFrom;
+  let claimError: unknown = null;
+  const isResumeHandoff = Boolean(
+    options.resumeSession
+      && options.resumeSession === owner.session
+      && resumeFrom?.status === "waiting_for_human"
+      && resumeFrom.taskId === owner.taskId
+      && resumeFrom.taskRunId !== taskRunId
+      && sessionFromRun(resumeFrom) === owner.session
+      && (!current
+        || (current.taskRunId === resumeFrom.taskRunId && current.session === owner.session)),
+  );
+  if ((!options.resumeSession || isResumeHandoff) && (!current || isResumeHandoff)) {
+    if (resumeFrom) {
+      const claimRejected = new Error("Automation session registry claim rejected");
+      let registryClaimed = false;
+      db.exec("BEGIN");
+      try {
+        updateTaskRun(db, resumeFrom.taskRunId, {
+          status: "failed",
+          finishedAt: new Date().toISOString(),
+          errorMessage: `Superseded by resume handoff: ${taskRunId}`,
+          logTail: tail(`${resumeFrom.logTail}\nautomation-resume-handoff: ${taskRunId}\n`),
+        });
+        if (!ownAutomationSession(owner)) throw claimRejected;
+        registryClaimed = true;
+        db.exec("COMMIT");
+        disarmAutomationSessionTimeout(owner.taskId);
+        return true;
+      } catch (error) {
+        try {
+          db.exec("ROLLBACK");
+        } finally {
+          if (registryClaimed) restoreAutomationSessionOwnership(owner, current);
+        }
+        claimError = error;
+      }
+    } else if (ownAutomationSession(owner)) {
+      disarmAutomationSessionTimeout(owner.taskId);
+      return true;
+    }
+  }
+  updateTaskRun(db, taskRunId, {
+    status: "failed",
+    finishedAt: new Date().toISOString(),
+    exitCode: null,
+    signal: null,
+    errorMessage: claimError && errorMessage(claimError) !== "Automation session registry claim rejected"
+      ? `Automation session handoff failed: ${errorMessage(claimError)}`
+      : "Automation session is still closing. Try again after cleanup finishes.",
+  });
+  return false;
+}
+
+export function accumulateAutomationOutput(
+  state: { logTail: string; resumeFailure: string | null },
+  chunk: string,
+) {
+  const logChunk = stripVTControlCharacters(chunk);
+  const combined = state.logTail + logChunk;
+  return {
+    logChunk,
+    logTail: tail(combined),
+    resumeFailure: state.resumeFailure ?? resumeFailureMessage(combined),
+  };
+}
+
+function createAutomationTaskRunExecution(
+  task: NonNullable<ReturnType<typeof taskById>>,
+  taskDb: ReturnType<typeof openLedgerDatabase>,
+  options: AutomationTaskExecutionOptions,
+): AutomationTaskRunExecution | null {
+  const attempt = 1;
+  const maxAttempts = 1;
+  const startedAt = new Date().toISOString();
+  const logPath = join(
+    "data",
+    "automation",
+    "logs",
+    `${task.id}-${Date.now()}-${attempt}.log`,
+  );
+  const env = automationProcessEnv();
+  const isLibrettoTask = task.command[0] === "libretto";
+  const session = isLibrettoTask
+    ? options.resumeSession ?? createAutomationSessionId()
+    : null;
+  const command = resolveTaskCommand(task, {
+    resumeSession: options.resumeSession,
+    session: options.resumeSession ? undefined : session ?? undefined,
+  }, env);
+  if (task.id === "exchange-rates" && options.scheduledAtUtc) {
+    if (command.command === "npm") command.args.push("--");
+    command.args.push("--scheduled-at-utc", options.scheduledAtUtc);
+    command.display += ` --scheduled-at-utc ${options.scheduledAtUtc}`;
+  }
+  const run = createTaskRun(taskDb, {
+    taskId: task.id,
+    script: command.display,
+    kind: task.kind,
+    status: "running",
+    attempt,
+    maxAttempts,
+    startedAt,
+    logPath,
+  });
+  const owner = session ? {
+    taskId: task.id,
+    taskRunId: run.taskRunId,
+    session,
+    pid: sessionPid(session),
+  } : null;
+  if (session) {
+    appendLog(logPath, "automation-session: " + session + "\n");
+    const resumeFrom = options.resumeSession
+      ? activeTaskRuns(taskDb).find((candidate) =>
+        candidate.taskId === task.id
+        && candidate.taskRunId !== run.taskRunId
+        && candidate.status === "waiting_for_human"
+        && sessionFromRun(candidate) === options.resumeSession
+      )
+      : undefined;
+    if (!claimRunAutomationSession(taskDb, run.taskRunId, owner!, {
+      resumeSession: options.resumeSession,
+      resumeFrom,
+    })) return null;
+  }
+  return { task, taskDb, run, logPath, command, session, owner };
+}
+
+async function executeAutomationTaskProcess(
+  execution: AutomationTaskRunExecution,
+): Promise<AutomationTaskProcessResult> {
+  let logTail = "";
+  let detectedResumeFailure: string | null = null;
+  let statementSummary: StatementRunSummary | null = null;
+  const outputPersistenceWarnings: string[] = [];
+  const result = await new Promise<Pick<AutomationTaskProcessResult, "exitCode" | "signal" | "error">>((resolve) => {
+    const recordOutputPersistenceError = (error: unknown) => {
+      const line = `automation-output-write-failed: ${errorMessage(error)}`;
+      console.error(line);
+      logTail = tail(`${logTail}\n${line}\n`);
+      outputPersistenceWarnings.push(line);
+    };
+    const outputBuffer = createAutomationOutputBuffer(
+      () => {
+        if (!isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) {
+          updateTaskRun(execution.taskDb, execution.run.taskRunId, {
+            ...liveTaskRunUpdate(logTail),
+          });
+        }
+      },
+      500,
+      recordOutputPersistenceError,
+    );
+    const onOutput = (chunk: Buffer) => {
+      const output = accumulateAutomationOutput(
+        { logTail, resumeFailure: detectedResumeFailure },
+        chunk.toString("utf8"),
+      );
+      statementSummary = parseStatementRunSummary(`${logTail}${output.logChunk}`)
+        ?? statementSummary;
+      logTail = output.logTail;
+      detectedResumeFailure = output.resumeFailure;
+      try {
+        appendLog(execution.logPath, output.logChunk);
+      } catch (error) {
+        recordOutputPersistenceError(error);
+      }
+      outputBuffer.push(output.logChunk);
+      if (execution.owner) {
+        ownAutomationSession({ ...execution.owner, pid: sessionPid(execution.owner.session) });
+      }
+    };
+    const child = spawn(execution.command.command, execution.command.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: execution.command.env,
+    });
+    activeTaskChildren.set(execution.task.id, child);
+    child.stdout.on("data", onOutput);
+    child.stderr.on("data", onOutput);
+    child.on("error", (error) => {
+      activeTaskChildren.delete(execution.task.id);
+      outputBuffer.flush();
+      resolve({ exitCode: null, signal: null, error });
+    });
+    child.on("close", (exitCode, signal) => {
+      activeTaskChildren.delete(execution.task.id);
+      outputBuffer.flush();
+      resolve({ exitCode, signal, error: null });
+    });
+  });
+  return {
+    ...result,
+    logTail,
+    resumeFailure: detectedResumeFailure ?? resumeFailureMessage(logTail),
+    statementSummary,
+    outputPersistenceWarnings,
+  };
+}
+
+export function liveTaskRunUpdate(logTail: string) {
+  const resumeFailure = resumeFailureMessage(logTail);
+  if (resumeFailure) return { status: "failed" as const, errorMessage: resumeFailure, logTail };
+  if (shouldMarkWaitingForHuman(logTail)) return { status: "waiting_for_human" as const, logTail };
+  return { logTail };
+}
+
+export async function runAutomationTaskExecution(
+  task: NonNullable<ReturnType<typeof taskById>>,
+  taskDb: ReturnType<typeof openLedgerDatabase>,
+  ledgerDir: string,
+  options: AutomationTaskExecutionOptions,
+  onRunCreated: (taskRunId: string) => void,
+) {
+  const execution = createAutomationTaskRunExecution(task, taskDb, options);
+  if (!execution) return { status: "failed" as const };
+  onRunCreated(execution.run.taskRunId);
+  try {
+    const result = await executeAutomationTaskProcess(execution);
+    return await finalizeAutomationTaskRun(execution, result, ledgerDir);
+  } finally {
+    activeTaskChildren.delete(task.id);
+  }
+}
+
+export function automationTaskChild(taskId: string) {
+  return activeTaskChildren.get(taskId);
+}
+
+export function terminateAutomationTaskProcesses() {
+  for (const child of activeTaskChildren.values()) child.kill("SIGTERM");
+}

--- a/src/lib/automation/server/task-run-execution.ts
+++ b/src/lib/automation/server/task-run-execution.ts
@@ -13,29 +13,26 @@ import { validateLibrettoSessionName } from "./libretto-session.ts";
 import {
   appendLog,
   errorMessage,
+  sessionPid,
+  tail,
+  claimAutomationTaskRunSession,
+  refreshAutomationSession,
+  sessionFromRun,
+  type OwnedAutomationSession,
+} from "./automation-session-disposition.ts";
+import {
   finalizeAutomationTaskRun,
   isForceQuitRun,
-  sessionFromRun,
-  sessionPid,
   shouldMarkWaitingForHuman,
-  tail,
   type AutomationTaskProcessResult,
   type AutomationTaskRunFinalizationContext,
   type AutomationTaskRunExecution,
 } from "./task-run-finalization.ts";
 import {
-  disarmAutomationSessionTimeout,
-  ownAutomationSession,
-  ownedAutomationSession,
-  restoreAutomationSessionOwnership,
-  type OwnedAutomationSession,
-} from "./session-lifecycle.ts";
-import {
   activeTaskRuns,
   createTaskRun,
   taskRunById,
   updateTaskRun,
-  type AutomationTaskRun,
 } from "./store.ts";
 import { taskById } from "./tasks.ts";
 
@@ -103,66 +100,7 @@ export function createAutomationOutputBuffer(
   };
 }
 
-export function claimRunAutomationSession(
-  db: ReturnType<typeof openLedgerDatabase>,
-  taskRunId: string,
-  owner: OwnedAutomationSession,
-  options: { resumeSession?: string; resumeFrom?: AutomationTaskRun } = {},
-) {
-  const current = ownedAutomationSession(owner.taskId);
-  const resumeFrom = options.resumeFrom;
-  let claimError: unknown = null;
-  const isResumeHandoff = Boolean(
-    options.resumeSession
-      && options.resumeSession === owner.session
-      && resumeFrom?.status === "waiting_for_human"
-      && resumeFrom.taskId === owner.taskId
-      && resumeFrom.taskRunId !== taskRunId
-      && sessionFromRun(resumeFrom) === owner.session
-      && (!current
-        || (current.taskRunId === resumeFrom.taskRunId && current.session === owner.session)),
-  );
-  if ((!options.resumeSession || isResumeHandoff) && (!current || isResumeHandoff)) {
-    if (resumeFrom) {
-      const claimRejected = new Error("Automation session registry claim rejected");
-      let registryClaimed = false;
-      db.exec("BEGIN");
-      try {
-        updateTaskRun(db, resumeFrom.taskRunId, {
-          status: "failed",
-          finishedAt: new Date().toISOString(),
-          errorMessage: `Superseded by resume handoff: ${taskRunId}`,
-          logTail: tail(`${resumeFrom.logTail}\nautomation-resume-handoff: ${taskRunId}\n`),
-        });
-        if (!ownAutomationSession(owner)) throw claimRejected;
-        registryClaimed = true;
-        db.exec("COMMIT");
-        disarmAutomationSessionTimeout(owner.taskId);
-        return true;
-      } catch (error) {
-        try {
-          db.exec("ROLLBACK");
-        } finally {
-          if (registryClaimed) restoreAutomationSessionOwnership(owner, current);
-        }
-        claimError = error;
-      }
-    } else if (ownAutomationSession(owner)) {
-      disarmAutomationSessionTimeout(owner.taskId);
-      return true;
-    }
-  }
-  updateTaskRun(db, taskRunId, {
-    status: "failed",
-    finishedAt: new Date().toISOString(),
-    exitCode: null,
-    signal: null,
-    errorMessage: claimError && errorMessage(claimError) !== "Automation session registry claim rejected"
-      ? `Automation session handoff failed: ${errorMessage(claimError)}`
-      : "Automation session is still closing. Try again after cleanup finishes.",
-  });
-  return false;
-}
+export const claimRunAutomationSession = claimAutomationTaskRunSession;
 
 export function accumulateAutomationOutput(
   state: { logTail: string; resumeFailure: string | null },
@@ -280,7 +218,7 @@ async function executeAutomationTaskProcess(
       }
       outputBuffer.push(output.logChunk);
       if (execution.owner) {
-        ownAutomationSession({ ...execution.owner, pid: sessionPid(execution.owner.session) });
+        refreshAutomationSession(execution.owner);
       }
     };
     const child = spawn(execution.command.command, execution.command.args, {
@@ -336,8 +274,6 @@ export async function runAutomationTaskExecution(
       taskRunId: execution.run.taskRunId,
       logPath: execution.logPath,
       ledgerDir,
-      session: execution.session,
-      owner: execution.owner,
     };
     return await finalizeAutomationTaskRun(finalizationContext, result);
   } finally {

--- a/src/lib/automation/server/task-run-execution.ts
+++ b/src/lib/automation/server/task-run-execution.ts
@@ -20,6 +20,7 @@ import {
   shouldMarkWaitingForHuman,
   tail,
   type AutomationTaskProcessResult,
+  type AutomationTaskRunFinalizationContext,
   type AutomationTaskRunExecution,
 } from "./task-run-finalization.ts";
 import {
@@ -328,7 +329,17 @@ export async function runAutomationTaskExecution(
   onRunCreated(execution.run.taskRunId);
   try {
     const result = await executeAutomationTaskProcess(execution);
-    return await finalizeAutomationTaskRun(execution, result, ledgerDir);
+    const finalizationContext: AutomationTaskRunFinalizationContext = {
+      taskDb,
+      taskId: task.id,
+      taskKind: task.kind,
+      taskRunId: execution.run.taskRunId,
+      logPath: execution.logPath,
+      ledgerDir,
+      session: execution.session,
+      owner: execution.owner,
+    };
+    return await finalizeAutomationTaskRun(finalizationContext, result);
   } finally {
     activeTaskChildren.delete(task.id);
   }

--- a/src/lib/automation/server/task-run-finalization.check.ts
+++ b/src/lib/automation/server/task-run-finalization.check.ts
@@ -15,7 +15,7 @@ import {
   finalizeAutomationTaskRun,
   finalizePersistedRun,
   type AutomationTaskProcessResult,
-  type AutomationTaskRunExecution,
+  type AutomationTaskRunFinalizationContext,
 } from "./task-run-finalization.ts";
 
 function createExecution(ledgerDir: string) {
@@ -32,16 +32,17 @@ function createExecution(ledgerDir: string) {
     startedAt: new Date().toISOString(),
     logPath,
   });
-  const execution = {
-    task,
+  const finalization = {
     taskDb: db,
-    run: { taskRunId: run.taskRunId },
+    taskId: task.id,
+    taskKind: task.kind,
+    taskRunId: run.taskRunId,
     logPath,
-    command: {},
+    ledgerDir,
     session: null,
     owner: null,
-  } as AutomationTaskRunExecution;
-  return { db, run, execution };
+  } satisfies AutomationTaskRunFinalizationContext;
+  return { db, run, finalization };
 }
 
 function result(overrides: Partial<AutomationTaskProcessResult> = {}): AutomationTaskProcessResult {
@@ -60,7 +61,7 @@ function result(overrides: Partial<AutomationTaskProcessResult> = {}): Automatio
 test("live finalization persists a partial statement outcome through one transition", async () => {
   const ledgerDir = mkdtempSync(join(tmpdir(), "automation-finalization-live-"));
   try {
-    const { db, run, execution } = createExecution(ledgerDir);
+    const { db, run, finalization } = createExecution(ledgerDir);
     const summary = {
       status: "partial" as const,
       results: [
@@ -70,7 +71,7 @@ test("live finalization persists a partial statement outcome through one transit
     };
 
     assert.deepEqual(
-      await finalizeAutomationTaskRun(execution, result({ statementSummary: summary }), ledgerDir),
+      await finalizeAutomationTaskRun(finalization, result({ statementSummary: summary })),
       { status: "partial" },
     );
     const persisted = taskRunById(db, run.taskRunId)!;
@@ -86,17 +87,16 @@ test("live finalization persists a partial statement outcome through one transit
 test("waiting for human remains active until a later run takes over", async () => {
   const ledgerDir = mkdtempSync(join(tmpdir(), "automation-finalization-waiting-"));
   try {
-    const { db, run, execution } = createExecution(ledgerDir);
+    const { db, run, finalization } = createExecution(ledgerDir);
     assert.deepEqual(
       await finalizeAutomationTaskRun(
-        execution,
+        finalization,
         result({ logTail: "Workflow paused. resume --session ses-waiting" }),
-        ledgerDir,
       ),
       { status: "waiting_for_human" },
     );
     assert.deepEqual(
-      await finalizeAutomationTaskRun(execution, result(), ledgerDir),
+      await finalizeAutomationTaskRun(finalization, result()),
       { status: "waiting_for_human" },
     );
     assert.equal(taskRunById(db, run.taskRunId)?.status, "waiting_for_human");

--- a/src/lib/automation/server/task-run-finalization.check.ts
+++ b/src/lib/automation/server/task-run-finalization.check.ts
@@ -39,8 +39,6 @@ function createExecution(ledgerDir: string) {
     taskRunId: run.taskRunId,
     logPath,
     ledgerDir,
-    session: null,
-    owner: null,
   } satisfies AutomationTaskRunFinalizationContext;
   return { db, run, finalization };
 }

--- a/src/lib/automation/server/task-run-finalization.check.ts
+++ b/src/lib/automation/server/task-run-finalization.check.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { statementRunSummaryLine } from "../statement-run-summary.ts";
+import {
+  activeTaskRuns,
+  createTaskRun,
+  taskRunById,
+} from "./store.ts";
+import { taskById } from "./tasks.ts";
+import {
+  finalizeAutomationTaskRun,
+  finalizePersistedRun,
+  type AutomationTaskProcessResult,
+  type AutomationTaskRunExecution,
+} from "./task-run-finalization.ts";
+
+function createExecution(ledgerDir: string) {
+  const db = openLedgerDatabase(ledgerDir);
+  const task = taskById("exchange-rates")!;
+  const logPath = join(ledgerDir, "automation.log");
+  const run = createTaskRun(db, {
+    taskId: task.id,
+    script: "run:exchange-rates",
+    kind: task.kind,
+    status: "running",
+    attempt: 1,
+    maxAttempts: 1,
+    startedAt: new Date().toISOString(),
+    logPath,
+  });
+  const execution = {
+    task,
+    taskDb: db,
+    run: { taskRunId: run.taskRunId },
+    logPath,
+    command: {},
+    session: null,
+    owner: null,
+  } as AutomationTaskRunExecution;
+  return { db, run, execution };
+}
+
+function result(overrides: Partial<AutomationTaskProcessResult> = {}): AutomationTaskProcessResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    error: null,
+    logTail: "",
+    resumeFailure: null,
+    statementSummary: null,
+    outputPersistenceWarnings: [],
+    ...overrides,
+  };
+}
+
+test("live finalization persists a partial statement outcome through one transition", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-finalization-live-"));
+  try {
+    const { db, run, execution } = createExecution(ledgerDir);
+    const summary = {
+      status: "partial" as const,
+      results: [
+        { typeId: "deposit", status: "success" as const },
+        { typeId: "loan", status: "failed" as const, error: "no account" },
+      ],
+    };
+
+    assert.deepEqual(
+      await finalizeAutomationTaskRun(execution, result({ statementSummary: summary }), ledgerDir),
+      { status: "partial" },
+    );
+    const persisted = taskRunById(db, run.taskRunId)!;
+    assert.equal(persisted.status, "partial");
+    assert.equal(persisted.errorMessage, null);
+    assert.ok(readFileSync(persisted.logPath, "utf8").includes(statementRunSummaryLine(summary.results)));
+    db.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("waiting for human remains active until a later run takes over", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-finalization-waiting-"));
+  try {
+    const { db, run, execution } = createExecution(ledgerDir);
+    assert.deepEqual(
+      await finalizeAutomationTaskRun(
+        execution,
+        result({ logTail: "Workflow paused. resume --session ses-waiting" }),
+        ledgerDir,
+      ),
+      { status: "waiting_for_human" },
+    );
+    assert.deepEqual(
+      await finalizeAutomationTaskRun(execution, result(), ledgerDir),
+      { status: "waiting_for_human" },
+    );
+    assert.equal(taskRunById(db, run.taskRunId)?.status, "waiting_for_human");
+    assert.deepEqual(activeTaskRuns(db).map((active) => active.taskRunId), [run.taskRunId]);
+    db.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});
+
+test("persisted finalization preserves the primary error and is idempotent", async () => {
+  const ledgerDir = mkdtempSync(join(tmpdir(), "automation-finalization-recovery-"));
+  try {
+    const db = openLedgerDatabase(ledgerDir);
+    const task = taskById("exchange-rates")!;
+    const logPath = join(ledgerDir, "recovery.log");
+    const run = createTaskRun(db, {
+      taskId: task.id,
+      script: "run:exchange-rates",
+      kind: task.kind,
+      status: "running",
+      attempt: 1,
+      maxAttempts: 1,
+      startedAt: new Date().toISOString(),
+      logPath,
+      errorMessage: "workflow failed",
+    });
+    await finalizePersistedRun(db, taskRunById(db, run.taskRunId)!, "App abnormal exit");
+    await finalizePersistedRun(db, taskRunById(db, run.taskRunId)!, "different reason");
+    const persisted = taskRunById(db, run.taskRunId)!;
+
+    assert.equal(persisted.status, "failed");
+    assert.equal(
+      persisted.errorMessage,
+      "workflow failed\nSession cleanup failed: Missing Libretto session identity",
+    );
+    assert.equal(readFileSync(logPath, "utf8").split("automation-session-finalize:").length, 2);
+    db.close();
+  } finally {
+    rmSync(ledgerDir, { recursive: true, force: true });
+  }
+});

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -138,6 +138,84 @@ export async function finalizeTerminalAutomationSession(
   }
 }
 
+type SessionCleanupResult = {
+  errorMessage: string | null;
+  cleanupFailed: boolean;
+};
+
+type TaskRunFinalizationPlan = {
+  status: AutomationTaskStatus;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  errorMessage: string | null;
+  logTail: string;
+  logAppend?: string | ((cleanup: SessionCleanupResult | null) => string);
+  cleanup?: (workflowError: string | null) => Promise<SessionCleanupResult>;
+};
+
+function isTerminalTaskRunStatus(status: AutomationTaskStatus) {
+  return status === "completed" || status === "partial" || status === "failed";
+}
+
+async function finalizeTaskRunTransition(
+  db: ReturnType<typeof openLedgerDatabase>,
+  run: Pick<AutomationTaskRun, "taskRunId" | "logPath">,
+  plan: TaskRunFinalizationPlan,
+) {
+  const current = taskRunById(db, run.taskRunId);
+  if (!current) throw new Error(`Missing automation task run: ${run.taskRunId}`);
+  if (isTerminalTaskRunStatus(current.status)) return { status: current.status, skipped: true };
+  if (current.status !== "running" && current.status !== "waiting_for_human") {
+    return { status: current.status, skipped: true };
+  }
+  if (current.status === "waiting_for_human" && plan.status !== "failed") {
+    return { status: current.status, skipped: true };
+  }
+
+  let status = plan.status;
+  let taskError = plan.errorMessage;
+  let logTail = plan.logTail;
+  let cleanupResult: SessionCleanupResult | null = null;
+  if (plan.cleanup) {
+    cleanupResult = await plan.cleanup(taskError);
+    taskError = cleanupResult.errorMessage;
+    if (cleanupResult.cleanupFailed && (status === "completed" || status === "partial")) {
+      status = "failed";
+    }
+  }
+
+  const afterCleanup = taskRunById(db, run.taskRunId);
+  if (!afterCleanup) throw new Error(`Missing automation task run: ${run.taskRunId}`);
+  if (isTerminalTaskRunStatus(afterCleanup.status)) {
+    return { status: afterCleanup.status, skipped: true };
+  }
+
+  if (plan.logAppend) {
+    try {
+      appendLog(
+        run.logPath,
+        typeof plan.logAppend === "function"
+          ? plan.logAppend(cleanupResult)
+          : plan.logAppend,
+      );
+    } catch (error) {
+      const warning = `automation-output-write-failed: ${errorMessage(error)}`;
+      console.error(warning);
+      taskError = [taskError, warning].filter(Boolean).join("\n") || null;
+      logTail = tail(`${logTail}\n${warning}\n`);
+    }
+  }
+  updateTaskRun(db, run.taskRunId, {
+    status,
+    finishedAt: new Date().toISOString(),
+    exitCode: plan.exitCode,
+    signal: plan.signal,
+    logTail,
+    errorMessage: taskError,
+  });
+  return { status, skipped: false };
+}
+
 export function sessionPid(session: string) {
   try {
     return readLibrettoSessionState(session)?.pid ?? null;
@@ -180,30 +258,36 @@ export async function finalizePersistedRun(
 ) {
   const session = sessionFromRun(run);
   const pid = session ? sessionPid(session) : null;
-  let cleanupError: string | null = null;
-  if (!session) {
-    cleanupError = "Missing Libretto session identity";
-  } else {
-    ownAutomationSession({ taskId: run.taskId, taskRunId: run.taskRunId, session, pid });
-    try {
-      await finalizeOwnedAutomationSession(run.taskId);
-    } catch (error) {
-      cleanupError = errorMessage(error);
-    }
-  }
-  updateTaskRun(db, run.taskRunId, {
+  const owner = session
+    ? { taskId: run.taskId, taskRunId: run.taskRunId, session, pid }
+    : null;
+  let cleanupError: string | null = owner ? null : "Missing Libretto session identity";
+  const result = await finalizeTaskRunTransition(db, run, {
     status: "failed",
-    finishedAt: new Date().toISOString(),
     exitCode: null,
     signal: null,
-    errorMessage: cleanupError
-      ? appendCleanupError(run.errorMessage ?? reason, cleanupError)
-      : run.errorMessage ?? reason,
+    errorMessage: run.errorMessage ?? reason,
+    logTail: run.logTail,
+    logAppend: () => "automation-session-finalize: session="
+      + (session ?? "unknown")
+      + " pid=" + (pid ?? "unknown")
+      + " cleanup-error=" + (cleanupError ?? "none") + "\n",
+    cleanup: owner
+      ? async (workflowError) => {
+        ownAutomationSession(owner);
+        const result = await finalizeTerminalAutomationSession(
+          owner,
+          workflowError,
+          () => finalizeOwnedAutomationSession(run.taskId),
+        );
+        if (result.cleanupFailed) cleanupError = result.errorMessage;
+        return result;
+      }
+      : async (workflowError) => ({
+        errorMessage: appendCleanupError(workflowError, cleanupError ?? "Missing Libretto session identity"),
+        cleanupFailed: true,
+      }),
   });
-  appendLog(
-    run.logPath,
-    `automation-session-finalize: session=${session ?? "unknown"} pid=${pid ?? "unknown"} cleanup-error=${cleanupError ?? "none"}\n`,
-  );
 }
 
 export async function finalizePersistedActiveRuns(
@@ -232,30 +316,28 @@ function scheduleAutomationTaskRunTimeout(
   ledgerDir: string,
 ) {
   if (!execution.session) return;
-  const timeoutOwner = {
+  const timeoutOwner = execution.owner ?? {
     taskId: execution.task.id,
     taskRunId: execution.run.taskRunId,
     session: execution.session,
+    pid: sessionPid(execution.session),
   };
   armAutomationSessionTimeout(execution.task.id, async () => {
     const timeoutDb = openLedgerDatabase(ledgerDir);
     try {
-      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
-      let timeoutError: string | null = null;
-      try {
-        await finalizeExactOwnedAutomationSession(timeoutOwner);
-      } catch (error) {
-        timeoutError = errorMessage(error);
-      }
-      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
-      updateTaskRun(timeoutDb, execution.run.taskRunId, {
+      const run = taskRunById(timeoutDb, execution.run.taskRunId);
+      if (!run || run.status !== "waiting_for_human") return;
+      await finalizeTaskRunTransition(timeoutDb, run, {
         status: "failed",
-        finishedAt: new Date().toISOString(),
         exitCode: null,
         signal: null,
-        errorMessage: timeoutError
-          ? appendCleanupError("等待人工操作超過 20 分鐘", timeoutError)
-          : "等待人工操作超過 20 分鐘",
+        errorMessage: "等待人工操作超過 20 分鐘",
+        logTail: run.logTail,
+        cleanup: (workflowError) => finalizeTerminalAutomationSession(
+          timeoutOwner,
+          workflowError,
+          () => finalizeExactOwnedAutomationSession(timeoutOwner),
+        ),
       });
     } catch (error) {
       console.error("automation-session-timeout-failed", error);
@@ -291,40 +373,36 @@ export async function finalizeAutomationTaskRun(
     ?? resumeFailure
     ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
   taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
-  if (execution.owner && !shouldRetainAutomationSession(status)) {
-    const retainedOwner = ownedAutomationSession(execution.task.id) ?? execution.owner;
-    const cleanup = await finalizeTerminalAutomationSession(
-      retainedOwner,
-      taskError,
-      () => finalizeExactOwnedAutomationSession(execution.owner!),
-    );
-    taskError = cleanup.errorMessage;
-    if (cleanup.cleanupFailed && (status === "completed" || status === "partial")) status = "failed";
-  }
   if (isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) return { status: "failed" as const };
   let logTail = result.logTail;
+  let summaryLine: string | undefined;
   if (result.statementSummary) {
-    const summaryLine = statementRunSummaryLine(result.statementSummary.results);
-    try {
-      appendLog(execution.logPath, `\n${summaryLine}\n`);
-    } catch (error) {
-      const warning = `automation-output-write-failed: ${errorMessage(error)}`;
-      console.error(warning);
-      taskError = [taskError, warning].filter(Boolean).join("\n") || null;
-      logTail = tail(`${logTail}\n${warning}\n`);
-    }
+    summaryLine = statementRunSummaryLine(result.statementSummary.results);
     logTail = tail(`${logTail}\n${summaryLine}\n`);
   }
-  updateTaskRun(execution.taskDb, execution.run.taskRunId, {
+  const owner = execution.owner && !shouldRetainAutomationSession(status)
+    ? ownedAutomationSession(execution.task.id) ?? execution.owner
+    : null;
+  const transition = await finalizeTaskRunTransition(execution.taskDb, {
+    taskRunId: execution.run.taskRunId,
+    logPath: execution.logPath,
+  }, {
     status,
-    finishedAt: new Date().toISOString(),
     exitCode: result.exitCode,
     signal: result.signal,
-    logTail,
     errorMessage: taskError,
+    logTail,
+    logAppend: summaryLine ? `\n${summaryLine}\n` : undefined,
+    cleanup: owner
+      ? async (workflowError) => finalizeTerminalAutomationSession(
+        owner,
+        workflowError,
+        () => finalizeExactOwnedAutomationSession(execution.owner!),
+      )
+      : undefined,
   });
-  if (execution.session && shouldRetainAutomationSession(status)) {
+  if (!transition.skipped && execution.session && shouldRetainAutomationSession(status)) {
     scheduleAutomationTaskRunTimeout(execution, ledgerDir);
   }
-  return { status };
+  return { status: transition.status };
 }

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -9,6 +9,7 @@ import { resolveTaskCommand } from "./desktop-command.ts";
 import { readLibrettoSessionState } from "./libretto-session.ts";
 import {
   armAutomationSessionTimeout,
+  claimAutomationSessionForCleanup,
   finalizeExactOwnedAutomationSession,
   finalizeOwnedAutomationSession,
   ownAutomationSession,
@@ -46,6 +47,12 @@ export type AutomationTaskRunFinalizationContext = {
   session: string | null;
   owner: OwnedAutomationSession | null;
 };
+
+export type ForceQuitFinalizationDependencies = Partial<{
+  readSessionState: typeof readLibrettoSessionState;
+  claimSession: typeof claimAutomationSessionForCleanup;
+  finalizeSession: typeof finalizeExactOwnedAutomationSession;
+}>;
 
 export type AutomationTaskProcessResult = {
   exitCode: number | null;
@@ -310,6 +317,74 @@ export async function finalizePersistedRun(
     sessionCleanupMode: "owned",
     sessionCleanupError: owner ? null : "Missing Libretto session identity",
   });
+}
+
+export async function finalizeForceQuitTaskRun(
+  db: ReturnType<typeof openLedgerDatabase>,
+  run: AutomationTaskRun,
+  session: string,
+  dependencies: ForceQuitFinalizationDependencies = {},
+) {
+  const current = taskRunById(db, run.taskRunId);
+  if (!current || current.status !== "waiting_for_human") {
+    throw new Error(`Automation task is not waiting for human input: ${run.taskId}`);
+  }
+
+  const deps = {
+    readSessionState: readLibrettoSessionState,
+    claimSession: claimAutomationSessionForCleanup,
+    finalizeSession: finalizeExactOwnedAutomationSession,
+    ...dependencies,
+  };
+  let owner: OwnedAutomationSession = {
+    taskId: run.taskId,
+    taskRunId: run.taskRunId,
+    session,
+    pid: null,
+  };
+  let cleanupFailure: unknown = null;
+  const workflowError = "Browser session force quit.";
+  let taskError = workflowError;
+  try {
+    owner = {
+      ...owner,
+      pid: deps.readSessionState(session)?.pid ?? null,
+    };
+    if (!deps.claimSession(owner)) {
+      throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
+    }
+    let finalizeFailure: unknown = null;
+    const cleanupResult = await finalizeTerminalAutomationSession(
+      owner,
+      workflowError,
+      async () => {
+        try {
+          if (!await deps.finalizeSession(owner)) {
+            throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
+          }
+        } catch (error) {
+          finalizeFailure = error;
+          throw error;
+        }
+      },
+    );
+    cleanupFailure = finalizeFailure;
+    taskError = cleanupResult.errorMessage ?? workflowError;
+  } catch (error) {
+    cleanupFailure = error;
+    taskError = appendCleanupError(workflowError, errorMessage(error));
+  }
+
+  await finalizeTaskRunTransition(db, run, {
+    status: "failed",
+    sessionDisposition: "relinquish",
+    exitCode: null,
+    signal: null,
+    errorMessage: taskError,
+    logTail: run.logTail,
+  });
+  if (cleanupFailure) throw cleanupFailure;
+  return { session };
 }
 
 export async function finalizePersistedActiveRuns(

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -1,0 +1,330 @@
+import { appendFileSync, closeSync, mkdirSync, openSync, readSync } from "node:fs";
+import { dirname } from "node:path";
+import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import {
+  statementRunSummaryLine,
+  type StatementRunSummary,
+} from "../statement-run-summary.ts";
+import { resolveTaskCommand } from "./desktop-command.ts";
+import { readLibrettoSessionState } from "./libretto-session.ts";
+import {
+  armAutomationSessionTimeout,
+  finalizeExactOwnedAutomationSession,
+  finalizeOwnedAutomationSession,
+  ownAutomationSession,
+  ownedAutomationSession,
+  type OwnedAutomationSession,
+} from "./session-lifecycle.ts";
+import {
+  activeTaskRuns,
+  taskRunById,
+  updateTaskRun,
+  type AutomationTaskRun,
+  type AutomationTaskStatus,
+} from "./store.ts";
+import { taskById, type AutomationTaskKind } from "./tasks.ts";
+
+const SESSION_LOG_PREFIX_BYTES = 4_000;
+
+export type AutomationTaskRunExecution = {
+  task: NonNullable<ReturnType<typeof taskById>>;
+  taskDb: ReturnType<typeof openLedgerDatabase>;
+  run: Pick<AutomationTaskRun, "taskRunId">;
+  logPath: string;
+  command: ReturnType<typeof resolveTaskCommand>;
+  session: string | null;
+  owner: OwnedAutomationSession | null;
+};
+
+export type AutomationTaskProcessResult = {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  error: Error | null;
+  logTail: string;
+  resumeFailure: string | null;
+  statementSummary: StatementRunSummary | null;
+  outputPersistenceWarnings: string[];
+};
+
+export function appendLog(logPath: string, chunk: string) {
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, chunk);
+}
+
+export function tail(value: string) {
+  return value.slice(-4000);
+}
+
+export function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function shouldRetainAutomationSession(status: AutomationTaskStatus) {
+  return status === "waiting_for_human";
+}
+
+export function appendCleanupError(message: string | null, cleanup: string) {
+  const suffix = "Session cleanup failed: " + cleanup;
+  return message ? message + "\n" + suffix : suffix;
+}
+
+export function shouldMarkWaitingForHuman(output: string) {
+  return /manual-(?:auth|otp)-required|workflow paused|resume --session|\benter\b[^\r\n]*(?:captcha|otp|verification|certificate)/i.test(output);
+}
+
+export function finalFailureMessage(logTail: string, exitCode: number | null) {
+  const message = logTail
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .toReversed()
+    .find((line) =>
+      !/^automation-progress:/i.test(line) &&
+      !/^automation-output-write-failed:/i.test(line) &&
+      !/^libretto run CDP patch/i.test(line) &&
+      !/^Running workflow /i.test(line) &&
+      !/^Browser is still open\./i.test(line)
+    );
+  return message ?? `Task exited with code ${exitCode}`;
+}
+
+export function isForceQuitRun(
+  run: Pick<AutomationTaskRun, "status" | "errorMessage"> | null | undefined,
+) {
+  return run?.status === "failed" && run.errorMessage?.startsWith("Browser session force quit") === true;
+}
+
+export function nextAttemptStatus(input: {
+  kind: AutomationTaskKind;
+  attempt: number;
+  maxAttempts: number;
+  exitCode: number | null;
+  waitingForHuman?: boolean;
+}): AutomationTaskStatus {
+  if (input.exitCode === 0 && input.waitingForHuman) return "waiting_for_human";
+  if (input.exitCode === 0) return "completed";
+  return "failed";
+}
+
+export function automationCleanupFailureDetails(
+  owner: OwnedAutomationSession,
+  error: unknown,
+) {
+  return {
+    taskRunId: owner.taskRunId,
+    sessionId: owner.session,
+    retainedPid: owner.pid,
+    error: errorMessage(error),
+  };
+}
+
+export async function finalizeTerminalAutomationSession(
+  owner: OwnedAutomationSession,
+  workflowError: string | null,
+  finalize: () => Promise<unknown> = () => finalizeExactOwnedAutomationSession(owner),
+) {
+  try {
+    await finalize();
+    return { errorMessage: workflowError, cleanupFailed: false };
+  } catch (error) {
+    console.error(
+      "automation-session-cleanup-failed",
+      automationCleanupFailureDetails(owner, error),
+    );
+    return {
+      errorMessage: appendCleanupError(workflowError, errorMessage(error)),
+      cleanupFailed: true,
+    };
+  }
+}
+
+export function sessionPid(session: string) {
+  try {
+    return readLibrettoSessionState(session)?.pid ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function sessionFromRun(run: AutomationTaskRun) {
+  try {
+    const buffer = Buffer.alloc(SESSION_LOG_PREFIX_BYTES);
+    const descriptor = openSync(run.logPath, "r");
+    let length: number;
+    try {
+      length = readSync(descriptor, buffer, 0, SESSION_LOG_PREFIX_BYTES, 0);
+    } finally {
+      closeSync(descriptor);
+    }
+    const output = buffer.toString("utf8", 0, length);
+    const session = automationSessionFromLog(output) ?? resumeSessionFromLog(output);
+    if (session) return session;
+  } catch {
+    // The bounded log tail remains the recovery source when the log file is unavailable.
+  }
+  return automationSessionFromLog(run.logTail) ?? resumeSessionFromLog(run.logTail);
+}
+
+export function automationSessionFromLog(output: string) {
+  return output.match(/automation-session:\s+([A-Za-z0-9._-]+)/i)?.[1] ?? null;
+}
+
+export function resumeSessionFromLog(output: string) {
+  return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
+}
+
+export async function finalizePersistedRun(
+  db: ReturnType<typeof openLedgerDatabase>,
+  run: AutomationTaskRun,
+  reason: string,
+) {
+  const session = sessionFromRun(run);
+  const pid = session ? sessionPid(session) : null;
+  let cleanupError: string | null = null;
+  if (!session) {
+    cleanupError = "Missing Libretto session identity";
+  } else {
+    ownAutomationSession({ taskId: run.taskId, taskRunId: run.taskRunId, session, pid });
+    try {
+      await finalizeOwnedAutomationSession(run.taskId);
+    } catch (error) {
+      cleanupError = errorMessage(error);
+    }
+  }
+  updateTaskRun(db, run.taskRunId, {
+    status: "failed",
+    finishedAt: new Date().toISOString(),
+    exitCode: null,
+    signal: null,
+    errorMessage: cleanupError
+      ? appendCleanupError(run.errorMessage ?? reason, cleanupError)
+      : run.errorMessage ?? reason,
+  });
+  appendLog(
+    run.logPath,
+    `automation-session-finalize: session=${session ?? "unknown"} pid=${pid ?? "unknown"} cleanup-error=${cleanupError ?? "none"}\n`,
+  );
+}
+
+export async function finalizePersistedActiveRuns(
+  ledgerDir: string,
+  reason: string,
+  finalizeRun: typeof finalizePersistedRun = finalizePersistedRun,
+) {
+  const db = openLedgerDatabase(ledgerDir);
+  const errors: unknown[] = [];
+  try {
+    for (const run of activeTaskRuns(db)) {
+      try {
+        await finalizeRun(db, run, reason);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+  } finally {
+    db.close();
+  }
+  if (errors.length) throw new AggregateError(errors, "Failed to finalize persisted automation runs");
+}
+
+function scheduleAutomationTaskRunTimeout(
+  execution: AutomationTaskRunExecution,
+  ledgerDir: string,
+) {
+  if (!execution.session) return;
+  const timeoutOwner = {
+    taskId: execution.task.id,
+    taskRunId: execution.run.taskRunId,
+    session: execution.session,
+  };
+  armAutomationSessionTimeout(execution.task.id, async () => {
+    const timeoutDb = openLedgerDatabase(ledgerDir);
+    try {
+      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
+      let timeoutError: string | null = null;
+      try {
+        await finalizeExactOwnedAutomationSession(timeoutOwner);
+      } catch (error) {
+        timeoutError = errorMessage(error);
+      }
+      if (taskRunById(timeoutDb, execution.run.taskRunId)?.status !== "waiting_for_human") return;
+      updateTaskRun(timeoutDb, execution.run.taskRunId, {
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        exitCode: null,
+        signal: null,
+        errorMessage: timeoutError
+          ? appendCleanupError("等待人工操作超過 20 分鐘", timeoutError)
+          : "等待人工操作超過 20 分鐘",
+      });
+    } catch (error) {
+      console.error("automation-session-timeout-failed", error);
+    } finally {
+      timeoutDb.close();
+    }
+  });
+}
+
+export async function finalizeAutomationTaskRun(
+  execution: AutomationTaskRunExecution,
+  result: AutomationTaskProcessResult,
+  ledgerDir: string,
+) {
+  const resumeFailure = result.resumeFailure;
+  let status: AutomationTaskStatus = result.error || resumeFailure
+    ? "failed"
+    : nextAttemptStatus({
+      kind: execution.task.kind,
+      attempt: 1,
+      maxAttempts: 1,
+      exitCode: result.exitCode,
+      waitingForHuman: shouldMarkWaitingForHuman(result.logTail),
+    });
+  if (status === "completed" && result.statementSummary) status = result.statementSummary.status;
+  const statementFailure = result.statementSummary?.status === "failed"
+    ? result.statementSummary.results
+      .filter((statement) => statement.status === "failed")
+      .map((statement) => `${statement.typeId}: ${statement.error ?? "Failed"}`)
+      .join("\n") || "No statement components completed."
+    : null;
+  let taskError = result.error?.message
+    ?? resumeFailure
+    ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
+  taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
+  if (execution.owner && !shouldRetainAutomationSession(status)) {
+    const retainedOwner = ownedAutomationSession(execution.task.id) ?? execution.owner;
+    const cleanup = await finalizeTerminalAutomationSession(
+      retainedOwner,
+      taskError,
+      () => finalizeExactOwnedAutomationSession(execution.owner!),
+    );
+    taskError = cleanup.errorMessage;
+    if (cleanup.cleanupFailed && (status === "completed" || status === "partial")) status = "failed";
+  }
+  if (isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) return { status: "failed" as const };
+  let logTail = result.logTail;
+  if (result.statementSummary) {
+    const summaryLine = statementRunSummaryLine(result.statementSummary.results);
+    try {
+      appendLog(execution.logPath, `\n${summaryLine}\n`);
+    } catch (error) {
+      const warning = `automation-output-write-failed: ${errorMessage(error)}`;
+      console.error(warning);
+      taskError = [taskError, warning].filter(Boolean).join("\n") || null;
+      logTail = tail(`${logTail}\n${warning}\n`);
+    }
+    logTail = tail(`${logTail}\n${summaryLine}\n`);
+  }
+  updateTaskRun(execution.taskDb, execution.run.taskRunId, {
+    status,
+    finishedAt: new Date().toISOString(),
+    exitCode: result.exitCode,
+    signal: result.signal,
+    logTail,
+    errorMessage: taskError,
+  });
+  if (execution.session && shouldRetainAutomationSession(status)) {
+    scheduleAutomationTaskRunTimeout(execution, ledgerDir);
+  }
+  return { status };
+}

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -171,6 +171,9 @@ type TaskRunFinalizationIntent = {
   errorMessage: string | null;
   logTail: string;
   statementSummary?: StatementRunSummary | null;
+};
+
+type TaskRunFinalizationImplementation = {
   sessionFinalizationLog?: boolean;
   sessionOwner?: OwnedAutomationSession | null;
   sessionCleanupMode?: "exact" | "owned";
@@ -185,6 +188,7 @@ async function finalizeTaskRunTransition(
   db: ReturnType<typeof openLedgerDatabase>,
   run: Pick<AutomationTaskRun, "taskRunId" | "logPath">,
   intent: TaskRunFinalizationIntent,
+  implementation: TaskRunFinalizationImplementation = {},
 ) {
   const current = taskRunById(db, run.taskRunId);
   if (!current) throw new Error(`Missing automation task run: ${run.taskRunId}`);
@@ -201,18 +205,18 @@ async function finalizeTaskRunTransition(
   let logTail = intent.logTail;
   let cleanupResult: SessionCleanupResult | null = null;
   if (intent.sessionDisposition === "relinquish") {
-    if (intent.sessionCleanupError) {
+    if (implementation.sessionCleanupError) {
       cleanupResult = {
-        errorMessage: appendCleanupError(taskError, intent.sessionCleanupError),
+        errorMessage: appendCleanupError(taskError, implementation.sessionCleanupError),
         cleanupFailed: true,
       };
-    } else if (intent.sessionOwner) {
-      if (intent.sessionCleanupMode === "owned") ownAutomationSession(intent.sessionOwner);
+    } else if (implementation.sessionOwner) {
+      if (implementation.sessionCleanupMode === "owned") ownAutomationSession(implementation.sessionOwner);
       cleanupResult = await finalizeTerminalAutomationSession(
-        intent.sessionOwner,
+        implementation.sessionOwner,
         taskError,
-        intent.sessionCleanupMode === "owned"
-          ? () => finalizeOwnedAutomationSession(intent.sessionOwner!.taskId)
+        implementation.sessionCleanupMode === "owned"
+          ? () => finalizeOwnedAutomationSession(implementation.sessionOwner!.taskId)
           : undefined,
       );
     }
@@ -231,11 +235,11 @@ async function finalizeTaskRunTransition(
   const summaryLine = intent.statementSummary
     ? statementRunSummaryLine(intent.statementSummary.results)
     : null;
-  const logAppend = intent.sessionFinalizationLog
+  const logAppend = implementation.sessionFinalizationLog
     ? "automation-session-finalize: session="
-      + (intent.sessionOwner?.session ?? "unknown")
-      + " pid=" + (intent.sessionOwner?.pid ?? "unknown")
-      + " cleanup-error=" + (cleanupResult?.cleanupFailed ? "failed" : intent.sessionCleanupError ?? "none") + "\n"
+      + (implementation.sessionOwner?.session ?? "unknown")
+      + " pid=" + (implementation.sessionOwner?.pid ?? "unknown")
+      + " cleanup-error=" + (cleanupResult?.cleanupFailed ? "failed" : implementation.sessionCleanupError ?? "none") + "\n"
     : summaryLine
       ? `\n${summaryLine}\n`
       : null;
@@ -312,6 +316,7 @@ export async function finalizePersistedRun(
     signal: null,
     errorMessage: run.errorMessage ?? reason,
     logTail: run.logTail,
+  }, {
     sessionFinalizationLog: true,
     sessionOwner: owner,
     sessionCleanupMode: "owned",
@@ -430,6 +435,7 @@ function scheduleAutomationTaskRunTimeout(
         signal: null,
         errorMessage: "等待人工操作超過 20 分鐘",
         logTail: run.logTail,
+      }, {
         sessionOwner: timeoutOwner,
         sessionCleanupMode: "exact",
       });
@@ -486,6 +492,7 @@ export async function finalizeAutomationTaskRun(
     errorMessage: taskError,
     logTail,
     statementSummary: result.statementSummary,
+  }, {
     sessionOwner: owner,
     sessionCleanupMode: "exact",
   });

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -36,6 +36,17 @@ export type AutomationTaskRunExecution = {
   owner: OwnedAutomationSession | null;
 };
 
+export type AutomationTaskRunFinalizationContext = {
+  taskDb: ReturnType<typeof openLedgerDatabase>;
+  taskId: string;
+  taskKind: AutomationTaskKind;
+  taskRunId: string;
+  logPath: string;
+  ledgerDir: string;
+  session: string | null;
+  owner: OwnedAutomationSession | null;
+};
+
 export type AutomationTaskProcessResult = {
   exitCode: number | null;
   signal: NodeJS.Signals | null;
@@ -143,14 +154,20 @@ type SessionCleanupResult = {
   cleanupFailed: boolean;
 };
 
-type TaskRunFinalizationPlan = {
+type AutomationSessionDisposition = "retain" | "relinquish";
+
+type TaskRunFinalizationIntent = {
   status: AutomationTaskStatus;
+  sessionDisposition: AutomationSessionDisposition;
   exitCode: number | null;
   signal: NodeJS.Signals | null;
   errorMessage: string | null;
   logTail: string;
-  logAppend?: string | ((cleanup: SessionCleanupResult | null) => string);
-  cleanup?: (workflowError: string | null) => Promise<SessionCleanupResult>;
+  statementSummary?: StatementRunSummary | null;
+  sessionFinalizationLog?: boolean;
+  sessionOwner?: OwnedAutomationSession | null;
+  sessionCleanupMode?: "exact" | "owned";
+  sessionCleanupError?: string | null;
 };
 
 function isTerminalTaskRunStatus(status: AutomationTaskStatus) {
@@ -160,7 +177,7 @@ function isTerminalTaskRunStatus(status: AutomationTaskStatus) {
 async function finalizeTaskRunTransition(
   db: ReturnType<typeof openLedgerDatabase>,
   run: Pick<AutomationTaskRun, "taskRunId" | "logPath">,
-  plan: TaskRunFinalizationPlan,
+  intent: TaskRunFinalizationIntent,
 ) {
   const current = taskRunById(db, run.taskRunId);
   if (!current) throw new Error(`Missing automation task run: ${run.taskRunId}`);
@@ -168,18 +185,32 @@ async function finalizeTaskRunTransition(
   if (current.status !== "running" && current.status !== "waiting_for_human") {
     return { status: current.status, skipped: true };
   }
-  if (current.status === "waiting_for_human" && plan.status !== "failed") {
+  if (current.status === "waiting_for_human" && intent.status !== "failed") {
     return { status: current.status, skipped: true };
   }
 
-  let status = plan.status;
-  let taskError = plan.errorMessage;
-  let logTail = plan.logTail;
+  let status = intent.status;
+  let taskError = intent.errorMessage;
+  let logTail = intent.logTail;
   let cleanupResult: SessionCleanupResult | null = null;
-  if (plan.cleanup) {
-    cleanupResult = await plan.cleanup(taskError);
-    taskError = cleanupResult.errorMessage;
-    if (cleanupResult.cleanupFailed && (status === "completed" || status === "partial")) {
+  if (intent.sessionDisposition === "relinquish") {
+    if (intent.sessionCleanupError) {
+      cleanupResult = {
+        errorMessage: appendCleanupError(taskError, intent.sessionCleanupError),
+        cleanupFailed: true,
+      };
+    } else if (intent.sessionOwner) {
+      if (intent.sessionCleanupMode === "owned") ownAutomationSession(intent.sessionOwner);
+      cleanupResult = await finalizeTerminalAutomationSession(
+        intent.sessionOwner,
+        taskError,
+        intent.sessionCleanupMode === "owned"
+          ? () => finalizeOwnedAutomationSession(intent.sessionOwner!.taskId)
+          : undefined,
+      );
+    }
+    if (cleanupResult) taskError = cleanupResult.errorMessage;
+    if (cleanupResult?.cleanupFailed && (status === "completed" || status === "partial")) {
       status = "failed";
     }
   }
@@ -190,14 +221,20 @@ async function finalizeTaskRunTransition(
     return { status: afterCleanup.status, skipped: true };
   }
 
-  if (plan.logAppend) {
+  const summaryLine = intent.statementSummary
+    ? statementRunSummaryLine(intent.statementSummary.results)
+    : null;
+  const logAppend = intent.sessionFinalizationLog
+    ? "automation-session-finalize: session="
+      + (intent.sessionOwner?.session ?? "unknown")
+      + " pid=" + (intent.sessionOwner?.pid ?? "unknown")
+      + " cleanup-error=" + (cleanupResult?.cleanupFailed ? "failed" : intent.sessionCleanupError ?? "none") + "\n"
+    : summaryLine
+      ? `\n${summaryLine}\n`
+      : null;
+  if (logAppend) {
     try {
-      appendLog(
-        run.logPath,
-        typeof plan.logAppend === "function"
-          ? plan.logAppend(cleanupResult)
-          : plan.logAppend,
-      );
+      appendLog(run.logPath, logAppend);
     } catch (error) {
       const warning = `automation-output-write-failed: ${errorMessage(error)}`;
       console.error(warning);
@@ -208,8 +245,8 @@ async function finalizeTaskRunTransition(
   updateTaskRun(db, run.taskRunId, {
     status,
     finishedAt: new Date().toISOString(),
-    exitCode: plan.exitCode,
-    signal: plan.signal,
+    exitCode: intent.exitCode,
+    signal: intent.signal,
     logTail,
     errorMessage: taskError,
   });
@@ -261,32 +298,17 @@ export async function finalizePersistedRun(
   const owner = session
     ? { taskId: run.taskId, taskRunId: run.taskRunId, session, pid }
     : null;
-  let cleanupError: string | null = owner ? null : "Missing Libretto session identity";
   const result = await finalizeTaskRunTransition(db, run, {
     status: "failed",
+    sessionDisposition: "relinquish",
     exitCode: null,
     signal: null,
     errorMessage: run.errorMessage ?? reason,
     logTail: run.logTail,
-    logAppend: () => "automation-session-finalize: session="
-      + (session ?? "unknown")
-      + " pid=" + (pid ?? "unknown")
-      + " cleanup-error=" + (cleanupError ?? "none") + "\n",
-    cleanup: owner
-      ? async (workflowError) => {
-        ownAutomationSession(owner);
-        const result = await finalizeTerminalAutomationSession(
-          owner,
-          workflowError,
-          () => finalizeOwnedAutomationSession(run.taskId),
-        );
-        if (result.cleanupFailed) cleanupError = result.errorMessage;
-        return result;
-      }
-      : async (workflowError) => ({
-        errorMessage: appendCleanupError(workflowError, cleanupError ?? "Missing Libretto session identity"),
-        cleanupFailed: true,
-      }),
+    sessionFinalizationLog: true,
+    sessionOwner: owner,
+    sessionCleanupMode: "owned",
+    sessionCleanupError: owner ? null : "Missing Libretto session identity",
   });
 }
 
@@ -312,32 +334,29 @@ export async function finalizePersistedActiveRuns(
 }
 
 function scheduleAutomationTaskRunTimeout(
-  execution: AutomationTaskRunExecution,
-  ledgerDir: string,
+  context: AutomationTaskRunFinalizationContext,
 ) {
-  if (!execution.session) return;
-  const timeoutOwner = execution.owner ?? {
-    taskId: execution.task.id,
-    taskRunId: execution.run.taskRunId,
-    session: execution.session,
-    pid: sessionPid(execution.session),
+  if (!context.session) return;
+  const timeoutOwner = context.owner ?? {
+    taskId: context.taskId,
+    taskRunId: context.taskRunId,
+    session: context.session,
+    pid: sessionPid(context.session),
   };
-  armAutomationSessionTimeout(execution.task.id, async () => {
-    const timeoutDb = openLedgerDatabase(ledgerDir);
+  armAutomationSessionTimeout(context.taskId, async () => {
+    const timeoutDb = openLedgerDatabase(context.ledgerDir);
     try {
-      const run = taskRunById(timeoutDb, execution.run.taskRunId);
+      const run = taskRunById(timeoutDb, context.taskRunId);
       if (!run || run.status !== "waiting_for_human") return;
       await finalizeTaskRunTransition(timeoutDb, run, {
         status: "failed",
+        sessionDisposition: "relinquish",
         exitCode: null,
         signal: null,
         errorMessage: "等待人工操作超過 20 分鐘",
         logTail: run.logTail,
-        cleanup: (workflowError) => finalizeTerminalAutomationSession(
-          timeoutOwner,
-          workflowError,
-          () => finalizeExactOwnedAutomationSession(timeoutOwner),
-        ),
+        sessionOwner: timeoutOwner,
+        sessionCleanupMode: "exact",
       });
     } catch (error) {
       console.error("automation-session-timeout-failed", error);
@@ -348,15 +367,14 @@ function scheduleAutomationTaskRunTimeout(
 }
 
 export async function finalizeAutomationTaskRun(
-  execution: AutomationTaskRunExecution,
+  context: AutomationTaskRunFinalizationContext,
   result: AutomationTaskProcessResult,
-  ledgerDir: string,
 ) {
   const resumeFailure = result.resumeFailure;
   let status: AutomationTaskStatus = result.error || resumeFailure
     ? "failed"
     : nextAttemptStatus({
-      kind: execution.task.kind,
+      kind: context.taskKind,
       attempt: 1,
       maxAttempts: 1,
       exitCode: result.exitCode,
@@ -373,36 +391,31 @@ export async function finalizeAutomationTaskRun(
     ?? resumeFailure
     ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
   taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
-  if (isForceQuitRun(taskRunById(execution.taskDb, execution.run.taskRunId))) return { status: "failed" as const };
+  if (isForceQuitRun(taskRunById(context.taskDb, context.taskRunId))) return { status: "failed" as const };
   let logTail = result.logTail;
-  let summaryLine: string | undefined;
   if (result.statementSummary) {
-    summaryLine = statementRunSummaryLine(result.statementSummary.results);
-    logTail = tail(`${logTail}\n${summaryLine}\n`);
+    logTail = tail(`${logTail}\n${statementRunSummaryLine(result.statementSummary.results)}\n`);
   }
-  const owner = execution.owner && !shouldRetainAutomationSession(status)
-    ? ownedAutomationSession(execution.task.id) ?? execution.owner
+  const sessionDisposition = shouldRetainAutomationSession(status) ? "retain" : "relinquish";
+  const owner = context.owner && sessionDisposition === "relinquish"
+    ? ownedAutomationSession(context.taskId) ?? context.owner
     : null;
-  const transition = await finalizeTaskRunTransition(execution.taskDb, {
-    taskRunId: execution.run.taskRunId,
-    logPath: execution.logPath,
+  const transition = await finalizeTaskRunTransition(context.taskDb, {
+    taskRunId: context.taskRunId,
+    logPath: context.logPath,
   }, {
     status,
+    sessionDisposition,
     exitCode: result.exitCode,
     signal: result.signal,
     errorMessage: taskError,
     logTail,
-    logAppend: summaryLine ? `\n${summaryLine}\n` : undefined,
-    cleanup: owner
-      ? async (workflowError) => finalizeTerminalAutomationSession(
-        owner,
-        workflowError,
-        () => finalizeExactOwnedAutomationSession(execution.owner!),
-      )
-      : undefined,
+    statementSummary: result.statementSummary,
+    sessionOwner: owner,
+    sessionCleanupMode: "exact",
   });
-  if (!transition.skipped && execution.session && shouldRetainAutomationSession(status)) {
-    scheduleAutomationTaskRunTimeout(execution, ledgerDir);
+  if (!transition.skipped && context.session && sessionDisposition === "retain") {
+    scheduleAutomationTaskRunTimeout(context);
   }
   return { status: transition.status };
 }

--- a/src/lib/automation/server/task-run-finalization.ts
+++ b/src/lib/automation/server/task-run-finalization.ts
@@ -1,21 +1,32 @@
-import { appendFileSync, closeSync, mkdirSync, openSync, readSync } from "node:fs";
-import { dirname } from "node:path";
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
 import {
   statementRunSummaryLine,
   type StatementRunSummary,
 } from "../statement-run-summary.ts";
 import { resolveTaskCommand } from "./desktop-command.ts";
-import { readLibrettoSessionState } from "./libretto-session.ts";
 import {
-  armAutomationSessionTimeout,
-  claimAutomationSessionForCleanup,
-  finalizeExactOwnedAutomationSession,
-  finalizeOwnedAutomationSession,
-  ownAutomationSession,
-  ownedAutomationSession,
+  appendLog,
+  automationSessionOwnerForRun,
+  errorMessage,
+  finalizeAutomationSessionForRun,
+  forceQuitAutomationSessionForRun,
+  armAutomationSessionDispositionTimeout,
+  sessionFromRun,
+  tail,
+  type AutomationSessionCleanupResult,
+  type AutomationSessionDisposition,
+  type ForceQuitFinalizationDependencies,
   type OwnedAutomationSession,
-} from "./session-lifecycle.ts";
+} from "./automation-session-disposition.ts";
+export {
+  appendCleanupError,
+  automationCleanupFailureDetails,
+  automationSessionFromLog,
+  errorMessage,
+  finalizeAutomationSession as finalizeTerminalAutomationSession,
+  resumeSessionFromLog,
+} from "./automation-session-disposition.ts";
+export type { ForceQuitFinalizationDependencies } from "./automation-session-disposition.ts";
 import {
   activeTaskRuns,
   taskRunById,
@@ -24,8 +35,6 @@ import {
   type AutomationTaskStatus,
 } from "./store.ts";
 import { taskById, type AutomationTaskKind } from "./tasks.ts";
-
-const SESSION_LOG_PREFIX_BYTES = 4_000;
 
 export type AutomationTaskRunExecution = {
   task: NonNullable<ReturnType<typeof taskById>>;
@@ -44,15 +53,7 @@ export type AutomationTaskRunFinalizationContext = {
   taskRunId: string;
   logPath: string;
   ledgerDir: string;
-  session: string | null;
-  owner: OwnedAutomationSession | null;
 };
-
-export type ForceQuitFinalizationDependencies = Partial<{
-  readSessionState: typeof readLibrettoSessionState;
-  claimSession: typeof claimAutomationSessionForCleanup;
-  finalizeSession: typeof finalizeExactOwnedAutomationSession;
-}>;
 
 export type AutomationTaskProcessResult = {
   exitCode: number | null;
@@ -64,26 +65,8 @@ export type AutomationTaskProcessResult = {
   outputPersistenceWarnings: string[];
 };
 
-export function appendLog(logPath: string, chunk: string) {
-  mkdirSync(dirname(logPath), { recursive: true });
-  appendFileSync(logPath, chunk);
-}
-
-export function tail(value: string) {
-  return value.slice(-4000);
-}
-
-export function errorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
-
 export function shouldRetainAutomationSession(status: AutomationTaskStatus) {
   return status === "waiting_for_human";
-}
-
-export function appendCleanupError(message: string | null, cleanup: string) {
-  const suffix = "Session cleanup failed: " + cleanup;
-  return message ? message + "\n" + suffix : suffix;
 }
 
 export function shouldMarkWaitingForHuman(output: string) {
@@ -124,45 +107,6 @@ export function nextAttemptStatus(input: {
   return "failed";
 }
 
-export function automationCleanupFailureDetails(
-  owner: OwnedAutomationSession,
-  error: unknown,
-) {
-  return {
-    taskRunId: owner.taskRunId,
-    sessionId: owner.session,
-    retainedPid: owner.pid,
-    error: errorMessage(error),
-  };
-}
-
-export async function finalizeTerminalAutomationSession(
-  owner: OwnedAutomationSession,
-  workflowError: string | null,
-  finalize: () => Promise<unknown> = () => finalizeExactOwnedAutomationSession(owner),
-) {
-  try {
-    await finalize();
-    return { errorMessage: workflowError, cleanupFailed: false };
-  } catch (error) {
-    console.error(
-      "automation-session-cleanup-failed",
-      automationCleanupFailureDetails(owner, error),
-    );
-    return {
-      errorMessage: appendCleanupError(workflowError, errorMessage(error)),
-      cleanupFailed: true,
-    };
-  }
-}
-
-type SessionCleanupResult = {
-  errorMessage: string | null;
-  cleanupFailed: boolean;
-};
-
-type AutomationSessionDisposition = "retain" | "relinquish";
-
 type TaskRunFinalizationIntent = {
   status: AutomationTaskStatus;
   sessionDisposition: AutomationSessionDisposition;
@@ -175,9 +119,7 @@ type TaskRunFinalizationIntent = {
 
 type TaskRunFinalizationImplementation = {
   sessionFinalizationLog?: boolean;
-  sessionOwner?: OwnedAutomationSession | null;
-  sessionCleanupMode?: "exact" | "owned";
-  sessionCleanupError?: string | null;
+  sessionCleanup?: AutomationSessionCleanupResult | null;
 };
 
 function isTerminalTaskRunStatus(status: AutomationTaskStatus) {
@@ -203,25 +145,12 @@ async function finalizeTaskRunTransition(
   let status = intent.status;
   let taskError = intent.errorMessage;
   let logTail = intent.logTail;
-  let cleanupResult: SessionCleanupResult | null = null;
-  if (intent.sessionDisposition === "relinquish") {
-    if (implementation.sessionCleanupError) {
-      cleanupResult = {
-        errorMessage: appendCleanupError(taskError, implementation.sessionCleanupError),
-        cleanupFailed: true,
-      };
-    } else if (implementation.sessionOwner) {
-      if (implementation.sessionCleanupMode === "owned") ownAutomationSession(implementation.sessionOwner);
-      cleanupResult = await finalizeTerminalAutomationSession(
-        implementation.sessionOwner,
-        taskError,
-        implementation.sessionCleanupMode === "owned"
-          ? () => finalizeOwnedAutomationSession(implementation.sessionOwner!.taskId)
-          : undefined,
-      );
-    }
-    if (cleanupResult) taskError = cleanupResult.errorMessage;
-    if (cleanupResult?.cleanupFailed && (status === "completed" || status === "partial")) {
+  const cleanupResult = intent.sessionDisposition === "relinquish"
+    ? implementation.sessionCleanup
+    : null;
+  if (cleanupResult) {
+    taskError = cleanupResult.errorMessage;
+    if (cleanupResult.cleanupFailed && (status === "completed" || status === "partial")) {
       status = "failed";
     }
   }
@@ -237,9 +166,9 @@ async function finalizeTaskRunTransition(
     : null;
   const logAppend = implementation.sessionFinalizationLog
     ? "automation-session-finalize: session="
-      + (implementation.sessionOwner?.session ?? "unknown")
-      + " pid=" + (implementation.sessionOwner?.pid ?? "unknown")
-      + " cleanup-error=" + (cleanupResult?.cleanupFailed ? "failed" : implementation.sessionCleanupError ?? "none") + "\n"
+      + (cleanupResult?.session ?? "unknown")
+      + " pid=" + (cleanupResult?.pid ?? "unknown")
+      + " cleanup-error=" + (cleanupResult?.cleanupFailed ? "failed" : "none") + "\n"
     : summaryLine
       ? `\n${summaryLine}\n`
       : null;
@@ -264,132 +193,56 @@ async function finalizeTaskRunTransition(
   return { status, skipped: false };
 }
 
-export function sessionPid(session: string) {
-  try {
-    return readLibrettoSessionState(session)?.pid ?? null;
-  } catch {
-    return null;
-  }
-}
-
-export function sessionFromRun(run: AutomationTaskRun) {
-  try {
-    const buffer = Buffer.alloc(SESSION_LOG_PREFIX_BYTES);
-    const descriptor = openSync(run.logPath, "r");
-    let length: number;
-    try {
-      length = readSync(descriptor, buffer, 0, SESSION_LOG_PREFIX_BYTES, 0);
-    } finally {
-      closeSync(descriptor);
-    }
-    const output = buffer.toString("utf8", 0, length);
-    const session = automationSessionFromLog(output) ?? resumeSessionFromLog(output);
-    if (session) return session;
-  } catch {
-    // The bounded log tail remains the recovery source when the log file is unavailable.
-  }
-  return automationSessionFromLog(run.logTail) ?? resumeSessionFromLog(run.logTail);
-}
-
-export function automationSessionFromLog(output: string) {
-  return output.match(/automation-session:\s+([A-Za-z0-9._-]+)/i)?.[1] ?? null;
-}
-
-export function resumeSessionFromLog(output: string) {
-  return output.match(/libretto resume --session\s+([\w-]+)/i)?.[1] ?? null;
-}
-
 export async function finalizePersistedRun(
   db: ReturnType<typeof openLedgerDatabase>,
   run: AutomationTaskRun,
   reason: string,
 ) {
-  const session = sessionFromRun(run);
-  const pid = session ? sessionPid(session) : null;
-  const owner = session
-    ? { taskId: run.taskId, taskRunId: run.taskRunId, session, pid }
-    : null;
-  const result = await finalizeTaskRunTransition(db, run, {
+  const current = taskRunById(db, run.taskRunId);
+  if (!current || isTerminalTaskRunStatus(current.status)) return;
+  const sessionCleanup = await finalizeAutomationSessionForRun(
+    current,
+    current.errorMessage ?? reason,
+    "recovery",
+  );
+  await finalizeTaskRunTransition(db, run, {
     status: "failed",
     sessionDisposition: "relinquish",
     exitCode: null,
     signal: null,
-    errorMessage: run.errorMessage ?? reason,
-    logTail: run.logTail,
+    errorMessage: null,
+    logTail: current.logTail,
   }, {
     sessionFinalizationLog: true,
-    sessionOwner: owner,
-    sessionCleanupMode: "owned",
-    sessionCleanupError: owner ? null : "Missing Libretto session identity",
+    sessionCleanup,
   });
 }
 
 export async function finalizeForceQuitTaskRun(
   db: ReturnType<typeof openLedgerDatabase>,
   run: AutomationTaskRun,
-  session: string,
   dependencies: ForceQuitFinalizationDependencies = {},
 ) {
   const current = taskRunById(db, run.taskRunId);
   if (!current || current.status !== "waiting_for_human") {
     throw new Error(`Automation task is not waiting for human input: ${run.taskId}`);
   }
-
-  const deps = {
-    readSessionState: readLibrettoSessionState,
-    claimSession: claimAutomationSessionForCleanup,
-    finalizeSession: finalizeExactOwnedAutomationSession,
-    ...dependencies,
-  };
-  let owner: OwnedAutomationSession = {
-    taskId: run.taskId,
-    taskRunId: run.taskRunId,
-    session,
-    pid: null,
-  };
-  let cleanupFailure: unknown = null;
-  const workflowError = "Browser session force quit.";
-  let taskError = workflowError;
-  try {
-    owner = {
-      ...owner,
-      pid: deps.readSessionState(session)?.pid ?? null,
-    };
-    if (!deps.claimSession(owner)) {
-      throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
-    }
-    let finalizeFailure: unknown = null;
-    const cleanupResult = await finalizeTerminalAutomationSession(
-      owner,
-      workflowError,
-      async () => {
-        try {
-          if (!await deps.finalizeSession(owner)) {
-            throw new Error(`Automation session ownership changed for task: ${run.taskId}`);
-          }
-        } catch (error) {
-          finalizeFailure = error;
-          throw error;
-        }
-      },
-    );
-    cleanupFailure = finalizeFailure;
-    taskError = cleanupResult.errorMessage ?? workflowError;
-  } catch (error) {
-    cleanupFailure = error;
-    taskError = appendCleanupError(workflowError, errorMessage(error));
-  }
-
+  const { operationalError, ...sessionCleanup } = await forceQuitAutomationSessionForRun(
+    run,
+    dependencies,
+  );
   await finalizeTaskRunTransition(db, run, {
     status: "failed",
     sessionDisposition: "relinquish",
     exitCode: null,
     signal: null,
-    errorMessage: taskError,
+    errorMessage: null,
     logTail: run.logTail,
+  }, {
+    sessionCleanup,
   });
-  if (cleanupFailure) throw cleanupFailure;
-  return { session };
+  if (operationalError) throw operationalError;
+  return { session: sessionCleanup.session };
 }
 
 export async function finalizePersistedActiveRuns(
@@ -416,28 +269,27 @@ export async function finalizePersistedActiveRuns(
 function scheduleAutomationTaskRunTimeout(
   context: AutomationTaskRunFinalizationContext,
 ) {
-  if (!context.session) return;
-  const timeoutOwner = context.owner ?? {
-    taskId: context.taskId,
-    taskRunId: context.taskRunId,
-    session: context.session,
-    pid: sessionPid(context.session),
-  };
-  armAutomationSessionTimeout(context.taskId, async () => {
+  const initialRun = taskRunById(context.taskDb, context.taskRunId);
+  if (!initialRun || !sessionFromRun(initialRun)) return;
+  armAutomationSessionDispositionTimeout(context.taskId, async () => {
     const timeoutDb = openLedgerDatabase(context.ledgerDir);
     try {
       const run = taskRunById(timeoutDb, context.taskRunId);
       if (!run || run.status !== "waiting_for_human") return;
+      const sessionCleanup = await finalizeAutomationSessionForRun(
+        run,
+        "等待人工操作超過 20 分鐘",
+        "exact",
+      );
       await finalizeTaskRunTransition(timeoutDb, run, {
         status: "failed",
         sessionDisposition: "relinquish",
         exitCode: null,
         signal: null,
-        errorMessage: "等待人工操作超過 20 分鐘",
+        errorMessage: null,
         logTail: run.logTail,
       }, {
-        sessionOwner: timeoutOwner,
-        sessionCleanupMode: "exact",
+        sessionCleanup,
       });
     } catch (error) {
       console.error("automation-session-timeout-failed", error);
@@ -472,14 +324,18 @@ export async function finalizeAutomationTaskRun(
     ?? resumeFailure
     ?? (status === "failed" ? statementFailure || finalFailureMessage(result.logTail, result.exitCode) : null);
   taskError = [taskError, ...result.outputPersistenceWarnings].filter(Boolean).join("\n") || null;
-  if (isForceQuitRun(taskRunById(context.taskDb, context.taskRunId))) return { status: "failed" as const };
+  const currentRun = taskRunById(context.taskDb, context.taskRunId);
+  if (!currentRun) throw new Error(`Missing automation task run: ${context.taskRunId}`);
+  if (isTerminalTaskRunStatus(currentRun.status)) return { status: currentRun.status };
+  if (isForceQuitRun(currentRun)) return { status: "failed" as const };
   let logTail = result.logTail;
   if (result.statementSummary) {
     logTail = tail(`${logTail}\n${statementRunSummaryLine(result.statementSummary.results)}\n`);
   }
   const sessionDisposition = shouldRetainAutomationSession(status) ? "retain" : "relinquish";
-  const owner = context.owner && sessionDisposition === "relinquish"
-    ? ownedAutomationSession(context.taskId) ?? context.owner
+  const sessionCleanup = sessionDisposition === "relinquish" && currentRun
+    && automationSessionOwnerForRun(currentRun)
+    ? await finalizeAutomationSessionForRun(currentRun, taskError, "exact")
     : null;
   const transition = await finalizeTaskRunTransition(context.taskDb, {
     taskRunId: context.taskRunId,
@@ -493,10 +349,9 @@ export async function finalizeAutomationTaskRun(
     logTail,
     statementSummary: result.statementSummary,
   }, {
-    sessionOwner: owner,
-    sessionCleanupMode: "exact",
+    sessionCleanup,
   });
-  if (!transition.skipped && context.session && sessionDisposition === "retain") {
+  if (!transition.skipped && sessionDisposition === "retain") {
     scheduleAutomationTaskRunTimeout(context);
   }
   return { status: transition.status };

--- a/src/lib/automation/server/tasks.ts
+++ b/src/lib/automation/server/tasks.ts
@@ -1,5 +1,5 @@
 import type { AutomationCredentialGroup, AutomationTaskKind, AutomationTaskSummary } from "../types.ts";
-import { BANK_STATEMENT_CAPABILITIES, resolveStatementSelection } from "../statement-selection.ts";
+import { BANK_STATEMENT_CAPABILITIES } from "../statement-selection.ts";
 
 export type { AutomationCredentialGroup, AutomationTaskKind, AutomationTaskSummary } from "../types.ts";
 
@@ -24,8 +24,6 @@ export const CSV_IMPORT_DEPENDENCY_IDS = [
 
 export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] = [
   {
-    id: "fubon",
-    enabledKey: "LIBRETTO_CLOUD_FUBON_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_FUBON_USER_ID",
       "LIBRETTO_CLOUD_FUBON_ACCOUNT",
@@ -34,8 +32,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.fubon,
   },
   {
-    id: "esun",
-    enabledKey: "LIBRETTO_CLOUD_ESUN_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_ESUN_USER_ID",
       "LIBRETTO_CLOUD_ESUN_ACCOUNT",
@@ -44,8 +40,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.esun,
   },
   {
-    id: "yuanta",
-    enabledKey: "LIBRETTO_CLOUD_YUANTA_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_YUANTA_USER_ID",
       "LIBRETTO_CLOUD_YUANTA_ACCOUNT",
@@ -54,8 +48,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.yuanta,
   },
   {
-    id: "yuanta-trade",
-    enabledKey: "LIBRETTO_CLOUD_YUANTA_TRADE_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_YUANTA_TRADE_USER_ID",
       "LIBRETTO_CLOUD_YUANTA_TRADE_PASSWORD",
@@ -65,8 +57,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES["yuanta-trade"],
   },
   {
-    id: "cathay",
-    enabledKey: "LIBRETTO_CLOUD_CATHAY_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_CATHAY_USER_ID",
       "LIBRETTO_CLOUD_CATHAY_ACCOUNT",
@@ -75,8 +65,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.cathay,
   },
   {
-    id: "hncb",
-    enabledKey: "LIBRETTO_CLOUD_HNCB_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_HNCB_USER_ID",
       "LIBRETTO_CLOUD_HNCB_ACCOUNT",
@@ -85,8 +73,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.hncb,
   },
   {
-    id: "ctbc",
-    enabledKey: "LIBRETTO_CLOUD_CTBC_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_CTBC_USER_ID",
       "LIBRETTO_CLOUD_CTBC_ACCOUNT",
@@ -95,8 +81,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.ctbc,
   },
   {
-    id: "post",
-    enabledKey: "LIBRETTO_CLOUD_POST_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_POST_USER_ID",
       "LIBRETTO_CLOUD_POST_ACCOUNT",
@@ -105,8 +89,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.post,
   },
   {
-    id: "sinopac",
-    enabledKey: "LIBRETTO_CLOUD_SINOPAC_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_SINOPAC_USER_ID",
       "LIBRETTO_CLOUD_SINOPAC_ACCOUNT",
@@ -115,8 +97,6 @@ export const AUTOMATION_CREDENTIAL_GROUPS: readonly AutomationCredentialGroup[] 
     ...BANK_STATEMENT_CAPABILITIES.sinopac,
   },
   {
-    id: "linebank",
-    enabledKey: "LIBRETTO_CLOUD_LINEBANK_ENABLED",
     credentialKeys: [
       "LIBRETTO_CLOUD_LINEBANK_USER_ID",
       "LIBRETTO_CLOUD_LINEBANK_ACCOUNT",
@@ -343,21 +323,6 @@ export function automationCredentialKeyIsSecret(key: string) {
 
 export function taskById(taskId: string) {
   return AUTOMATION_TASKS.find((task) => task.id === taskId) ?? null;
-}
-
-export function assertTaskStatementSelection(
-  task: AutomationTask,
-  settings: Record<string, string | boolean | undefined>,
-) {
-  if (!task.credentialGroupId) return;
-  const group = AUTOMATION_CREDENTIAL_GROUPS.find((candidate) => candidate.id === task.credentialGroupId);
-  if (!group?.statementSelectionKey || !group.statementTypes) return;
-  const selection = resolveStatementSelection(
-    { label: group.label, statementSelectionKey: group.statementSelectionKey, statementTypes: group.statementTypes },
-    settings,
-    settings[group.enabledKey] !== false,
-  );
-  if (selection.needsSetup) throw new Error(`Select at least one ${group.label} statement type.`);
 }
 
 function taskIsEnabled(task: AutomationTask, enabledGroups: Record<string, boolean>) {

--- a/src/lib/automation/statement-run-summary.ts
+++ b/src/lib/automation/statement-run-summary.ts
@@ -22,14 +22,7 @@ export function aggregateStatementResults(results: readonly StatementComponentRe
 }
 
 export function statementRunSummaryLine(results: readonly StatementComponentResult[]) {
-  const boundedResults = results.map((result) => (
-    result.error && result.error.length > STATEMENT_RUN_ERROR_MAX_LENGTH
-      ? {
-          ...result,
-          error: `${result.error.slice(0, STATEMENT_RUN_ERROR_MAX_LENGTH - 3)}...`,
-        }
-      : result
-  ));
+  const boundedResults = boundStatementErrors(results);
   return STATEMENT_RUN_SUMMARY_PREFIX + JSON.stringify({
     status: aggregateStatementResults(boundedResults),
     results: boundedResults,
@@ -48,20 +41,42 @@ function isStatementComponentResult(value: unknown): value is StatementComponent
 
 export function parseStatementRunSummary(text: string): StatementRunSummary | null {
   for (const line of text.split(/\r?\n/).toReversed()) {
-    if (!line.startsWith(STATEMENT_RUN_SUMMARY_PREFIX)) continue;
-    try {
-      const value = JSON.parse(line.slice(STATEMENT_RUN_SUMMARY_PREFIX.length)) as Record<string, unknown>;
-      if (!value || typeof value !== "object" || Array.isArray(value) || !Array.isArray(value.results)) {
-        continue;
-      }
-      if (!["completed", "partial", "failed"].includes(String(value.status))) continue;
-      if (!value.results.every(isStatementComponentResult)) continue;
-      const results = value.results;
-      if (value.status !== aggregateStatementResults(results)) continue;
-      return { status: value.status as StatementRunSummary["status"], results };
-    } catch {
-      continue;
-    }
+    const summary = parseStatementRunSummaryLine(line);
+    if (summary) return summary;
   }
   return null;
+}
+
+function boundStatementErrors(results: readonly StatementComponentResult[]) {
+  return results.map((result) => (
+    result.error && result.error.length > STATEMENT_RUN_ERROR_MAX_LENGTH
+      ? {
+          ...result,
+          error: `${result.error.slice(0, STATEMENT_RUN_ERROR_MAX_LENGTH - 3)}...`,
+        }
+      : result
+  ));
+}
+
+function parseStatementRunSummaryLine(line: string): StatementRunSummary | null {
+  if (!line.startsWith(STATEMENT_RUN_SUMMARY_PREFIX)) return null;
+  try {
+    return parseStatementRunSummaryValue(
+      JSON.parse(line.slice(STATEMENT_RUN_SUMMARY_PREFIX.length)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function parseStatementRunSummaryValue(value: unknown): StatementRunSummary | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.results)) return null;
+  const status = String(record.status);
+  if (!["completed", "partial", "failed"].includes(status)) return null;
+  if (!record.results.every(isStatementComponentResult)) return null;
+  const results = record.results;
+  if (status !== aggregateStatementResults(results)) return null;
+  return { status: status as StatementRunSummary["status"], results };
 }

--- a/src/lib/automation/statement-selection.check.ts
+++ b/src/lib/automation/statement-selection.check.ts
@@ -72,6 +72,10 @@ assert.throws(
     return true;
   },
 );
+assert.equal(
+  new StatementSelectionError(fubon.id, "unknown-type", fubon).message,
+  "Unknown Fubon statement type: unknown",
+);
 assert.deepEqual(
   selectStatementTypes(
     fubon,

--- a/src/lib/automation/statement-selection.check.ts
+++ b/src/lib/automation/statement-selection.check.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
 import {
   BANK_STATEMENT_CAPABILITIES,
+  isStatementSelectionGroup,
   selectStatementTypes,
   StatementSelectionError,
 } from "./statement-selection.ts";
 
 const fubon = BANK_STATEMENT_CAPABILITIES.fubon;
 const esun = BANK_STATEMENT_CAPABILITIES.esun;
+
+assert.equal(isStatementSelectionGroup({ statementSelectionKey: "types", statementTypes: [] }), true);
+assert.equal(isStatementSelectionGroup({ statementSelectionKey: "types" }), false);
 
 assert.deepEqual(selectStatementTypes(fubon, {}, "display"), {
   selectedIds: [], needsSetup: true, persisted: false,

--- a/src/lib/automation/statement-selection.check.ts
+++ b/src/lib/automation/statement-selection.check.ts
@@ -41,6 +41,17 @@ assert.deepEqual(
   ).selectedIds,
   ["deposit"],
 );
+assert.deepEqual(
+  selectStatementTypes(
+    fubon,
+    {
+      [fubon.enabledKey]: "false",
+      [fubon.statementSelectionKey]: "",
+    },
+    "strict",
+  ),
+  { selectedIds: [], needsSetup: false, persisted: true },
+);
 
 assert.throws(
   () => selectStatementTypes(

--- a/src/lib/automation/statement-selection.check.ts
+++ b/src/lib/automation/statement-selection.check.ts
@@ -1,61 +1,82 @@
 import assert from "node:assert/strict";
 import {
   BANK_STATEMENT_CAPABILITIES,
-  assertValidStatementSelections,
-  resolveStatementSelection,
-  serializeStatementSelection,
+  selectStatementTypes,
+  StatementSelectionError,
 } from "./statement-selection.ts";
 
 const fubon = BANK_STATEMENT_CAPABILITIES.fubon;
 const esun = BANK_STATEMENT_CAPABILITIES.esun;
-assert.deepEqual(resolveStatementSelection(fubon, {}, true), {
+
+assert.deepEqual(selectStatementTypes(fubon, {}, "display"), {
   selectedIds: [], needsSetup: true, persisted: false,
 });
-assert.deepEqual(resolveStatementSelection(esun, {}, true), {
+assert.deepEqual(selectStatementTypes(esun, {}, "strict"), {
   selectedIds: ["credit_card"], needsSetup: false, persisted: false,
 });
 assert.deepEqual(
-  resolveStatementSelection(fubon, { [fubon.statementSelectionKey]: "loan,deposit,loan" }, true).selectedIds,
-  ["deposit", "loan"],
-);
-assert.equal(serializeStatementSelection(["deposit", "credit_card"]), "deposit,credit_card");
-assert.deepEqual(
-  resolveStatementSelection(
-    { ...fubon, statementTypes: [...fubon.statementTypes, { id: "new_type" }] },
-    { [fubon.statementSelectionKey]: "deposit,loan" },
-    true,
+  selectStatementTypes(
+    fubon,
+    { [fubon.statementSelectionKey]: "loan,deposit,loan" },
+    "strict",
   ).selectedIds,
   ["deposit", "loan"],
 );
 assert.deepEqual(
-  resolveStatementSelection(fubon, { [fubon.statementSelectionKey]: "deposit" }, false).selectedIds,
+  selectStatementTypes(
+    { ...fubon, statementTypes: [...fubon.statementTypes, { id: "new_type" }] },
+    { [fubon.statementSelectionKey]: "deposit,loan" },
+    "strict",
+  ).selectedIds,
+  ["deposit", "loan"],
+);
+assert.deepEqual(
+  selectStatementTypes(
+    fubon,
+    {
+      [fubon.enabledKey]: false,
+      [fubon.statementSelectionKey]: "deposit",
+    },
+    "strict",
+  ).selectedIds,
   ["deposit"],
 );
+
 assert.throws(
-  () => resolveStatementSelection(fubon, { [fubon.statementSelectionKey]: "deposit,unknown" }, true),
-  /Unknown Fubon statement type: unknown/,
-);
-assert.deepEqual(
-  resolveStatementSelection(
+  () => selectStatementTypes(
     fubon,
     { [fubon.statementSelectionKey]: "deposit,unknown" },
-    false,
+    "strict",
   ),
-  { selectedIds: ["deposit"], needsSetup: false, persisted: true },
+  (error: unknown) => {
+    assert.ok(error instanceof StatementSelectionError);
+    assert.equal(error.groupId, "fubon");
+    assert.equal(error.reason, "unknown-type");
+    assert.deepEqual(error.unknownIds, ["unknown"]);
+    assert.equal(error.message, "Unknown Fubon statement type: unknown");
+    return true;
+  },
 );
 assert.deepEqual(
-  resolveStatementSelection(
+  selectStatementTypes(
     fubon,
     { [fubon.statementSelectionKey]: "deposit,unknown" },
-    true,
-    { tolerateUnknown: true },
+    "display",
   ),
   { selectedIds: ["deposit"], needsSetup: true, persisted: true },
 );
 assert.throws(
-  () => assertValidStatementSelections(
-    [{ id: "fubon", enabledKey: "LIBRETTO_CLOUD_FUBON_ENABLED", credentialKeys: [], ...fubon }],
-    { LIBRETTO_CLOUD_FUBON_ENABLED: true, [fubon.statementSelectionKey]: "" },
+  () => selectStatementTypes(
+    fubon,
+    { [fubon.statementSelectionKey]: "" },
+    "strict",
   ),
-  /Select at least one Fubon statement type/,
+  (error: unknown) => {
+    assert.ok(error instanceof StatementSelectionError);
+    assert.equal(error.groupId, "fubon");
+    assert.equal(error.reason, "missing-selection");
+    assert.deepEqual(error.unknownIds, []);
+    assert.equal(error.message, "Select at least one Fubon statement type.");
+    return true;
+  },
 );

--- a/src/lib/automation/statement-selection.ts
+++ b/src/lib/automation/statement-selection.ts
@@ -8,6 +8,12 @@ export type StatementSelectionGroup = {
   statementTypes: readonly StatementTypeCapability[];
 };
 
+export function isStatementSelectionGroup(
+  group: { statementSelectionKey?: string; statementTypes?: readonly StatementTypeCapability[] },
+): group is typeof group & StatementSelectionGroup {
+  return Boolean(group.statementSelectionKey && group.statementTypes);
+}
+
 type Settings = Record<string, string | boolean | undefined>;
 
 const disabledFlagValues = new Set(["0", "false", "no", "off", "disabled"]);

--- a/src/lib/automation/statement-selection.ts
+++ b/src/lib/automation/statement-selection.ts
@@ -10,6 +10,14 @@ export type StatementSelectionGroup = {
 
 type Settings = Record<string, string | boolean | undefined>;
 
+const disabledFlagValues = new Set(["0", "false", "no", "off", "disabled"]);
+
+export function automationFlagEnabled(value: string | boolean | undefined) {
+  if (value === undefined) return true;
+  if (typeof value === "boolean") return value;
+  return !disabledFlagValues.has(value.trim().toLowerCase());
+}
+
 export type StatementSelectionMode = "display" | "strict";
 
 export type StatementSelectionErrorReason =
@@ -67,7 +75,7 @@ export function selectStatementTypes(
   settings: Settings,
   mode: StatementSelectionMode,
 ): StatementSelectionState {
-  const enabled = settings[group.enabledKey] !== false;
+  const enabled = automationFlagEnabled(settings[group.enabledKey]);
   const raw = settings[group.statementSelectionKey];
   if (raw === undefined) {
     const selectedIds = group.statementTypes.length === 1 ? [group.statementTypes[0].id] : [];

--- a/src/lib/automation/statement-selection.ts
+++ b/src/lib/automation/statement-selection.ts
@@ -8,10 +8,12 @@ export type StatementSelectionGroup = {
   statementTypes: readonly StatementTypeCapability[];
 };
 
-export function isStatementSelectionGroup(
-  group: { statementSelectionKey?: string; statementTypes?: readonly StatementTypeCapability[] },
-): group is typeof group & StatementSelectionGroup {
-  return Boolean(group.statementSelectionKey && group.statementTypes);
+type StatementSelectionFields = Pick<StatementSelectionGroup, "statementSelectionKey" | "statementTypes">;
+
+export function isStatementSelectionGroup<
+  T extends { statementSelectionKey?: string; statementTypes?: readonly StatementTypeCapability[] },
+>(group: T): group is T & StatementSelectionFields {
+  return Boolean(group.statementSelectionKey && Array.isArray(group.statementTypes));
 }
 
 type Settings = Record<string, string | boolean | undefined>;

--- a/src/lib/automation/statement-selection.ts
+++ b/src/lib/automation/statement-selection.ts
@@ -54,7 +54,7 @@ export class StatementSelectionError extends Error {
     const message = reason === "missing-selection"
       ? "Select at least one " + group.label + " statement type."
       : reason === "unknown-type"
-        ? "Unknown " + group.label + " statement type: " + unknownIds[0]
+        ? "Unknown " + group.label + " statement type: " + (unknownIds[0] ?? "unknown")
         : group.statementSelectionKey + " must be a string.";
     super(message);
     this.groupId = groupId;

--- a/src/lib/automation/statement-selection.ts
+++ b/src/lib/automation/statement-selection.ts
@@ -1,12 +1,21 @@
-import type { AutomationCredentialGroup, StatementTypeCapability } from "./types.ts";
+import type { StatementTypeCapability } from "./types.ts";
 
-export type StatementCapability = {
+export type StatementSelectionGroup = {
+  id: string;
   label: string;
+  enabledKey: string;
   statementSelectionKey: string;
   statementTypes: readonly StatementTypeCapability[];
 };
 
 type Settings = Record<string, string | boolean | undefined>;
+
+export type StatementSelectionMode = "display" | "strict";
+
+export type StatementSelectionErrorReason =
+  | "missing-selection"
+  | "unknown-type"
+  | "invalid-value";
 
 export type StatementSelectionState = {
   selectedIds: string[];
@@ -14,63 +23,75 @@ export type StatementSelectionState = {
   persisted: boolean;
 };
 
+export class StatementSelectionError extends Error {
+  readonly name = "StatementSelectionError";
+  readonly unknownIds: readonly string[];
+  readonly groupId: string;
+  readonly reason: StatementSelectionErrorReason;
+
+  constructor(
+    groupId: string,
+    reason: StatementSelectionErrorReason,
+    group: StatementSelectionGroup,
+    unknownIds: readonly string[] = [],
+  ) {
+    const message = reason === "missing-selection"
+      ? "Select at least one " + group.label + " statement type."
+      : reason === "unknown-type"
+        ? "Unknown " + group.label + " statement type: " + unknownIds[0]
+        : group.statementSelectionKey + " must be a string.";
+    super(message);
+    this.groupId = groupId;
+    this.reason = reason;
+    this.unknownIds = [...unknownIds];
+  }
+}
+
 const types = (...ids: string[]) => ids.map((id) => ({ id }));
 
 export const BANK_STATEMENT_CAPABILITIES = {
-  fubon: { label: "Fubon", statementSelectionKey: "LIBRETTO_CLOUD_FUBON_STATEMENT_TYPES", statementTypes: types("deposit", "credit_card", "loan") },
-  esun: { label: "ESun", statementSelectionKey: "LIBRETTO_CLOUD_ESUN_STATEMENT_TYPES", statementTypes: types("credit_card") },
-  yuanta: { label: "Yuanta", statementSelectionKey: "LIBRETTO_CLOUD_YUANTA_STATEMENT_TYPES", statementTypes: types("deposit", "foreign_currency", "loan", "credit_card", "fund") },
-  "yuanta-trade": { label: "Yuanta Trade", statementSelectionKey: "LIBRETTO_CLOUD_YUANTA_TRADE_STATEMENT_TYPES", statementTypes: types("brokerage") },
-  cathay: { label: "Cathay", statementSelectionKey: "LIBRETTO_CLOUD_CATHAY_STATEMENT_TYPES", statementTypes: types("domestic", "foreign_currency") },
-  hncb: { label: "HNCB", statementSelectionKey: "LIBRETTO_CLOUD_HNCB_STATEMENT_TYPES", statementTypes: types("deposit") },
-  ctbc: { label: "CTBC", statementSelectionKey: "LIBRETTO_CLOUD_CTBC_STATEMENT_TYPES", statementTypes: types("deposit") },
-  post: { label: "Post Office", statementSelectionKey: "LIBRETTO_CLOUD_POST_STATEMENT_TYPES", statementTypes: types("deposit") },
-  sinopac: { label: "SinoPac", statementSelectionKey: "LIBRETTO_CLOUD_SINOPAC_STATEMENT_TYPES", statementTypes: types("accounts") },
-  linebank: { label: "LINE Bank", statementSelectionKey: "LIBRETTO_CLOUD_LINEBANK_STATEMENT_TYPES", statementTypes: types("accounts") },
-} as const satisfies Record<string, StatementCapability>;
+  fubon: { id: "fubon", label: "Fubon", enabledKey: "LIBRETTO_CLOUD_FUBON_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_FUBON_STATEMENT_TYPES", statementTypes: types("deposit", "credit_card", "loan") },
+  esun: { id: "esun", label: "ESun", enabledKey: "LIBRETTO_CLOUD_ESUN_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_ESUN_STATEMENT_TYPES", statementTypes: types("credit_card") },
+  yuanta: { id: "yuanta", label: "Yuanta", enabledKey: "LIBRETTO_CLOUD_YUANTA_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_YUANTA_STATEMENT_TYPES", statementTypes: types("deposit", "foreign_currency", "loan", "credit_card", "fund") },
+  "yuanta-trade": { id: "yuanta-trade", label: "Yuanta Trade", enabledKey: "LIBRETTO_CLOUD_YUANTA_TRADE_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_YUANTA_TRADE_STATEMENT_TYPES", statementTypes: types("brokerage") },
+  cathay: { id: "cathay", label: "Cathay", enabledKey: "LIBRETTO_CLOUD_CATHAY_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_CATHAY_STATEMENT_TYPES", statementTypes: types("domestic", "foreign_currency") },
+  hncb: { id: "hncb", label: "HNCB", enabledKey: "LIBRETTO_CLOUD_HNCB_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_HNCB_STATEMENT_TYPES", statementTypes: types("deposit") },
+  ctbc: { id: "ctbc", label: "CTBC", enabledKey: "LIBRETTO_CLOUD_CTBC_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_CTBC_STATEMENT_TYPES", statementTypes: types("deposit") },
+  post: { id: "post", label: "Post Office", enabledKey: "LIBRETTO_CLOUD_POST_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_POST_STATEMENT_TYPES", statementTypes: types("deposit") },
+  sinopac: { id: "sinopac", label: "SinoPac", enabledKey: "LIBRETTO_CLOUD_SINOPAC_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_SINOPAC_STATEMENT_TYPES", statementTypes: types("accounts") },
+  linebank: { id: "linebank", label: "LINE Bank", enabledKey: "LIBRETTO_CLOUD_LINEBANK_ENABLED", statementSelectionKey: "LIBRETTO_CLOUD_LINEBANK_STATEMENT_TYPES", statementTypes: types("accounts") },
+} as const satisfies Record<string, StatementSelectionGroup>;
 
-export function resolveStatementSelection(
-  group: StatementCapability,
+export function selectStatementTypes(
+  group: StatementSelectionGroup,
   settings: Settings,
-  enabled: boolean,
-  options: { tolerateUnknown?: boolean } = {},
+  mode: StatementSelectionMode,
 ): StatementSelectionState {
+  const enabled = settings[group.enabledKey] !== false;
   const raw = settings[group.statementSelectionKey];
   if (raw === undefined) {
     const selectedIds = group.statementTypes.length === 1 ? [group.statementTypes[0].id] : [];
+    if (enabled && !selectedIds.length && mode === "strict") {
+      throw new StatementSelectionError(group.id, "missing-selection", group);
+    }
     return { selectedIds, needsSetup: enabled && selectedIds.length === 0, persisted: false };
   }
-  if (typeof raw !== "string") throw new Error(`${group.statementSelectionKey} must be a string.`);
+  if (typeof raw !== "string") {
+    throw new StatementSelectionError(group.id, "invalid-value", group);
+  }
   const requested = new Set(raw.split(",").map((id) => id.trim()).filter(Boolean));
   const known = new Set(group.statementTypes.map((type) => type.id));
-  const unknownIds: string[] = [];
-  for (const id of requested) {
-    if (!known.has(id)) unknownIds.push(id);
-  }
-  if (enabled && unknownIds.length > 0 && !options.tolerateUnknown) {
-    throw new Error(`Unknown ${group.label} statement type: ${unknownIds[0]}`);
+  const unknownIds = [...requested].filter((id) => !known.has(id));
+  if (enabled && unknownIds.length > 0 && mode === "strict") {
+    throw new StatementSelectionError(group.id, "unknown-type", group, unknownIds);
   }
   const selectedIds = group.statementTypes.map((type) => type.id).filter((id) => requested.has(id));
+  if (enabled && !selectedIds.length && mode === "strict") {
+    throw new StatementSelectionError(group.id, "missing-selection", group);
+  }
   return {
     selectedIds,
     needsSetup: enabled && (selectedIds.length === 0 || unknownIds.length > 0),
     persisted: true,
   };
-}
-
-export const serializeStatementSelection = (ids: readonly string[]) => ids.join(",");
-
-export function assertValidStatementSelections(
-  groups: readonly AutomationCredentialGroup[],
-  settings: Settings,
-) {
-  for (const group of groups) {
-    if (!group.statementSelectionKey || !group.statementTypes) continue;
-    const state = resolveStatementSelection(
-      { label: group.label, statementSelectionKey: group.statementSelectionKey, statementTypes: group.statementTypes },
-      settings,
-      settings[group.enabledKey] !== false,
-    );
-    if (state.needsSetup) throw new Error(`Select at least one ${group.label} statement type.`);
-  }
 }

--- a/src/lib/onboarding/state.check.ts
+++ b/src/lib/onboarding/state.check.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import type { AutomationDesktopModel, CredentialGroupDto } from "../desktop/api.ts";
 import type { AutomationTaskRow } from "../automation/types.ts";
 import type { OverviewPageDto } from "../overview/types.ts";
+import { singleSourceUpdates } from "../automation/credential-setup.ts";
 import * as onboardingState from "./state.ts";
 import {
   ONBOARDING_STORAGE_KEY,
@@ -13,7 +14,6 @@ import {
   onboardingTaskDisclosure,
   readOnboardingState,
   settleAssistTextSubmission,
-  singleSourceUpdates,
   writeOnboardingState,
 } from "./state.ts";
 import {
@@ -319,7 +319,7 @@ const i18n = readFileSync("src/lib/i18n/i18n.ts", "utf8");
 for (const source of [automationDashboard, dashboardShell, overviewDashboard]) {
   assert.match(source, /data-onboarding/);
 }
-assert.match(automationDashboard, /singleSourceUpdates/);
+assert.match(automationDashboard, /buildCredentialSetupPlan/);
 assert.match(onboardingStateSource, /export function settleAssistTextSubmission/);
 assert.match(targetObserverSource, /export function activateOnboardingTarget/);
 assert.match(i18n, /welcomeTitle: "Build your first local overview"/);

--- a/src/lib/onboarding/state.ts
+++ b/src/lib/onboarding/state.ts
@@ -1,4 +1,3 @@
-import type { CredentialGroupDto } from "../desktop/api.ts";
 import type { AutomationTaskRow } from "../automation/types.ts";
 import type { OnboardingStep } from "./progression.ts";
 
@@ -76,21 +75,6 @@ export function writeOnboardingState(
   state: OnboardingState,
 ) {
   storage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
-}
-
-export function singleSourceUpdates(
-  groups: readonly CredentialGroupDto[],
-  selectedGroupId: string,
-  collectionGroupIds: ReadonlySet<string>,
-) {
-  return Object.fromEntries(
-    groups
-      .filter((group) => collectionGroupIds.has(group.id))
-      .map((group) => [
-        group.enabledKey,
-        group.id === selectedGroupId ? "true" : "false",
-      ]),
-  );
 }
 
 export function onboardingTaskDisclosure(

--- a/src/workflows/cathay-all-statements.check.ts
+++ b/src/workflows/cathay-all-statements.check.ts
@@ -131,7 +131,7 @@ assert.deepEqual(output, {
 assert.match(source, /BANK_STATEMENT_CAPABILITIES/);
 assert.match(
   source,
-  /resolveStatementSelection\([\s\S]*BANK_STATEMENT_CAPABILITIES\.cathay/,
+  /selectStatementTypes\([\s\S]*BANK_STATEMENT_CAPABILITIES\.cathay/,
 );
 assert.match(source, /runSelectedStatements\(selectedIds, \[/);
 assert.match(

--- a/src/workflows/cathay-all-statements.ts
+++ b/src/workflows/cathay-all-statements.ts
@@ -2,7 +2,7 @@ import { workflow, type LibrettoWorkflowContext } from "libretto";
 import { z } from "zod";
 import {
   BANK_STATEMENT_CAPABILITIES,
-  resolveStatementSelection,
+  selectStatementTypes,
 } from "../lib/automation/statement-selection.js";
 import {
   type CathayCredentials,
@@ -107,10 +107,10 @@ export async function runCathayAllStatements(
   const { page } = ctx;
   const requestedIds = new Set(
     input.statementTypes ??
-      resolveStatementSelection(
+      selectStatementTypes(
         BANK_STATEMENT_CAPABILITIES.cathay,
         process.env,
-        true,
+        "strict",
       ).selectedIds,
   );
   const selectedIds = BANK_STATEMENT_CAPABILITIES.cathay.statementTypes

--- a/src/workflows/fubon-all-statements.check.ts
+++ b/src/workflows/fubon-all-statements.check.ts
@@ -13,7 +13,7 @@ assert.match(source, /logoutNow/);
 assert.match(source, /BANK_STATEMENT_CAPABILITIES/);
 assert.match(
   source,
-  /resolveStatementSelection\([\s\S]*BANK_STATEMENT_CAPABILITIES\.fubon/,
+  /selectStatementTypes\([\s\S]*BANK_STATEMENT_CAPABILITIES\.fubon/,
 );
 assert.match(source, /runSelectedStatements\(selectedIds, \[/);
 assert.match(

--- a/src/workflows/fubon-all-statements.ts
+++ b/src/workflows/fubon-all-statements.ts
@@ -3,7 +3,7 @@ import type { Page } from "playwright";
 import { z } from "zod";
 import {
   BANK_STATEMENT_CAPABILITIES,
-  resolveStatementSelection,
+  selectStatementTypes,
 } from "../lib/automation/statement-selection.js";
 import {
   activateControlWithoutPointer,
@@ -150,10 +150,10 @@ export async function runFubonAllStatements(
   const input = rawInput as Input;
   const { page, session } = ctx;
   console.log("automation-progress: 0");
-  const selectedIds = resolveStatementSelection(
+  const selectedIds = selectStatementTypes(
     BANK_STATEMENT_CAPABILITIES.fubon,
     process.env,
-    true,
+    "strict",
   ).selectedIds;
   if (!selectedIds.length) throw new Error("Select at least one Fubon statement type.");
 

--- a/src/workflows/yuanta-all-statements.check.ts
+++ b/src/workflows/yuanta-all-statements.check.ts
@@ -28,7 +28,7 @@ assert.match(source, /yuanta-all-component-page-not-ready[\s\S]*durationMs/);
 assert.match(source, /BANK_STATEMENT_CAPABILITIES/);
 assert.match(
   source,
-  /resolveStatementSelection\([\s\S]*BANK_STATEMENT_CAPABILITIES\.yuanta/,
+  /selectStatementTypes\([\s\S]*BANK_STATEMENT_CAPABILITIES\.yuanta/,
 );
 assert.match(source, /runSelectedStatements\(selectedIds, \[/);
 assert.doesNotMatch(source, /continueOnError/);

--- a/src/workflows/yuanta-all-statements.ts
+++ b/src/workflows/yuanta-all-statements.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import type { StatementComponentResult } from "../lib/automation/statement-run-summary.js";
 import {
   BANK_STATEMENT_CAPABILITIES,
-  resolveStatementSelection,
+  selectStatementTypes,
 } from "../lib/automation/statement-selection.js";
 import { hasAttachedLocator } from "./browser-interaction.js";
 import { runSelectedStatements } from "./run-selected-statements.js";
@@ -477,10 +477,10 @@ export async function runYuantaAllStatements(
       credit_card: include.creditCard,
       fund: include.fund,
     };
-    const selectedIds = resolveStatementSelection(
+    const selectedIds = selectStatementTypes(
       BANK_STATEMENT_CAPABILITIES.yuanta,
       process.env,
-      true,
+      "strict",
     ).selectedIds.filter((typeId) => includeByType[typeId] !== false);
     const firstSelectedId = selectedIds[0];
     if (!firstSelectedId) throw new Error("Select at least one Yuanta statement type.");


### PR DESCRIPTION
## Summary

- Extract credential setup planning and validation into a reusable module
- Centralize statement selection handling with display and strict modes
- Enforce valid statement selections when saving credentials and starting automation tasks
- Add `StatementSelectionError` details and update domain terminology
- Expand coverage for credential plans and statement selection behavior

## Testing

- Added focused checks for credential setup planning and statement selection validation
- Existing automation runner checks updated for the centralized validation flow