### PR TITLE
Handle HNCB statement no-data responses and query form setup

### DIFF
--- a/src/workflows/hncb-statements.check.ts
+++ b/src/workflows/hncb-statements.check.ts
@@ -1,9 +1,38 @@
 import assert from "node:assert/strict";
-import type { Frame, Page } from "playwright";
+import { chromium, type Frame, type Page } from "playwright";
 import {
   ensureHncbStatementForm,
+  isNoStatementDataText,
   normalizeHncbTransactionRows,
+  prepareHncbStatementQueryForm,
 } from "./hncb-statements.ts";
+
+const browser = await chromium.launch();
+try {
+  const browserPage = await browser.newPage();
+  await browserPage.setContent(`
+    <form name="form1" target="acct">
+      <input type="hidden" name="excel_download" value="52">
+    </form>
+  `);
+
+  await prepareHncbStatementQueryForm(browserPage.mainFrame());
+
+  const form = browserPage.locator('form[name="form1"]');
+  assert.equal(await form.getAttribute("target"), "_self");
+  assert.equal(
+    await form.locator('input[name="excel_download"]').inputValue(),
+    "",
+  );
+} finally {
+  await browser.close();
+}
+
+assert.equal(
+  isNoStatementDataText("查     無     資     料"),
+  true,
+  "a spaced HNCB no-data result must finish instead of timing out",
+);
 
 const normalizedRows = normalizeHncbTransactionRows([
   ["交易日期", "交易時間", "帳務日期"],

--- a/src/workflows/hncb-statements.ts
+++ b/src/workflows/hncb-statements.ts
@@ -121,7 +121,9 @@ function cleanText(value: string | null | undefined): string {
 export function isNoStatementDataText(
   value: string | null | undefined,
 ): boolean {
-  return /查無資料|無資料|無交易|查無符合/.test(cleanText(value));
+  return /查\s*無\s*資\s*料|無\s*資\s*料|無\s*交\s*易|查\s*無\s*符\s*合/u.test(
+    cleanText(value),
+  );
 }
 
 function digitsOnly(value: string): string {
@@ -514,6 +516,22 @@ export async function ensureHncbStatementForm(
   });
 }
 
+export async function prepareHncbStatementQueryForm(
+  mainFrame: Frame,
+): Promise<void> {
+  await mainFrame
+    .locator('form[name="form1"]')
+    .first()
+    .evaluate((element) => {
+      const form = element as HTMLFormElement;
+      form.target = "_self";
+      const excelDownload = form.elements.namedItem("excel_download");
+      if (excelDownload instanceof HTMLInputElement) {
+        excelDownload.value = "";
+      }
+    });
+}
+
 function statementDownloadLink(mainFrame: Frame): Locator {
   return mainFrame
     .locator(
@@ -588,6 +606,7 @@ async function queryAccountStatements(
   dateRange: WorkflowOutput["dateRange"],
 ): Promise<Frame | null> {
   const mainFrame = await ensureHncbStatementForm(page);
+  await prepareHncbStatementQueryForm(mainFrame);
   await mainFrame.locator("#acct1").selectOption(account.value);
   await mainFrame.locator('input[name="inqtype"][value="3"]').check({
     force: true,


### PR DESCRIPTION
## Summary

- Detect spaced HNCB no-data messages so workflows finish instead of timing out.
- Reset the statement form target and Excel download value before querying.
- Add browser-backed checks for form preparation and no-data detection.

## Testing

- Added Playwright-based validation for HNCB form preparation.
- Added an assertion covering spaced no-data response text.