### PR TITLE
Fix replacement semantics for imported position snapshots

### DIFF
--- a/docs/bugs/2026-07-31-position-snapshot-replacement.md
+++ b/docs/bugs/2026-07-31-position-snapshot-replacement.md
@@ -1,0 +1,52 @@
+# Imported position snapshots retained closed positions
+
+- Date: 2026-07-31
+- Status: Fixed
+- Affected projections: `brokerage_holdings`, `fund_holdings`
+
+## Symptom
+
+After importing a newer Yuanta brokerage holdings export, symbols that were present
+only in an older export still appeared in Assets. The same accumulation behavior
+also applied to redeemed fund holdings.
+
+## Root cause
+
+Imported holding rows are intentionally immutable and deduplicated across source
+files. The account projection selected the latest row for each symbol, which
+mistook the union of all historical holding rows for the current portfolio.
+Absence from a newer full holdings export therefore had no effect.
+
+## Fix
+
+Brokerage and fund holdings are now treated as complete-set snapshots:
+
+1. Classify source files with the same typed CSV parser used by the importer.
+2. Select the latest source import for each bank/product pair.
+3. Use source-row lineage to project only statement rows represented by that
+   source import.
+4. Keep historical rows in the ledger for audit and daily history.
+
+An empty brokerage export is authoritative only when the workflow verifies every
+requested holding page and finds a parsed report structure. A missing page or
+failed extraction emits no holdings snapshot and preserves the previous one.
+
+## Audit of other position-producing structures
+
+| Structure | Semantics | Why the same bug does or does not apply |
+| --- | --- | --- |
+| Brokerage holdings | Complete-set snapshot | Fixed by latest source-import scope. |
+| Fund holdings | Complete-set snapshot | Fixed by the same projection and covered by a redeemed-fund regression. |
+| Credit-card balance | Verified capture | Already selects only complete captures with both billed and unbilled evidence; legacy or partial captures are excluded. |
+| MaiCoin balance | Time-stamped account snapshot | Already selects the latest sync and explicitly creates zero-value positions for wallets absent from that latest sync. |
+| TWD and foreign cash | Balance-bearing transaction stream | Current value comes from the latest transaction balance per account/currency; file-row absence is not a close-position signal. |
+| Loans | Balance-bearing transaction stream | Current liability comes from the latest principal/balance row; file-row absence is not a payoff signal. |
+
+## Verification
+
+- A newer brokerage snapshot removes symbols omitted from the new full export.
+- A verified empty brokerage snapshot clears the account.
+- A newer fund snapshot removes redeemed funds.
+- An empty Yuanta extraction without report structure is rejected.
+- Existing credit-card capture and MaiCoin latest-sync regression coverage remains
+  part of the full test suite.

--- a/src/ledger/position-snapshot-replacement.check.ts
+++ b/src/ledger/position-snapshot-replacement.check.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadAssets } from "../lib/assets/server/load-assets.ts";
+import { importDownloadsCsv } from "./import-downloads-csv.ts";
+
+const brokerageHeaders = [
+  "as_of_date",
+  "account_number",
+  "asset_type",
+  "sub_category",
+  "product_code",
+  "product_name",
+  "currency",
+  "quantity",
+  "market_date",
+  "market_price",
+  "market_value_original",
+  "market_value_twd",
+  "cost_price",
+  "cost_amount",
+  "unrealized_pnl_original",
+  "unrealized_pnl_twd",
+  "return_rate",
+  "fx_rate",
+];
+
+function brokerageCsv(symbols: string[]) {
+  const rows = symbols.map((symbol, index) => [
+    "2026-07-31",
+    "9948",
+    "stock",
+    "US stock",
+    symbol,
+    `${symbol} Incorporated`,
+    "USD",
+    String(index + 1),
+    "2026-07-31",
+    "100",
+    String((index + 1) * 100),
+    String((index + 1) * 3000),
+    "90",
+    String((index + 1) * 90),
+    "10",
+    "300",
+    "11.11",
+    "30",
+  ]);
+  return [brokerageHeaders, ...rows].map((row) => row.join(",")).join("\n") + "\n";
+}
+
+const fundHeaders = [
+  "資料類別",
+  "基金識別",
+  "查詢期間",
+  "基金名稱",
+  "基金類型",
+  "投資幣別",
+  "投資金額",
+  "不含息參考市值",
+  "不含息參考損益",
+  "不含息參考報酬率",
+  "含息參考損益",
+  "含息參考報酬率",
+  "狀態",
+];
+
+function fundCsv(funds: string[]) {
+  const rows = funds.map((fund, index) => [
+    "holding",
+    fund,
+    "2026-07-31",
+    `${fund} Fund`,
+    "equity",
+    "USD",
+    String((index + 1) * 100),
+    String((index + 1) * 110),
+    "10",
+    "10",
+    "10",
+    "10",
+    "active",
+  ]);
+  return [fundHeaders, ...rows].map((row) => row.join(",")).join("\n") + "\n";
+}
+
+async function symbolsAfterImports(options: {
+  fixtureName: string;
+  sourceFolder: string;
+  product: string;
+  snapshots: Array<{ fileName: string; csv: string }>;
+}) {
+  const rootDir = await mkdtemp(join(tmpdir(), `${options.fixtureName}-`));
+  try {
+    const downloadsDir = join(rootDir, "downloads");
+    const outputDir = join(rootDir, "ledger");
+    const sourceDir = join(downloadsDir, options.sourceFolder);
+    await mkdir(sourceDir, { recursive: true });
+
+    const importInput = {
+      downloadsDir,
+      outputDir,
+      bankFilters: ["yuanta"],
+      productFilters: [options.product],
+    };
+
+    for (const snapshot of options.snapshots) {
+      await writeFile(join(sourceDir, snapshot.fileName), snapshot.csv, "utf8");
+      await importDownloadsCsv(importInput);
+    }
+
+    const assets = await loadAssets(outputDir);
+    return Object.values(assets.positionsByAccount)
+      .flat()
+      .map((position) => position.symbol)
+      .sort();
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+test("a newer brokerage holdings snapshot removes sold positions", async () => {
+  const symbols = await symbolsAfterImports({
+    fixtureName: "brokerage-snapshot-replacement",
+    sourceFolder: "yuanta-trade-statements",
+    product: "trade-statements",
+    snapshots: [
+      {
+        fileName: "holdings-20260731090000.csv",
+        csv: brokerageCsv(["ANET", "VRT"]),
+      },
+      {
+        fileName: "holdings-20260731100000.csv",
+        csv: brokerageCsv(["ANET"]),
+      },
+    ],
+  });
+  assert.deepEqual(symbols, ["ANET"]);
+});
+
+test("an empty brokerage holdings snapshot clears the account", async () => {
+  const symbols = await symbolsAfterImports({
+    fixtureName: "brokerage-empty-snapshot",
+    sourceFolder: "yuanta-trade-statements",
+    product: "trade-statements",
+    snapshots: [
+      {
+        fileName: "holdings-20260731090000.csv",
+        csv: brokerageCsv(["ANET"]),
+      },
+      {
+        fileName: "holdings-20260731100000.csv",
+        csv: brokerageCsv([]),
+      },
+    ],
+  });
+  assert.deepEqual(symbols, []);
+});
+
+test("a newer fund holdings snapshot removes redeemed funds", async () => {
+  const symbols = await symbolsAfterImports({
+    fixtureName: "fund-snapshot-replacement",
+    sourceFolder: "yuanta-fund-statements",
+    product: "fund-statements",
+    snapshots: [
+      {
+        fileName: "fund-holdings-20260731090000.csv",
+        csv: fundCsv(["FUND-A", "FUND-B"]),
+      },
+      {
+        fileName: "fund-holdings-20260731100000.csv",
+        csv: fundCsv(["FUND-A"]),
+      },
+    ],
+  });
+  assert.deepEqual(symbols, ["FUND-A"]);
+});

--- a/src/lib/assets/server/load-assets.ts
+++ b/src/lib/assets/server/load-assets.ts
@@ -21,6 +21,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
   try {
     const [
       sourceFiles,
+      sourceRowLineage,
       accountTransactions,
       foreignCurrencyTransactions,
       creditCardCaptures,
@@ -36,6 +37,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
       maicoinStatementRows,
     ] = await Promise.all([
       db.select().from(schema.sourceFileImports).all(),
+      db.select().from(schema.sourceRowLineage).all(),
       db.select().from(schema.accountTransactions).all(),
       db.select().from(schema.foreignCurrencyTransactions).all(),
       db.select().from(schema.creditCardCaptures).all(),
@@ -54,6 +56,7 @@ export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Assets
     const data: LedgerQueryData = {
       ...emptyLedgerQueryData(),
       sourceFiles,
+      sourceRowLineage,
       accountTransactions,
       foreignCurrencyTransactions,
       creditCardCaptures,

--- a/src/lib/data-issues/server/ledger-visibility.ts
+++ b/src/lib/data-issues/server/ledger-visibility.ts
@@ -7,8 +7,12 @@ import {
   type UnavailableAccountIssue,
   unavailableAccountFromIssue,
 } from "../../shared-ledger/server/accounts.ts";
+import {
+  sourceImportScopeKey,
+  type SourceImportScope,
+} from "../../shared-ledger/server/source-import-scope.ts";
 
-export type ImportScope = `${string}|${string}`;
+export type ImportScope = SourceImportScope;
 
 export type ActiveLedgerSupport = {
   statementKeys: ReadonlySet<string>;
@@ -19,9 +23,7 @@ export type ActiveLedgerSupport = {
 export const statementSupportKey = (table: string, statementRowId: string) =>
   `${table}|${statementRowId}`;
 
-export function importScope(row: { sourceFileId: string; importRunId: string }): ImportScope {
-  return `${row.sourceFileId}|${row.importRunId}`;
-}
+export const importScope = sourceImportScopeKey;
 
 function completeCaptureIds(
   captures: LedgerQueryData["creditCardCaptures"],
@@ -74,6 +76,7 @@ function filterLedgerData(
   return {
     ...data,
     sourceFiles: visible(data.sourceFiles),
+    sourceRowLineage: visible(data.sourceRowLineage),
     accountTransactions: visible(data.accountTransactions),
     foreignCurrencyTransactions: visible(data.foreignCurrencyTransactions),
     creditCardStatementLines,
@@ -137,6 +140,8 @@ export function applyLedgerVisibility(
   return {
     ...data,
     sourceFiles: data.sourceFiles.filter((row) => support.sourceVersionKeys.has(row.sourceVersionKey)),
+    sourceRowLineage: data.sourceRowLineage
+      .filter((row) => support.sourceVersionKeys.has(row.sourceVersionKey)),
     accountTransactions: visible(data.accountTransactions, PROJECTIONS.accountTransactions),
     foreignCurrencyTransactions: visible(
       data.foreignCurrencyTransactions,

--- a/src/lib/overview/server/daily-history.ts
+++ b/src/lib/overview/server/daily-history.ts
@@ -6,6 +6,7 @@ import {
   type LedgerQueryData,
 } from "../../shared-ledger/server/accounts.ts";
 import { historyPointKey, type AccountRowDto, type CurrencyAmountDto, type DailyHistoryRowDto } from "../../shared-ledger/types.ts";
+import { sourceImportScopeKey } from "../../shared-ledger/server/source-import-scope.ts";
 
 export function buildDailyHistory(data: LedgerQueryData): DailyHistoryRowDto[] {
   const rows = dailyHistoryPoints(data);
@@ -120,23 +121,26 @@ function snapshotData(data: LedgerQueryData, point: HistoryPoint): LedgerQueryDa
     creditCardCaptures,
     creditCardCaptureEntries,
   }).filter((snapshot) => snapshot.asOfDate <= point.date);
-  const sourceFileIds = new Set(
-    data.sourceFiles
-      .filter((source) => sourceFileDate(source) <= point.date)
-      .map((source) => source.sourceFileId),
-  );
+  const sourceFiles = data.sourceFiles
+    .filter((source) => sourceFileDate(source) <= point.date);
+  const sourceScopes = new Set(sourceFiles.map(
+    sourceImportScopeKey,
+  ));
+  const isVisibleAtPoint = (row: { sourceFileId: string; importRunId: string }) =>
+    sourceScopes.has(sourceImportScopeKey(row));
   return {
     ...data,
-    sourceFiles: data.sourceFiles.filter((source) => sourceFileIds.has(source.sourceFileId)),
-    accountTransactions: data.accountTransactions.filter((row) => sourceFileIds.has(row.sourceFileId)),
-    foreignCurrencyTransactions: data.foreignCurrencyTransactions.filter((row) => sourceFileIds.has(row.sourceFileId)),
-    creditCardStatementLines: data.creditCardStatementLines.filter((row) => sourceFileIds.has(row.sourceFileId)),
+    sourceFiles,
+    sourceRowLineage: data.sourceRowLineage.filter(isVisibleAtPoint),
+    accountTransactions: data.accountTransactions.filter(isVisibleAtPoint),
+    foreignCurrencyTransactions: data.foreignCurrencyTransactions.filter(isVisibleAtPoint),
+    creditCardStatementLines: data.creditCardStatementLines.filter(isVisibleAtPoint),
     creditCardCaptures,
     creditCardCaptureEntries,
     creditCardSnapshots,
-    loanTransactions: data.loanTransactions.filter((row) => sourceFileIds.has(row.sourceFileId)),
-    fundHoldings: data.fundHoldings.filter((row) => sourceFileIds.has(row.sourceFileId)),
-    brokerageHoldings: data.brokerageHoldings.filter((row) => sourceFileIds.has(row.sourceFileId)),
+    loanTransactions: data.loanTransactions.filter(isVisibleAtPoint),
+    fundHoldings: data.fundHoldings.filter(isVisibleAtPoint),
+    brokerageHoldings: data.brokerageHoldings.filter(isVisibleAtPoint),
     maicoinAccountSnapshots: data.maicoinAccountSnapshots.filter((row) => row.capturedAt.slice(0, 10) <= point.date),
   };
 }

--- a/src/lib/overview/server/load-overview.ts
+++ b/src/lib/overview/server/load-overview.ts
@@ -23,6 +23,7 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
   try {
     const [
       sourceFiles,
+      sourceRowLineage,
       accountTransactions,
       foreignCurrencyTransactions,
       creditCardStatementLines,
@@ -36,6 +37,7 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
       maicoinStatementRows,
     ] = await Promise.all([
       db.select().from(schema.sourceFileImports).all(),
+      db.select().from(schema.sourceRowLineage).all(),
       db.select().from(schema.accountTransactions).all(),
       db.select().from(schema.foreignCurrencyTransactions).all(),
       db.select().from(schema.creditCardStatementLines).all(),
@@ -52,6 +54,7 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
     const data: LedgerQueryData = {
       ...emptyLedgerQueryData(),
       sourceFiles,
+      sourceRowLineage,
       accountTransactions,
       foreignCurrencyTransactions,
       creditCardStatementLines,

--- a/src/lib/shared-ledger/server/accounts.ts
+++ b/src/lib/shared-ledger/server/accounts.ts
@@ -18,7 +18,9 @@ import type {
   maicoinAccountSnapshots,
   maicoinStatementRows,
   sourceFileImports,
+  sourceRowLineage,
 } from "../../../ledger/db/schema.ts";
+import { latestPositionSnapshotRows } from "./position-snapshots.ts";
 import type {
   AccountGroup,
   AccountKind,
@@ -47,6 +49,7 @@ type MaicoinAccountSnapshot = typeof maicoinAccountSnapshots.$inferSelect;
 type MaicoinStatementRow = typeof maicoinStatementRows.$inferSelect;
 type ImportRun = typeof importRuns.$inferSelect;
 type SourceFile = typeof sourceFileImports.$inferSelect;
+type SourceRowLineage = typeof sourceRowLineage.$inferSelect;
 
 type CommonRow = {
   bank: string;
@@ -58,6 +61,7 @@ type CommonRow = {
 export type LedgerQueryData = {
   importRuns: ImportRun[];
   sourceFiles: SourceFile[];
+  sourceRowLineage: SourceRowLineage[];
   accountTransactions: AccountTransaction[];
   foreignCurrencyTransactions: ForeignCurrencyTransaction[];
   creditCardStatementLines: CreditCardStatementLine[];
@@ -93,6 +97,7 @@ export function emptyLedgerQueryData(): LedgerQueryData {
   return {
     importRuns: [],
     sourceFiles: [],
+    sourceRowLineage: [],
     accountTransactions: [],
     foreignCurrencyTransactions: [],
     creditCardStatementLines: [],
@@ -191,8 +196,18 @@ export function buildRawPositions(data: LedgerQueryData): RawPosition[] {
       latestVerifiedCreditCardRows(data),
     ),
     ...loanPositions(data.loanTransactions),
-    ...fundPositions(data.fundHoldings),
-    ...brokeragePositions(data.brokerageHoldings),
+    ...fundPositions(latestPositionSnapshotRows(
+      data.fundHoldings,
+      data.sourceFiles,
+      data.sourceRowLineage,
+      "fund_holdings",
+    )),
+    ...brokeragePositions(latestPositionSnapshotRows(
+      data.brokerageHoldings,
+      data.sourceFiles,
+      data.sourceRowLineage,
+      "brokerage_holdings",
+    )),
     ...maicoinPositions(data.maicoinAccountSnapshots, data.maicoinStatementRows),
   ];
 }

--- a/src/lib/shared-ledger/server/mock-data.ts
+++ b/src/lib/shared-ledger/server/mock-data.ts
@@ -1,4 +1,5 @@
 import type { LedgerQueryData } from "./accounts.ts";
+import { sourceImportScopeKey } from "./source-import-scope.ts";
 
 type LedgerRow<K extends keyof LedgerQueryData> = LedgerQueryData[K][number];
 
@@ -34,6 +35,7 @@ export function mockLedgerQueryData(referenceDate = new Date()): LedgerQueryData
   return shiftTemplateDates({
     importRuns,
     sourceFiles,
+    sourceRowLineage: mockPositionSourceRowLineage(),
     accountTransactions,
     foreignCurrencyTransactions,
     creditCardStatementLines,
@@ -51,6 +53,26 @@ export function mockLedgerQueryData(referenceDate = new Date()): LedgerQueryData
     maicoinAccountSnapshots,
     maicoinStatementRows,
   }, referenceDate);
+}
+
+function mockPositionSourceRowLineage(): LedgerQueryData["sourceRowLineage"] {
+  const versionByScope = new Map(sourceFiles.map((source) => [
+    sourceImportScopeKey(source),
+    source.sourceVersionKey,
+  ]));
+  return [
+    ...fundHoldings.map((row) => ({ row, projectionTable: "fund_holdings" })),
+    ...brokerageHoldings.map((row) => ({ row, projectionTable: "brokerage_holdings" })),
+  ].map(({ row, projectionTable }) => ({
+    sourceFileId: row.sourceFileId,
+    importRunId: row.importRunId,
+    sourceVersionKey: versionByScope.get(sourceImportScopeKey(row)) ?? "",
+    sourceRowIndex: row.sourceRowIndex,
+    projectionTable,
+    statementRowId: row.statementRowId,
+    outcome: "inserted",
+    createdAt: row.importedAt,
+  }));
 }
 
 const TEMPLATE_LATEST_DATE = Date.UTC(2026, 5, 28);

--- a/src/lib/shared-ledger/server/position-snapshots.ts
+++ b/src/lib/shared-ledger/server/position-snapshots.ts
@@ -1,0 +1,94 @@
+import type {
+  sourceFileImports,
+  sourceRowLineage,
+} from "../../../ledger/db/schema.ts";
+import {
+  createSourceCsvParser,
+  type TypedStatementTable,
+} from "../../../ledger/source-csv-parsers.ts";
+import { sourceImportScopeKey } from "./source-import-scope.ts";
+
+type SourceFile = typeof sourceFileImports.$inferSelect;
+type SourceRowLineage = typeof sourceRowLineage.$inferSelect;
+
+export type PositionSnapshotTable = Extract<
+  TypedStatementTable,
+  "fund_holdings" | "brokerage_holdings"
+>;
+
+type PositionSnapshotRow = {
+  bank: string;
+  product: string;
+  statementRowId: string;
+};
+
+function projectionTableFor(source: SourceFile): TypedStatementTable {
+  return createSourceCsvParser({
+    bank: source.bank,
+    product: source.product,
+    sourceRelativePath: source.sourceRelativePath,
+    metadata: null,
+    headers: [],
+  }).table;
+}
+
+function compareSnapshotSources(left: SourceFile, right: SourceFile): number {
+  const fields: Array<keyof Pick<
+    SourceFile,
+    "sourceRelativePath" | "sourceFileModifiedAt" | "importedAt" | "sourceVersionKey"
+  >> = [
+    "sourceRelativePath",
+    "sourceFileModifiedAt",
+    "importedAt",
+    "sourceVersionKey",
+  ];
+  for (const field of fields) {
+    const comparison = (left[field] ?? "").localeCompare(right[field] ?? "");
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}
+
+function latestSourceByInstitution(
+  sources: SourceFile[],
+  projectionTable: PositionSnapshotTable,
+): Map<string, Map<string, SourceFile>> {
+  const byBank = new Map<string, Map<string, SourceFile>>();
+  for (const source of sources) {
+    if (projectionTableFor(source) !== projectionTable) continue;
+    const byProduct = byBank.get(source.bank) ?? new Map<string, SourceFile>();
+    const previous = byProduct.get(source.product);
+    if (!previous || compareSnapshotSources(source, previous) > 0) {
+      byProduct.set(source.product, source);
+    }
+    byBank.set(source.bank, byProduct);
+  }
+  return byBank;
+}
+
+export function latestPositionSnapshotRows<T extends PositionSnapshotRow>(
+  rows: T[],
+  sourceFiles: SourceFile[],
+  sourceLineage: SourceRowLineage[],
+  projectionTable: PositionSnapshotTable,
+): T[] {
+  const latestSources = latestSourceByInstitution(sourceFiles, projectionTable);
+  if (latestSources.size === 0) return rows;
+
+  const statementIdsByScope = new Map<string, Set<string>>();
+  for (const lineage of sourceLineage) {
+    if (lineage.projectionTable !== projectionTable) continue;
+    const scope = sourceImportScopeKey(lineage);
+    const statementIds = statementIdsByScope.get(scope) ?? new Set<string>();
+    statementIds.add(lineage.statementRowId);
+    statementIdsByScope.set(scope, statementIds);
+  }
+
+  return rows.filter((row) => {
+    const latestSource = latestSources.get(row.bank)?.get(row.product);
+    if (!latestSource) return true;
+    return statementIdsByScope
+      .get(sourceImportScopeKey(latestSource))
+      ?.has(row.statementRowId) === true;
+  });
+}

--- a/src/lib/shared-ledger/server/source-import-scope.ts
+++ b/src/lib/shared-ledger/server/source-import-scope.ts
@@ -1,0 +1,7 @@
+export type SourceImportScope = `${string}|${string}`;
+
+export function sourceImportScopeKey(
+  value: { sourceFileId: string; importRunId: string },
+): SourceImportScope {
+  return `${value.sourceFileId}|${value.importRunId}`;
+}

--- a/src/workflows/yuanta-trade-statements.check.ts
+++ b/src/workflows/yuanta-trade-statements.check.ts
@@ -4,6 +4,7 @@ import type { Page } from "playwright";
 import {
   dismissPasswordChangeReminderIfPresent,
   fillTradeLoginForm,
+  isCompleteHoldingCapture,
 } from "./yuanta-trade-statements.ts";
 
 function fakePage(reminderVisible: boolean | Error) {
@@ -85,4 +86,35 @@ test("removes focus from the YuanTa password field after filling credentials", a
     "fill:#loginPWD:password",
     "blur:#loginPWD",
   ]);
+});
+
+const completeHoldingPage = {
+  reportType: "Stock",
+  url: "https://global.yuanta.com.tw/NexusWebTrade/AssetReport/Stock",
+  currentAssetType: "Stock",
+  summaryRows: [],
+  grids: [{
+    gridId: "gridStock",
+    category: "Stock",
+    columns: [],
+    rows: [],
+  }],
+};
+
+test("accepts a verified empty YuanTa holdings page as authoritative", () => {
+  assert.equal(isCompleteHoldingCapture([completeHoldingPage], ["Stock"]), true);
+});
+
+test("rejects an empty YuanTa extraction without report structure", () => {
+  assert.equal(isCompleteHoldingCapture(
+    [{ ...completeHoldingPage, grids: [] }],
+    ["Stock"],
+  ), false);
+});
+
+test("rejects a partial YuanTa holdings capture", () => {
+  assert.equal(isCompleteHoldingCapture(
+    [completeHoldingPage],
+    ["Stock", "Bond"],
+  ), false);
 });

--- a/src/workflows/yuanta-trade-statements.ts
+++ b/src/workflows/yuanta-trade-statements.ts
@@ -86,6 +86,7 @@ const outputSchema = z.object({
   holdingPageCount: z.number().int().nonnegative(),
   holdingGridCount: z.number().int().nonnegative(),
   holdingRowCount: z.number().int().nonnegative(),
+  holdingCaptureComplete: z.boolean(),
   tradePageCount: z.number().int().nonnegative(),
   tradeGridCount: z.number().int().nonnegative(),
   tradeRowCount: z.number().int().nonnegative(),
@@ -732,6 +733,33 @@ function gridCount(pages: ReportPage[]): number {
   return pages.reduce((total, page) => total + page.grids.length, 0);
 }
 
+type HoldingCaptureEvidence = Pick<
+  ReportPage,
+  "reportType" | "url" | "currentAssetType" | "summaryRows" | "grids"
+>;
+
+export function isCompleteHoldingCapture(
+  pages: HoldingCaptureEvidence[],
+  requestedTypes: readonly string[],
+): boolean {
+  if (requestedTypes.length === 0 || pages.length !== requestedTypes.length) {
+    return false;
+  }
+  const pagesByType = new Map(pages.map((page) => [page.reportType, page]));
+  return requestedTypes.every((reportType) => {
+    const page = pagesByType.get(reportType);
+    if (!page || page.currentAssetType !== reportType) return false;
+    let routeName = "";
+    try {
+      routeName = new URL(page.url).pathname.split("/").filter(Boolean).at(-1) ?? "";
+    } catch {
+      return false;
+    }
+    const hasParsedReportStructure = page.grids.length > 0 || page.summaryRows.length > 0;
+    return routeName === reportType && hasParsedReportStructure;
+  });
+}
+
 function normalizeTradeRows(
   pages: ReportPage[],
   dateRange: { startDate: string; endDate: string },
@@ -1023,6 +1051,7 @@ async function writeResultsFiles(
   outputDir: string,
   result: {
     holdings: CsvRow[];
+    holdingsCaptureComplete: boolean;
     trades: CsvRow[];
     summaries: CsvRow[];
   },
@@ -1040,7 +1069,7 @@ async function writeResultsFiles(
     );
   }
 
-  if (result.holdings.length > 0) {
+  if (result.holdingsCaptureComplete) {
     files.push(
       await writeTableWithMetadata(
         outputDir,
@@ -1173,8 +1202,18 @@ export default workflow("yuantaTradeStatements", {
     const tradeRows = normalizeTradeRows(trades, dateRange);
     const holdingRows = normalizeHoldingRows(holdings, dateRange);
     const summaryRows = normalizeSummaryRows([...holdings, ...trades], dateRange);
+    const holdingCaptureComplete = input.includeHoldings && isCompleteHoldingCapture(
+      holdings,
+      input.holdingTypes,
+    );
+    if (input.includeHoldings && !holdingCaptureComplete) {
+      console.warn(
+        "Holding capture was incomplete; preserving the previous authoritative snapshot.",
+      );
+    }
     const files = await writeResultsFiles(input.outputDir, {
       holdings: holdingRows,
+      holdingsCaptureComplete: holdingCaptureComplete,
       trades: tradeRows,
       summaries: summaryRows,
     });
@@ -1186,6 +1225,7 @@ export default workflow("yuantaTradeStatements", {
       holdingPageCount: holdings.length,
       holdingGridCount: gridCount(holdings),
       holdingRowCount: holdingRows.length,
+      holdingCaptureComplete,
       tradePageCount: trades.length,
       tradeGridCount: gridCount(trades),
       tradeRowCount: tradeRows.length,


### PR DESCRIPTION
## What

- Treat Yuanta brokerage and fund holdings as complete-set snapshots instead of accumulating historical rows into the current portfolio.
- Select the latest source-import scope through source-row lineage while retaining older rows for audit and daily history.
- Centralize source scope identity, typed snapshot classification, and deterministic source ordering in a focused snapshot module.
- Emit an empty Yuanta brokerage snapshot only after every requested holdings page has verifiable report structure; incomplete extraction preserves the prior snapshot.
- Add regression coverage for sold brokerage symbols, verified empty brokerage accounts, redeemed funds, and incomplete Yuanta extraction.
- Document the audit of credit cards, MaiCoin, cash/foreign balances, and loans.

## Why

The account projection previously selected the latest row per symbol. Because imports retain historical canonical rows, a symbol omitted from a newer full holdings export, such as VRT or VRTL after sale, remained visible forever.

## Impact

Current brokerage and fund positions now reflect the latest authoritative export. Historical source rows remain available. Failed or structurally incomplete empty extractions cannot clear an account.

## Checks

- npm test — 278/278 passed
- npm run typecheck — 0 errors, 0 warnings
- npm run privacy-check — no leaks found
- Live Yuanta collection/import verified that VRT and VRTL are absent from account ****9948