### PR TITLE
執行第一個 host-gated Authorized tool request

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,8 +12,8 @@ import {
 import {
   createAgentHarnessService,
   createInlineAgentHelper,
-  createNoToolAgentGateway,
 } from "../src/lib/agent/server/harness.ts";
+import { createFinancialOverviewToolGateway } from "../src/lib/agent/server/tool-gateway.ts";
 import {
   createAppleSystemModelProtocolClient,
   createAppleSystemModelProvider,
@@ -215,7 +215,11 @@ async function start() {
     helper: createInlineAgentHelper(),
     provider: agentProvider,
     runStore: agentStore,
-    toolGateway: createNoToolAgentGateway(),
+    toolGateway: createFinancialOverviewToolGateway({
+      ledgerDir,
+      runStore: agentStore,
+      clock: { now: () => new Date().toISOString() },
+    }),
     clock: { now: () => new Date().toISOString() },
     diagnosticsSink: { record() {} },
   });

--- a/src/ledger/db/migrations.check.ts
+++ b/src/ledger/db/migrations.check.ts
@@ -687,7 +687,7 @@ try {
 
   assert.deepEqual(
     versions.map((row) => row.version),
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
   );
   for (const table of ["agent_runs", "agent_run_lineage"]) {
     const columns = migrated.prepare(`PRAGMA table_info(${table})`).all() as Array<{
@@ -695,6 +695,13 @@ try {
     }>;
     assert.equal(columns.filter((column) => column.name === "analysis_id").length, 1);
   }
+  const agentToolOutcomeColumns = migrated.prepare(
+    "PRAGMA table_info(agent_tool_outcomes)",
+  ).all() as Array<{ name: string }>;
+  assert.deepEqual(agentToolOutcomeColumns.map((column) => column.name), [
+    "run_id", "request_id", "outcome", "result_reference", "result_json",
+    "proposal_json", "decision_json", "occurred_at", "updated_at", "record_json",
+  ]);
   const exchangeRateColumns = migrated.prepare(
     "PRAGMA table_info(exchange_rates)",
   ).all() as Array<{ name: string; notnull: number }>;

--- a/src/ledger/db/migrations.ts
+++ b/src/ledger/db/migrations.ts
@@ -814,6 +814,27 @@ function addAgentAnalysisId(db: LedgerDatabase) {
   addColumnIfMissing(db, "agent_run_lineage", "analysis_id", "analysis_id TEXT");
 }
 
+function createAgentToolOutcomeSchema(db: LedgerDatabase) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_tool_outcomes (
+      run_id TEXT NOT NULL,
+      request_id TEXT NOT NULL,
+      outcome TEXT NOT NULL CHECK (outcome IN ('not-dispatched', 'completed', 'outcome-unknown')),
+      result_reference TEXT,
+      result_json TEXT,
+      proposal_json TEXT NOT NULL,
+      decision_json TEXT NOT NULL,
+      occurred_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (run_id, request_id),
+      FOREIGN KEY (run_id) REFERENCES agent_runs(run_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_agent_tool_outcomes_run
+    ON agent_tool_outcomes(run_id, occurred_at, request_id);
+  `);
+}
+
 function physicallyDeduplicateStatementRows(db: LedgerDatabase) {
   for (const table of TYPED_STATEMENT_TABLES) {
     if (
@@ -2078,6 +2099,11 @@ const migrations: LedgerMigration[] = [
     version: 29,
     name: "agent_run_analysis_identity",
     up: addAgentAnalysisId,
+  },
+  {
+    version: 30,
+    name: "agent_tool_outcomes",
+    up: createAgentToolOutcomeSchema,
   },
 ];
 

--- a/src/lib/agent/server/harness.check.ts
+++ b/src/lib/agent/server/harness.check.ts
@@ -11,6 +11,10 @@ import {
   type AgentProvider,
 } from "./harness.ts";
 import {
+  createReadFinancialOverviewProposal,
+  type AgentToolExecutionRecord,
+} from "./tool-gateway.ts";
+import {
   APPLE_SYSTEM_MODEL_HELPER_PROTOCOL_VERSION,
   createAppleSystemModelProvider,
   createAppleSystemModelProtocolClient,
@@ -58,6 +62,124 @@ function deterministicAdapter() {
     cancellations,
   };
 }
+
+function toolRecord(
+  runId: string,
+  requestId: string,
+  outcome: AgentToolExecutionRecord["outcome"],
+  occurredAt: string,
+): AgentToolExecutionRecord {
+  return {
+    runId,
+    requestId,
+    proposal: createReadFinancialOverviewProposal(runId, requestId),
+    decision: {
+      decisionVersion: "agent-tool-decision.v1",
+      allowed: outcome !== "not-dispatched",
+      reason: outcome === "not-dispatched" ? "run-authority-denied" : "allowed",
+    },
+    outcome,
+    result: null,
+    resultReference: null,
+    occurredAt,
+  };
+}
+
+test("in-memory tool requests use durable occurredAt/requestId ordering for list and latest status", async () => {
+  const store = createInMemoryAgentRunStore();
+  store.createRun({
+    runId: "run-tool-ordering-memory",
+    analysisId: null,
+    phase: "running",
+    startedAt: "2026-08-04T00:00:00.000Z",
+    finishedAt: null,
+    output: "",
+    failureReason: null,
+  });
+
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-a",
+    "not-dispatched",
+    "2026-08-04T00:00:01.000Z",
+  ));
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-b",
+    "not-dispatched",
+    "2026-08-04T00:00:02.000Z",
+  ));
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-a",
+    "outcome-unknown",
+    "2026-08-04T00:00:03.000Z",
+  ));
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-z",
+    "not-dispatched",
+    "2026-08-04T00:00:03.000Z",
+  ));
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-earlier",
+    "not-dispatched",
+    "2026-08-04T00:00:00.000Z",
+  ));
+  store.recordToolRequest?.(toolRecord(
+    "run-tool-ordering-memory",
+    "request-y",
+    "not-dispatched",
+    "2026-08-04T00:00:03.000Z",
+  ));
+
+  assert.deepEqual(
+    store.listToolRequests?.("run-tool-ordering-memory").map((record) => [
+      record.requestId,
+      record.outcome,
+      record.occurredAt,
+    ]),
+    [
+      ["request-earlier", "not-dispatched", "2026-08-04T00:00:00.000Z"],
+      ["request-b", "not-dispatched", "2026-08-04T00:00:02.000Z"],
+      ["request-a", "outcome-unknown", "2026-08-04T00:00:03.000Z"],
+      ["request-y", "not-dispatched", "2026-08-04T00:00:03.000Z"],
+      ["request-z", "not-dispatched", "2026-08-04T00:00:03.000Z"],
+    ],
+  );
+
+  const adapter = deterministicAdapter();
+  const service = createAgentHarnessService({
+    helper: adapter.helper,
+    provider: adapter.provider,
+    runStore: store,
+    toolGateway: { execute: () => ({ status: "rejected" }) },
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-tool-ordering-status",
+  });
+  await service.activate();
+  const started = service.start({});
+  for (const record of [
+    toolRecord(started.runId, "request-a", "not-dispatched", "2026-08-04T00:00:01.000Z"),
+    toolRecord(started.runId, "request-b", "not-dispatched", "2026-08-04T00:00:02.000Z"),
+    toolRecord(started.runId, "request-a", "outcome-unknown", "2026-08-04T00:00:03.000Z"),
+    toolRecord(started.runId, "request-z", "not-dispatched", "2026-08-04T00:00:03.000Z"),
+    toolRecord(started.runId, "request-earlier", "not-dispatched", "2026-08-04T00:00:00.000Z"),
+    toolRecord(started.runId, "request-y", "not-dispatched", "2026-08-04T00:00:03.000Z"),
+  ]) {
+    store.recordToolRequest?.(record);
+  }
+  assert.equal(service.status(started.runId).toolState?.toolName, "read_financial_overview");
+  assert.equal(service.status(started.runId).toolState?.outcome, "not-dispatched");
+  assert.equal(service.status(started.runId).toolState?.settlement, "normal");
+  assert.equal(service.status(started.runId).toolState?.resultReference, null);
+  assert.equal(
+    store.listToolRequests?.(started.runId).at(-1)?.requestId,
+    "request-z",
+  );
+});
 
 test("a helper crash is terminal, ordinary activation cannot replace it, and Start new run performs the replacement handshake", async () => {
   let helperLaunches = 0;

--- a/src/lib/agent/server/harness.check.ts
+++ b/src/lib/agent/server/harness.check.ts
@@ -1188,3 +1188,77 @@ test("SQLite Agent store rejects a canary before writing a run", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("a rejected provider gateway becomes a bounded unknown outcome without leaking its error", async () => {
+  const store = createInMemoryAgentRunStore();
+  const diagnostics: unknown[] = [];
+  const canary = "provider-gateway-secret-canary";
+  let submission!: Promise<{
+    requestId: string;
+    decision: { decisionVersion: string; allowed: boolean; reason: string };
+    outcome: string;
+    result: unknown;
+    resultReference: unknown;
+    settlement: string;
+  }>;
+  let complete!: () => void;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: capability, onComplete }) {
+      complete = onComplete;
+      submission = capability.submit({
+        proposalVersion: "agent-tool-proposal.v1",
+        requestId: "request-gateway-rejection",
+        runId,
+        toolName: "read_financial_overview",
+        input: {},
+        permission: "financial.overview.read",
+        sensitivity: "derived-financial",
+        resource: "ledger.overview",
+        runAuthority: runId,
+      });
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: {
+      async submit() {
+        throw new Error(`gateway rejected with ${canary}`);
+      },
+    },
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record(event) { diagnostics.push(event); } },
+    idFactory: () => "run-gateway-rejection",
+    secretValues: [canary],
+  });
+
+  await service.activate();
+  service.start({});
+  complete();
+  const bounded = await submission;
+  assert.equal(bounded.requestId, "request-gateway-rejection");
+  assert.equal(bounded.decision.decisionVersion, "agent-tool-decision.v1");
+  assert.equal(bounded.decision.allowed, false);
+  assert.equal(bounded.outcome, "outcome-unknown");
+  assert.equal(bounded.result, null);
+  assert.equal(bounded.resultReference, null);
+  assert.equal(bounded.settlement, "normal");
+  assert.equal(service.status("run-gateway-rejection").phase, "failed");
+  assert.equal(store.getRun("run-gateway-rejection")?.failureReason, "tool-outcome-unknown");
+  assert.deepEqual(service.lineage("run-gateway-rejection").map((event) => event.kind), [
+    "run.started", "tool.proposal", "tool.decision", "tool.outcome", "run.failed",
+  ]);
+  assert.equal(service.lineage("run-gateway-rejection").at(-1)?.transitionReason, "tool-outcome-unknown");
+  assert.equal(JSON.stringify(bounded).includes(canary), false);
+  assert.equal(JSON.stringify(service.lineage("run-gateway-rejection")).includes(canary), false);
+  assert.equal(JSON.stringify(diagnostics).includes(canary), false);
+
+  complete();
+  assert.equal(service.complete("run-gateway-rejection").phase, "failed");
+  assert.equal(service.cancel("run-gateway-rejection").phase, "failed");
+});

--- a/src/lib/agent/server/harness.check.ts
+++ b/src/lib/agent/server/harness.check.ts
@@ -1384,3 +1384,64 @@ test("a rejected provider gateway becomes a bounded unknown outcome without leak
   assert.equal(service.complete("run-gateway-rejection").phase, "failed");
   assert.equal(service.cancel("run-gateway-rejection").phase, "failed");
 });
+
+test("tool lineage retains the sanitized proposal only on proposal events", async () => {
+  const store = createInMemoryAgentRunStore();
+  let submissionDone!: () => void;
+  const done = new Promise<void>((resolve) => { submissionDone = resolve; });
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: capability, onComplete }) {
+      void capability.submit(createReadFinancialOverviewProposal(runId, "request-lineage-shape"))
+        .finally(() => {
+          onComplete();
+          submissionDone();
+        });
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: {
+      async submit(proposal) {
+        const requestId = (proposal as { requestId: string }).requestId;
+        return {
+          requestId,
+          decision: {
+            decisionVersion: "agent-tool-decision.v1",
+            allowed: false,
+            reason: "permission-denied" as const,
+          },
+          outcome: "not-dispatched" as const,
+          result: null,
+          resultReference: null,
+          settlement: "normal" as const,
+        };
+      },
+    },
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-lineage-shape",
+  });
+  await service.activate();
+  service.start({});
+  await done;
+  const events = service.lineage("run-lineage-shape");
+  const proposalEvent = events.find((event) => event.kind === "tool.proposal");
+  const decisionEvent = events.find((event) => event.kind === "tool.decision");
+  const outcomeEvent = events.find((event) => event.kind === "tool.outcome");
+  assert.ok(proposalEvent?.tool?.proposal);
+  assert.equal(proposalEvent?.tool?.proposal?.requestId, "request-lineage-shape");
+  assert.equal(decisionEvent?.tool?.proposal, undefined);
+  assert.equal(outcomeEvent?.tool?.proposal, undefined);
+  assert.equal(decisionEvent?.tool?.requestId, "request-lineage-shape");
+  assert.equal(decisionEvent?.tool?.toolName, "read_financial_overview");
+  assert.equal(decisionEvent?.tool?.decision?.reason, "permission-denied");
+  assert.equal(outcomeEvent?.tool?.requestId, "request-lineage-shape");
+  assert.equal(outcomeEvent?.tool?.outcome, "not-dispatched");
+  assert.equal(outcomeEvent?.tool?.resultReference, null);
+});

--- a/src/lib/agent/server/harness.ts
+++ b/src/lib/agent/server/harness.ts
@@ -555,6 +555,24 @@ export function createAgentHarnessService({
     return malformed;
   }
 
+  function unknownToolSubmission(
+    requestId: string,
+    settlement: AgentToolSubmission["settlement"],
+  ): AgentToolSubmission {
+    return {
+      requestId,
+      decision: {
+        decisionVersion: "agent-tool-decision.v1",
+        allowed: false,
+        reason: "tool-not-allowlisted",
+      },
+      outcome: "outcome-unknown",
+      result: null,
+      resultReference: null,
+      settlement,
+    };
+  }
+
   function createProviderToolGateway(runId: string): AgentProviderToolGateway {
     const runProvider = runProviders.get(runId);
     if (!runProvider) throw new Error("Agent run provider metadata not found.");
@@ -606,7 +624,18 @@ export function createAgentHarnessService({
           appendToolEvent("tool.proposal", "proposed");
           let submission: AgentToolSubmission;
           if ("submit" in toolGateway && typeof toolGateway.submit === "function") {
-            submission = await toolGateway.submit(proposal);
+            try {
+              submission = await toolGateway.submit(proposal);
+            } catch {
+              // A gateway rejection means dispatch settlement is unknown. Keep
+              // the provider-facing record bounded and never project the error.
+              submission = unknownToolSubmission(
+                requestId,
+                runStore.getRun(runId)?.phase === "cancelled"
+                  ? "cancelled-in-flight"
+                  : "normal",
+              );
+            }
           } else {
             submission = {
               requestId,

--- a/src/lib/agent/server/harness.ts
+++ b/src/lib/agent/server/harness.ts
@@ -596,28 +596,15 @@ export function createAgentHarnessService({
             ? proposedRecord.toolName
             : "unknown";
           const appendToolEvent = (
-          kind: AgentLineageEvent["kind"],
-          status: AgentLineageEvent["status"],
-          submission?: AgentToolSubmission,
+            kind: AgentLineageEvent["kind"],
+            status: AgentLineageEvent["status"],
+            submission?: AgentToolSubmission,
           ) => {
             if (!runStore.getRun(runId)) return;
-            recordLineage({
-            runId,
-            analysisId: requireRun(runStore, runId).analysisId,
-            seq: runStore.getLineage(runId).length + 1,
-            kind,
-            status,
-            occurredAt: clock.now(),
-            dataClasses: ["financial.derived"],
-            providerIdentity: runProvider.providerIdentity,
-            osBuild: runProvider.osBuild,
-            providerAssurance: runProvider.assurance,
-            transitionReason: null,
-            secretFields: [],
-            tool: {
+            const tool: NonNullable<AgentLineageEvent["tool"]> = {
               requestId,
               toolName,
-              proposal: proposedRecord,
+              ...(kind === "tool.proposal" ? { proposal: proposedRecord } : {}),
               ...(submission ? {
                 decision: submission.decision,
                 decisionReason: submission.decision.reason,
@@ -625,7 +612,21 @@ export function createAgentHarnessService({
                 resultReference: submission.resultReference?.value ?? null,
                 settlement: submission.settlement,
               } : {}),
-            },
+            };
+            recordLineage({
+              runId,
+              analysisId: requireRun(runStore, runId).analysisId,
+              seq: runStore.getLineage(runId).length + 1,
+              kind,
+              status,
+              occurredAt: clock.now(),
+              dataClasses: ["financial.derived"],
+              providerIdentity: runProvider.providerIdentity,
+              osBuild: runProvider.osBuild,
+              providerAssurance: runProvider.assurance,
+              transitionReason: null,
+              secretFields: [],
+              tool,
             });
           };
           appendToolEvent("tool.proposal", "proposed");

--- a/src/lib/agent/server/harness.ts
+++ b/src/lib/agent/server/harness.ts
@@ -524,26 +524,31 @@ export function createAgentHarnessService({
   }
 
   function safeProviderProposal(runId: string, rawProposal: unknown): AgentToolProposal | Record<string, unknown> {
-    const validation = validateAgentToolProposal(rawProposal);
-    if (validation.value) {
-      const protectedProposal = secretBoundary.protectRecord(
-        "diagnostic-export",
-        "agent-tool-proposal",
-        validation.value as unknown as Record<string, unknown>,
-      );
-      if (protectedProposal.failure) {
-        const safe = createReadFinancialOverviewProposal(runId, "redacted");
-        const { input: _input, ...malformed } = safe;
-        return malformed;
+    try {
+      const validation = validateAgentToolProposal(rawProposal);
+      if (validation.value) {
+        const protectedProposal = secretBoundary.protectRecord(
+          "diagnostic-export",
+          "agent-tool-proposal",
+          validation.value as unknown as Record<string, unknown>,
+        );
+        if (protectedProposal.failure) {
+          const safe = createReadFinancialOverviewProposal(runId, "redacted");
+          const { input: _input, ...malformed } = safe;
+          return malformed;
+        }
+        if (validation.value.runId === runId && validation.value.runAuthority === runId) {
+          return validation.value;
+        }
+        return {
+          ...validation.value,
+          runId,
+          runAuthority: "invalid",
+        };
       }
-      if (validation.value.runId === runId && validation.value.runAuthority === runId) {
-        return validation.value;
-      }
-      return {
-        ...validation.value,
-        runId,
-        runAuthority: "invalid",
-      };
+    } catch {
+      // Provider input is untrusted. Cyclic or otherwise unserializable values
+      // must follow the same bounded malformed-proposal path as schema failures.
     }
     const safe = createReadFinancialOverviewProposal(runId, "redacted");
     const { input: _input, ...malformed } = safe;

--- a/src/lib/agent/server/harness.ts
+++ b/src/lib/agent/server/harness.ts
@@ -7,6 +7,16 @@ import {
   type SecretBoundaryGate,
   type SecretSchemaAllowlist,
 } from "../../automation/server/secret-boundary.ts";
+import type {
+  AgentToolProposal,
+  AgentProviderToolGateway,
+  AgentToolExecutionRecord,
+  AgentToolSubmission,
+} from "./tool-gateway.ts";
+import {
+  createReadFinancialOverviewProposal,
+  validateAgentToolProposal,
+} from "./tool-gateway.ts";
 
 export type { SecretBoundaryDependencies, SecretBoundaryGate } from "../../automation/server/secret-boundary.ts";
 
@@ -28,6 +38,7 @@ export const AGENT_FAILURE_REASONS = [
   "provider-concurrent-request",
   "provider-refused",
   "provider-generation-failed",
+  "tool-outcome-unknown",
   "provider-failed",
   "helper-launch-failed",
   "secret-boundary-violation",
@@ -44,14 +55,21 @@ export type AgentRunStatus = {
   startedAt: string;
   finishedAt: string | null;
   output: string;
+  toolState?: {
+    outcome: "not-dispatched" | "completed" | "outcome-unknown";
+    toolName: string;
+    resultReference: string | null;
+    settlement: "normal" | "cancelled-in-flight";
+  };
 };
 
 export type AgentLineageEvent = {
   runId: string;
   analysisId: string | null;
   seq: number;
-  kind: "run.started" | "run.completed" | "run.cancelled" | "run.failed";
-  status: "allowed" | "observed";
+  kind: "run.started" | "run.completed" | "run.cancelled" | "run.failed"
+    | "tool.proposal" | "tool.decision" | "tool.outcome";
+  status: "allowed" | "observed" | "proposed" | "blocked";
   occurredAt: string;
   dataClasses: readonly string[];
   providerIdentity: string;
@@ -59,6 +77,16 @@ export type AgentLineageEvent = {
   providerAssurance: AgentSystemModelActivation["assurance"];
   transitionReason: AgentTransitionReason;
   secretFields: readonly [];
+  tool?: {
+    requestId: string;
+    toolName: string;
+    proposal?: Record<string, unknown>;
+    decision?: { decisionVersion: string; allowed: boolean; reason: string };
+    decisionReason?: string;
+    outcome?: "not-dispatched" | "completed" | "outcome-unknown";
+    resultReference?: string | null;
+    settlement?: "normal" | "cancelled-in-flight";
+  };
 };
 
 export type AgentDiagnosticsEvent = {
@@ -68,6 +96,14 @@ export type AgentDiagnosticsEvent = {
   occurredAt: string;
   transitionReason: AgentTransitionReason;
   secretFields: readonly [];
+  tool?: {
+    requestId: string;
+    toolName: string;
+    decision?: { decisionVersion: string; allowed: boolean; reason: string };
+    outcome?: "not-dispatched" | "completed" | "outcome-unknown";
+    resultReference?: string | null;
+    settlement?: "normal" | "cancelled-in-flight";
+  };
 };
 
 export type AgentToolRequest = {
@@ -79,14 +115,21 @@ export type AgentToolResult = {
   status: "rejected" | "completed";
 };
 
-export type AgentToolGateway = {
+/**
+ * Kept as a narrow compatibility boundary for callers that have not yet
+ * installed the host gateway. The provider-facing value is always the
+ * proposal-only `submit` capability below; it never contains `execute`.
+ */
+/** Compatibility name for the single proposal-only provider capability. */
+export type AgentToolGateway = AgentProviderToolGateway;
+export type LegacyAgentToolGateway = {
   execute(request: AgentToolRequest): AgentToolResult;
 };
 
 export type AgentProviderStart = {
   runId: string;
   input: AgentStartInput;
-  toolGateway: AgentToolGateway;
+  toolGateway: AgentProviderToolGateway;
   onStream: (content: string) => void;
   onComplete: () => void;
   onFailure: (error: Error) => void;
@@ -149,6 +192,9 @@ export type AgentRunStore = {
   ): void;
   appendLineage(event: AgentLineageEvent): void;
   getLineage(runId: string): AgentLineageEvent[];
+  recordToolRequest?(record: AgentToolExecutionRecord): void;
+  getToolRequest?(runId: string, requestId: string): AgentToolExecutionRecord | null;
+  listToolRequests?(runId: string): AgentToolExecutionRecord[];
 };
 
 export type AgentDiagnosticsSink = {
@@ -188,6 +234,7 @@ export const AGENT_SECRET_SCHEMA_ALLOWLIST: SecretSchemaAllowlist = {
     "providerAssurance",
     "transitionReason",
     "secretFields",
+    "tool",
   ],
   "agent-diagnostic": [
     "runId",
@@ -196,11 +243,21 @@ export const AGENT_SECRET_SCHEMA_ALLOWLIST: SecretSchemaAllowlist = {
     "occurredAt",
     "transitionReason",
     "secretFields",
+    "tool",
   ],
   "agent-start-input": ["analysisId", "prompt"],
   "agent-activation": ["apiVersion", "availability", "warning"],
   "agent-stream": ["output"],
-  "agent-status": ["apiVersion", "runId", "phase", "action", "startedAt", "finishedAt", "output"],
+  "agent-status": ["apiVersion", "runId", "phase", "action", "startedAt", "finishedAt", "output", "toolState"],
+  "agent-tool-proposal": [
+    "proposalVersion", "requestId", "runId", "toolName", "input", "permission",
+    "sensitivity", "resource", "runAuthority",
+  ],
+  "agent-tool-decision": ["decisionVersion", "allowed", "reason"],
+  "agent-tool-result": ["resultVersion", "toolName", "data", "reference", "secretFields"],
+  "agent-tool-outcome": [
+    "runId", "requestId", "proposal", "decision", "outcome", "result", "resultReference", "occurredAt", "settlement",
+  ],
 };
 
 export function createAgentSecretBoundaryGate({
@@ -231,6 +288,20 @@ export function createAgentSecretBoundaryGate({
 export function createInMemoryAgentRunStore(): AgentRunStore {
   const runs = new Map<string, AgentRunRecord>();
   const lineage = new Map<string, AgentLineageEvent[]>();
+  const toolRequests = new Map<string, AgentToolExecutionRecord>();
+  const outcomeRank = { "not-dispatched": 1, "outcome-unknown": 2, completed: 3 } as const;
+  const canUpgradeOutcome = (
+    next: AgentToolExecutionRecord,
+    current: AgentToolExecutionRecord,
+  ) => {
+    if (outcomeRank[next.outcome] <= outcomeRank[current.outcome]) return false;
+    if (current.outcome === "outcome-unknown") {
+      return current.settlement === "cancelled-in-flight"
+        && next.outcome === "completed"
+        && next.settlement === "cancelled-in-flight";
+    }
+    return current.outcome === "not-dispatched";
+  };
   return {
     createRun(record) {
       if (runs.has(record.runId)) throw new Error("Agent run already exists.");
@@ -258,13 +329,44 @@ export function createInMemoryAgentRunStore(): AgentRunStore {
         secretFields: [],
       }));
     },
+    recordToolRequest(record) {
+      const key = `${record.runId}:${record.requestId}`;
+      const existing = toolRequests.get(key);
+      if (!existing || canUpgradeOutcome(record, existing)) {
+        toolRequests.set(key, { ...record });
+      }
+    },
+    getToolRequest(runId, requestId) {
+      const record = toolRequests.get(`${runId}:${requestId}`);
+      return record ? { ...record } : null;
+    },
+    listToolRequests(runId) {
+      return [...toolRequests.values()]
+        .filter((record) => record.runId === runId)
+        .map((record) => ({ ...record }));
+    },
   };
 }
 
-export function createNoToolAgentGateway(): AgentToolGateway {
+export function createNoToolAgentGateway(): AgentProviderToolGateway {
   return {
-    execute() {
-      return { status: "rejected" };
+    async submit(proposal) {
+      const requestId = typeof proposal === "object" && proposal !== null
+        && typeof (proposal as { requestId?: unknown }).requestId === "string"
+        ? (proposal as { requestId: string }).requestId
+        : "unknown";
+      return {
+        requestId,
+        decision: {
+          decisionVersion: "agent-tool-decision.v1",
+          allowed: false,
+          reason: "tool-not-allowlisted",
+        },
+        outcome: "not-dispatched",
+        result: null,
+        resultReference: null,
+        settlement: "normal",
+      };
     },
   };
 }
@@ -315,7 +417,7 @@ export type AgentHarnessDependencies = {
   helper: AgentHelper;
   provider: AgentProvider;
   runStore: AgentRunStore;
-  toolGateway: AgentToolGateway;
+  toolGateway: AgentToolGateway | LegacyAgentToolGateway;
   clock: AgentClock;
   diagnosticsSink: AgentDiagnosticsSink;
   idFactory?: () => string;
@@ -324,7 +426,11 @@ export type AgentHarnessDependencies = {
   secretBoundaryDependencies?: Partial<SecretBoundaryDependencies>;
 };
 
-function statusFor(record: AgentRunRecord, output = record.output): AgentRunStatus {
+function statusFor(
+  record: AgentRunRecord,
+  output = record.output,
+  toolState?: AgentRunStatus["toolState"],
+): AgentRunStatus {
   return {
     runId: record.runId,
     phase: record.phase,
@@ -332,6 +438,7 @@ function statusFor(record: AgentRunRecord, output = record.output): AgentRunStat
     startedAt: record.startedAt,
     finishedAt: record.finishedAt,
     output,
+    ...(toolState ? { toolState } : {}),
   };
 }
 
@@ -374,10 +481,34 @@ export function createAgentHarnessService({
   let activationGeneration = 0;
   const outputs = new Map<string, string>();
   const runProviders = new Map<string, AgentSystemModelActivation>();
+  const runContinuations = new Map<string, boolean>();
+  const pendingToolRequests = new Map<string, number>();
+  const completionRequested = new Map<string, boolean>();
 
   function cleanupRun(runId: string) {
+    if ((pendingToolRequests.get(runId) ?? 0) > 0) {
+      outputs.delete(runId);
+      return;
+    }
     runProviders.delete(runId);
+    runContinuations.delete(runId);
+    completionRequested.delete(runId);
     outputs.delete(runId);
+  }
+
+  function beginToolRequest(runId: string) {
+    pendingToolRequests.set(runId, (pendingToolRequests.get(runId) ?? 0) + 1);
+  }
+
+  function endToolRequest(runId: string): boolean {
+    const remaining = (pendingToolRequests.get(runId) ?? 1) - 1;
+    if (remaining > 0) {
+      pendingToolRequests.set(runId, remaining);
+      return false;
+    }
+    pendingToolRequests.delete(runId);
+    if (runStore.getRun(runId)?.phase !== "running") cleanupRun(runId);
+    return true;
   }
 
   function recordLineage(event: AgentLineageEvent) {
@@ -390,6 +521,150 @@ export function createAgentHarnessService({
       throw new Error(secretBoundaryFailureMessage(protectedEvent.failure));
     }
     runStore.appendLineage(protectedEvent.value as unknown as AgentLineageEvent);
+  }
+
+  function safeProviderProposal(runId: string, rawProposal: unknown): AgentToolProposal | Record<string, unknown> {
+    const validation = validateAgentToolProposal(rawProposal);
+    if (validation.value) {
+      const protectedProposal = secretBoundary.protectRecord(
+        "diagnostic-export",
+        "agent-tool-proposal",
+        validation.value as unknown as Record<string, unknown>,
+      );
+      if (protectedProposal.failure) {
+        const safe = createReadFinancialOverviewProposal(runId, "redacted");
+        const { input: _input, ...malformed } = safe;
+        return malformed;
+      }
+      if (validation.value.runId === runId && validation.value.runAuthority === runId) {
+        return validation.value;
+      }
+      return {
+        ...validation.value,
+        runId,
+        runAuthority: "invalid",
+      };
+    }
+    const safe = createReadFinancialOverviewProposal(runId, "redacted");
+    const { input: _input, ...malformed } = safe;
+    return malformed;
+  }
+
+  function createProviderToolGateway(runId: string): AgentProviderToolGateway {
+    const runProvider = runProviders.get(runId);
+    if (!runProvider) throw new Error("Agent run provider metadata not found.");
+    return {
+      submit: async (rawProposal): Promise<AgentToolSubmission> => {
+        beginToolRequest(runId);
+        try {
+          const proposal = safeProviderProposal(runId, rawProposal);
+          const proposedRecord = proposal as Record<string, unknown>;
+          const requestId = typeof proposedRecord.requestId === "string"
+            ? proposedRecord.requestId
+            : "redacted";
+          const toolName = typeof proposedRecord.toolName === "string"
+            ? proposedRecord.toolName
+            : "unknown";
+          const appendToolEvent = (
+          kind: AgentLineageEvent["kind"],
+          status: AgentLineageEvent["status"],
+          submission?: AgentToolSubmission,
+          ) => {
+            if (!runStore.getRun(runId)) return;
+            recordLineage({
+            runId,
+            analysisId: requireRun(runStore, runId).analysisId,
+            seq: runStore.getLineage(runId).length + 1,
+            kind,
+            status,
+            occurredAt: clock.now(),
+            dataClasses: ["financial.derived"],
+            providerIdentity: runProvider.providerIdentity,
+            osBuild: runProvider.osBuild,
+            providerAssurance: runProvider.assurance,
+            transitionReason: null,
+            secretFields: [],
+            tool: {
+              requestId,
+              toolName,
+              proposal: proposedRecord,
+              ...(submission ? {
+                decision: submission.decision,
+                decisionReason: submission.decision.reason,
+                outcome: submission.outcome,
+                resultReference: submission.resultReference?.value ?? null,
+                settlement: submission.settlement,
+              } : {}),
+            },
+            });
+          };
+          appendToolEvent("tool.proposal", "proposed");
+          let submission: AgentToolSubmission;
+          if ("submit" in toolGateway && typeof toolGateway.submit === "function") {
+            submission = await toolGateway.submit(proposal);
+          } else {
+            submission = {
+              requestId,
+              decision: {
+                decisionVersion: "agent-tool-decision.v1",
+                allowed: false,
+                reason: "tool-not-allowlisted",
+              },
+              outcome: "not-dispatched",
+              result: null,
+              resultReference: null,
+              settlement: "normal",
+            };
+          }
+          const durableSubmission = submission;
+          appendToolEvent("tool.decision", durableSubmission.decision.allowed ? "allowed" : "blocked", durableSubmission);
+          appendToolEvent("tool.outcome", "observed", durableSubmission);
+          const currentPhase = runStore.getRun(runId)?.phase;
+          recordDiagnostics({
+            runId,
+            kind: "tool.outcome",
+            phase: currentPhase ?? "cancelled",
+            occurredAt: clock.now(),
+            transitionReason: null,
+            secretFields: [],
+            tool: {
+              requestId: durableSubmission.requestId,
+              toolName,
+              decision: durableSubmission.decision,
+              outcome: durableSubmission.outcome,
+              resultReference: durableSubmission.resultReference?.value ?? null,
+              settlement: durableSubmission.settlement,
+            },
+          });
+          if (durableSubmission.outcome === "outcome-unknown" && currentPhase === "running") {
+            transition(runId, "run.failed", "failed", "tool-outcome-unknown");
+          }
+          if (currentPhase !== "running" && durableSubmission.result !== null) {
+            return {
+              requestId: durableSubmission.requestId,
+              decision: {
+                decisionVersion: "agent-tool-decision.v1",
+                allowed: false,
+                reason: "run-authority-denied",
+              },
+              outcome: "not-dispatched",
+              result: null,
+              resultReference: null,
+              settlement: durableSubmission.settlement,
+            };
+          }
+          return durableSubmission;
+        } finally {
+          const noPending = endToolRequest(runId);
+          if (noPending
+            && completionRequested.get(runId) === true
+            && runStore.getRun(runId)?.phase === "running") {
+            completionRequested.delete(runId);
+            transition(runId, "run.completed", "completed");
+          }
+        }
+      },
+    };
   }
 
   function recordDiagnostics(event: AgentDiagnosticsEvent) {
@@ -412,6 +687,7 @@ export function createAgentHarnessService({
   ) {
     const record = requireRun(runStore, runId);
     if (record.phase !== "running") return statusFor(record, outputs.get(runId));
+    runContinuations.set(runId, false);
     const runProvider = runProviders.get(runId);
     if (!runProvider) throw new Error("Agent run provider metadata not found.");
     try {
@@ -463,7 +739,14 @@ export function createAgentHarnessService({
   }
 
   function status(runId: string) {
-    return statusFor(requireRun(runStore, runId), outputs.get(runId));
+    const record = requireRun(runStore, runId);
+    const latestTool = runStore.listToolRequests?.(runId).at(-1);
+    return statusFor(record, outputs.get(runId), latestTool ? {
+      outcome: latestTool.outcome,
+      toolName: latestTool.proposal.toolName,
+      resultReference: latestTool.resultReference?.value ?? null,
+      settlement: latestTool.settlement ?? "normal",
+    } : undefined);
   }
 
   function failCancellation(runId: string): never {
@@ -546,6 +829,7 @@ export function createAgentHarnessService({
       runStore.createRun(protectedRecord.value as typeof record);
       outputs.set(runId, "");
       runProviders.set(runId, runProvider);
+      runContinuations.set(runId, true);
       recordLineage({
         runId,
         analysisId: record.analysisId,
@@ -573,9 +857,9 @@ export function createAgentHarnessService({
           runId,
           input: protectedInput.value as AgentStartInput,
           provider,
-          toolGateway,
+          toolGateway: createProviderToolGateway(runId),
           onStream: (output) => {
-            if (!runProviders.has(runId)) return;
+            if (!runProviders.has(runId) || runContinuations.get(runId) !== true) return;
             const protectedStream = secretBoundary.protectRecord(
               "diagnostic-export",
               "agent-stream",
@@ -597,7 +881,13 @@ export function createAgentHarnessService({
             }
             outputs.set(runId, protectedStream.value.output as string);
           },
-          onComplete: () => transition(runId, "run.completed", "completed"),
+          onComplete: () => {
+            if ((pendingToolRequests.get(runId) ?? 0) > 0) {
+              completionRequested.set(runId, true);
+              return;
+            }
+            transition(runId, "run.completed", "completed");
+          },
           onFailure: (error) => transition(
             runId,
             "run.failed",

--- a/src/lib/agent/server/harness.ts
+++ b/src/lib/agent/server/harness.ts
@@ -343,6 +343,13 @@ export function createInMemoryAgentRunStore(): AgentRunStore {
     listToolRequests(runId) {
       return [...toolRequests.values()]
         .filter((record) => record.runId === runId)
+        .sort((left, right) => {
+          if (left.occurredAt < right.occurredAt) return -1;
+          if (left.occurredAt > right.occurredAt) return 1;
+          if (left.requestId < right.requestId) return -1;
+          if (left.requestId > right.requestId) return 1;
+          return 0;
+        })
         .map((record) => ({ ...record }));
     },
   };

--- a/src/lib/agent/server/store.check.ts
+++ b/src/lib/agent/server/store.check.ts
@@ -567,3 +567,73 @@ test("SQLite tool outcomes are monotonic and never regress a terminal result", (
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("SQLite tool outcome upgrades update occurred_at for durable ordering and record replay", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-ordering-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-tool-ordering",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const record = (requestId: string, outcome: AgentToolExecutionRecord["outcome"], occurredAt: string): AgentToolExecutionRecord => ({
+      runId: "run-tool-ordering",
+      requestId,
+      proposal: createReadFinancialOverviewProposal("run-tool-ordering", requestId),
+      decision: {
+        decisionVersion: "agent-tool-decision.v1",
+        allowed: outcome !== "not-dispatched",
+        reason: outcome === "not-dispatched" ? "run-authority-denied" : "allowed",
+      },
+      outcome,
+      result: null,
+      resultReference: null,
+      occurredAt,
+    });
+    const first = record("request-first", "not-dispatched", "2026-08-04T00:00:01.000Z");
+    const second = record("request-second", "not-dispatched", "2026-08-04T00:00:02.000Z");
+    store.recordToolRequest?.(first);
+    store.recordToolRequest?.(second);
+    const upgraded = record("request-first", "outcome-unknown", "2026-08-04T00:00:03.000Z");
+    store.recordToolRequest?.(upgraded);
+    store.close();
+
+    const db = openLedgerDatabase(root);
+    const rows = db.prepare(`
+      SELECT request_id, occurred_at, record_json
+      FROM agent_tool_outcomes
+      WHERE run_id = ?
+      ORDER BY occurred_at, request_id
+    `).all("run-tool-ordering") as Array<{
+      request_id: string;
+      occurred_at: string;
+      record_json: string;
+    }>;
+    assert.deepEqual(rows.map((row) => row.request_id), ["request-second", "request-first"]);
+    assert.deepEqual(
+      rows.map((row) => [row.request_id, row.occurred_at, JSON.parse(row.record_json).record.occurredAt]),
+      [
+        ["request-second", "2026-08-04T00:00:02.000Z", "2026-08-04T00:00:02.000Z"],
+        ["request-first", "2026-08-04T00:00:03.000Z", "2026-08-04T00:00:03.000Z"],
+      ],
+    );
+    db.close();
+
+    const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.deepEqual(
+      reopened.listToolRequests?.("run-tool-ordering").map((item) => [item.requestId, item.outcome, item.occurredAt]),
+      [
+        ["request-second", "not-dispatched", "2026-08-04T00:00:02.000Z"],
+        ["request-first", "outcome-unknown", "2026-08-04T00:00:03.000Z"],
+      ],
+    );
+    reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/server/store.check.ts
+++ b/src/lib/agent/server/store.check.ts
@@ -966,3 +966,179 @@ test("SQLite tool outcome upgrades update occurred_at for durable ordering and r
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("SQLite tool outcome decoding rejects tampered nested proposals without echoing values", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-proposal-integrity-"));
+  const runId = "run-tool-proposal-integrity";
+  const requestId = "request-tool-proposal-integrity";
+  const mutations: Array<[string, (value: Record<string, unknown>) => void]> = [
+    ["tampered-proposal-version-secret", (value) => { value.proposalVersion = "tampered-proposal-version-secret"; }],
+    ["tampered-tool-name-secret", (value) => { value.toolName = "tampered-tool-name-secret"; }],
+    ["tampered-permission-secret", (value) => { value.permission = "tampered-permission-secret"; }],
+    ["tampered-sensitivity-secret", (value) => { value.sensitivity = "tampered-sensitivity-secret"; }],
+    ["tampered-resource-secret", (value) => { value.resource = "tampered-resource-secret"; }],
+    ["tampered-run-authority-secret", (value) => { value.runAuthority = 42; }],
+    ["tampered-run-id-secret", (value) => { value.runId = "tampered-run-id-secret"; }],
+    ["tampered-request-id-secret", (value) => { value.requestId = "tampered-request-id-secret"; }],
+    ["tampered-input-shape-secret", (value) => { value.input = { unexpected: "tampered-input-shape-secret" }; }],
+    ["tampered-extra-shape-secret", (value) => { value.extra = "tampered-extra-shape-secret"; }],
+  ];
+  try {
+    insertRun(root, runId, {
+      runId,
+      analysisId: null,
+      phase: "completed",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: "2026-08-04T00:00:01.000Z",
+      output: "",
+      failureReason: null,
+    });
+    const db = openLedgerDatabase(root);
+    for (const [index, [secret, mutate]] of mutations.entries()) {
+      const rowRequestId = `${requestId}-${index}`;
+      const nested = createReadFinancialOverviewProposal(runId, rowRequestId) as unknown as Record<string, unknown>;
+      mutate(nested);
+      const tamperedRequestId = rowRequestId;
+      db.prepare(`
+        INSERT INTO agent_tool_outcomes (
+          run_id, request_id, outcome, result_reference, result_json,
+          proposal_json, decision_json, occurred_at, updated_at, record_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        runId,
+        tamperedRequestId,
+        "not-dispatched",
+        null,
+        null,
+        JSON.stringify(nested),
+        JSON.stringify({
+          decisionVersion: "agent-tool-decision.v1",
+          allowed: false,
+          reason: "run-authority-denied",
+        }),
+        "2026-08-04T00:00:02.000Z",
+        "2026-08-04T00:00:02.000Z",
+        JSON.stringify({
+          recordVersion: 1,
+          record: {
+            runId,
+            requestId: tamperedRequestId,
+            proposal: nested,
+            decision: {
+              decisionVersion: "agent-tool-decision.v1",
+              allowed: false,
+              reason: "run-authority-denied",
+            },
+            outcome: "not-dispatched",
+            result: null,
+            resultReference: null,
+            occurredAt: "2026-08-04T00:00:02.000Z",
+          },
+        }),
+      );
+      const store = createSqliteAgentRunStore(root, { secretValues: [] });
+      try {
+        assert.ok(store.getToolRequest);
+        assert.ok(store.listToolRequests);
+        assert.throws(
+          () => store.getToolRequest!(runId, tamperedRequestId),
+          (error: unknown) => error instanceof Error
+            && error.message === "Invalid Agent tool outcome record."
+            && !error.message.includes(secret),
+        );
+        assert.throws(
+          () => store.listToolRequests!(runId),
+          /Invalid Agent tool outcome record\./,
+        );
+      } finally {
+        store.close();
+      }
+    }
+    db.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite tool outcome decoding rejects a persisted result with an invalid currency key", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-result-currency-"));
+  const runId = "run-tool-result-currency";
+  const requestId = "request-tool-result-currency";
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId,
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const data: NonNullable<AgentToolExecutionRecord["result"]>["data"] = {
+      aggregateVersion: "financial-overview.aggregate.v1",
+      snapshot: { snapshotId: "snapshot", importedAt: null, snapshotDate: null },
+      totalsByCurrency: { TWD: { assets: 1, liabilities: 0, net: 1 } },
+      overview: {
+        cashAssets: {},
+        foreignAssets: {},
+        investmentAssets: {},
+        unbilledCreditCard: {},
+        loans: {},
+        netAssets: {},
+      },
+      counts: { normalizedTransactions: 0, assetPositions: 0, includedPositions: 0, assetSnapshots: 0 },
+      quality: { status: "pass", issueCount: 0 },
+    };
+    const completedResult: NonNullable<AgentToolExecutionRecord["result"]> = {
+      resultVersion: "agent-tool-result.v1",
+      toolName: "read_financial_overview",
+      data,
+      reference: {
+        referenceVersion: "immutable-result-ref.v1",
+        value: `immutable-result-ref.v1:${hashBytes(stableStringify(data))}`,
+      },
+      secretFields: [],
+    };
+    store.recordToolRequest?.({
+      runId,
+      requestId,
+      proposal: createReadFinancialOverviewProposal(runId, requestId),
+      decision: { decisionVersion: "agent-tool-decision.v1", allowed: true, reason: "allowed" },
+      outcome: "completed",
+      result: completedResult,
+      resultReference: completedResult.reference,
+      occurredAt: "2026-08-04T00:00:01.000Z",
+    });
+    store.close();
+
+    const db = openLedgerDatabase(root);
+    const row = db.prepare(
+      "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? AND request_id = ?",
+    ).get(runId, requestId) as { record_json: string };
+    const persisted = JSON.parse(row.record_json) as {
+      record: AgentToolExecutionRecord;
+    };
+    const persistedResult = persisted.record.result;
+    assert.ok(persistedResult);
+    persistedResult.data.totalsByCurrency = {
+      usd: { assets: 1, liabilities: 0, net: 1 },
+    };
+    persistedResult.reference.value =
+      `immutable-result-ref.v1:${hashBytes(stableStringify(persistedResult.data))}`;
+    persisted.record.resultReference = persistedResult.reference;
+    db.prepare(
+      "UPDATE agent_tool_outcomes SET record_json = ? WHERE run_id = ? AND request_id = ?",
+    ).run(JSON.stringify(persisted), runId, requestId);
+    db.close();
+
+    const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.throws(
+      () => reopened.getToolRequest!(runId, requestId),
+      /Invalid Agent tool outcome record\./,
+    );
+    reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/src/lib/agent/server/store.check.ts
+++ b/src/lib/agent/server/store.check.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { openLedgerDatabase } from "../../../ledger/db/client.ts";
+import { hashBytes, stableStringify } from "../../../ledger/content-hash.ts";
 import { createSqliteAgentRunStore } from "./store.ts";
+import { createReadFinancialOverviewProposal, type AgentToolExecutionRecord } from "./tool-gateway.ts";
 
 type RunRowOverrides = {
   analysisId?: string | null;
@@ -418,6 +420,148 @@ test("SQLite Agent store rejects whitespace-only v1 and present legacy lineage i
       () => store.getLineage("run-blank-legacy-build"),
       /Invalid Agent lineage record/,
     );
+    store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite Agent store persists durable Authorized tool outcomes and replays validated results", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-outcomes-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-tool-store",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const proposal = createReadFinancialOverviewProposal("run-tool-store", "request-store");
+    const resultData: NonNullable<AgentToolExecutionRecord["result"]> = {
+      resultVersion: "agent-tool-result.v1",
+      toolName: "read_financial_overview",
+      data: {
+        aggregateVersion: "financial-overview.aggregate.v1",
+        snapshot: { snapshotId: "snapshot", importedAt: null, snapshotDate: null },
+        totalsByCurrency: {},
+        overview: {
+          cashAssets: {}, foreignAssets: {}, investmentAssets: {},
+          unbilledCreditCard: {}, loans: {}, netAssets: {},
+        },
+        counts: { normalizedTransactions: 0, assetPositions: 0, includedPositions: 0, assetSnapshots: 0 },
+        quality: { status: "pass", issueCount: 0 },
+      },
+      reference: { referenceVersion: "immutable-result-ref.v1", value: "" },
+      secretFields: [],
+    };
+    resultData.reference.value = `immutable-result-ref.v1:${hashBytes(stableStringify(resultData.data))}`;
+    const record: AgentToolExecutionRecord = {
+      runId: "run-tool-store",
+      requestId: "request-store",
+      proposal,
+      decision: {
+        decisionVersion: "agent-tool-decision.v1",
+        allowed: true,
+        reason: "allowed",
+      },
+      outcome: "completed",
+      result: resultData,
+    resultReference: resultData.reference,
+      occurredAt: "2026-08-04T00:00:01.000Z",
+    };
+    store.recordToolRequest?.(record);
+    store.appendLineage({
+      runId: "run-tool-store",
+      analysisId: null,
+      seq: 1,
+      kind: "tool.proposal",
+      status: "proposed",
+      occurredAt: "2026-08-04T00:00:01.000Z",
+      dataClasses: ["financial.derived"],
+      providerIdentity: "test-provider",
+      osBuild: "test",
+      providerAssurance: "unverified-build",
+      transitionReason: null,
+      secretFields: [],
+      tool: { requestId: "request-store", toolName: "read_financial_overview", proposal },
+    });
+    store.close();
+
+    const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.deepEqual(reopened.getToolRequest?.("run-tool-store", "request-store"), record);
+    assert.deepEqual(reopened.listToolRequests?.("run-tool-store"), [record]);
+    assert.equal(reopened.getLineage("run-tool-store")[0]?.tool?.proposal?.proposalVersion, "agent-tool-proposal.v1");
+    reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite tool outcomes are monotonic and never regress a terminal result", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-monotonic-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-tool-monotonic",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const proposal = createReadFinancialOverviewProposal("run-tool-monotonic", "request-monotonic");
+    const data: NonNullable<AgentToolExecutionRecord["result"]>["data"] = {
+      aggregateVersion: "financial-overview.aggregate.v1",
+      snapshot: { snapshotId: "snapshot", importedAt: null, snapshotDate: null },
+      totalsByCurrency: {},
+      overview: {
+        cashAssets: {}, foreignAssets: {}, investmentAssets: {},
+        unbilledCreditCard: {}, loans: {}, netAssets: {},
+      },
+      counts: { normalizedTransactions: 0, assetPositions: 0, includedPositions: 0, assetSnapshots: 0 },
+      quality: { status: "pass", issueCount: 0 },
+    };
+    const completedResult: NonNullable<AgentToolExecutionRecord["result"]> = {
+      resultVersion: "agent-tool-result.v1",
+      toolName: "read_financial_overview",
+      data,
+      reference: {
+        referenceVersion: "immutable-result-ref.v1",
+        value: `immutable-result-ref.v1:${hashBytes(stableStringify(data))}`,
+      },
+      secretFields: [],
+    };
+    const base: AgentToolExecutionRecord = {
+      runId: "run-tool-monotonic",
+      requestId: "request-monotonic",
+      proposal,
+      decision: { decisionVersion: "agent-tool-decision.v1", allowed: true, reason: "allowed" },
+      outcome: "outcome-unknown",
+      result: null,
+      resultReference: null,
+      occurredAt: "2026-08-04T00:00:01.000Z",
+    };
+    store.recordToolRequest?.(base);
+    store.recordToolRequest?.({
+      ...base,
+      outcome: "completed",
+      result: completedResult,
+      resultReference: completedResult.reference,
+      occurredAt: "2026-08-04T00:00:02.000Z",
+    });
+    store.recordToolRequest?.({
+      ...base,
+      decision: { decisionVersion: "agent-tool-decision.v1", allowed: false, reason: "run-authority-denied" },
+      outcome: "not-dispatched",
+      occurredAt: "2026-08-04T00:00:03.000Z",
+    });
+    const persisted = store.getToolRequest?.("run-tool-monotonic", "request-monotonic");
+    assert.equal(persisted?.outcome, "outcome-unknown");
+    assert.equal(persisted?.result, null);
     store.close();
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/src/lib/agent/server/store.check.ts
+++ b/src/lib/agent/server/store.check.ts
@@ -493,8 +493,60 @@ test("SQLite Agent store persists durable Authorized tool outcomes and replays v
     const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
     assert.deepEqual(reopened.getToolRequest?.("run-tool-store", "request-store"), record);
     assert.deepEqual(reopened.listToolRequests?.("run-tool-store"), [record]);
-    assert.equal(reopened.getLineage("run-tool-store")[0]?.tool?.proposal?.proposalVersion, "agent-tool-proposal.v1");
+    assert.deepEqual(reopened.getLineage("run-tool-store")[0]?.tool, {
+      requestId: "request-store",
+      toolName: "read_financial_overview",
+      proposal,
+    });
     reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite Agent lineage rejects a malformed tool payload at the existing invalid-record boundary", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-lineage-invalid-tool-"));
+  try {
+    insertRun(root, "run-lineage-invalid-tool", {
+      recordVersion: 1,
+      record: {
+        runId: "run-lineage-invalid-tool",
+        analysisId: null,
+        phase: "completed",
+        startedAt: "2026-08-03T00:00:00.000Z",
+        finishedAt: "2026-08-03T00:00:01.000Z",
+        output: "",
+        failureReason: null,
+      },
+    });
+    insertLineage(root, "run-lineage-invalid-tool", {
+      recordVersion: 1,
+      record: {
+        runId: "run-lineage-invalid-tool",
+        analysisId: null,
+        seq: 1,
+        kind: "tool.proposal",
+        status: "proposed",
+        occurredAt: "2026-08-03T00:00:01.000Z",
+        dataClasses: ["financial.derived"],
+        providerIdentity: "test-provider",
+        osBuild: "test",
+        providerAssurance: "unverified-build",
+        transitionReason: null,
+        secretFields: [],
+        tool: {
+          requestId: "request-lineage-invalid-tool",
+          toolName: "",
+        },
+      },
+    });
+
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.throws(
+      () => store.getLineage("run-lineage-invalid-tool"),
+      /Invalid Agent lineage record/,
+    );
+    store.close();
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -563,6 +615,121 @@ test("SQLite tool outcomes are monotonic and never regress a terminal result", (
     assert.equal(persisted?.outcome, "outcome-unknown");
     assert.equal(persisted?.result, null);
     store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite tool outcome upgrades synchronize denormalized proposal and decision columns", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-tool-denormalized-update-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-tool-denormalized-update",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const requestId = "request-denormalized-update";
+    const proposalA = {
+      ...createReadFinancialOverviewProposal("run-tool-denormalized-update", requestId),
+      runAuthority: "other-run",
+    };
+    const proposalB = createReadFinancialOverviewProposal("run-tool-denormalized-update", requestId);
+    const decisionA = {
+      decisionVersion: "agent-tool-decision.v1" as const,
+      allowed: false,
+      reason: "run-authority-denied" as const,
+    };
+    const decisionB = {
+      decisionVersion: "agent-tool-decision.v1" as const,
+      allowed: true,
+      reason: "allowed" as const,
+    };
+    const initial: AgentToolExecutionRecord = {
+      runId: "run-tool-denormalized-update",
+      requestId,
+      proposal: proposalA,
+      decision: decisionA,
+      outcome: "not-dispatched",
+      result: null,
+      resultReference: null,
+      occurredAt: "2026-08-04T00:00:01.000Z",
+    };
+    const stable = {
+      ...initial,
+      requestId: "request-stable",
+      proposal: {
+        ...createReadFinancialOverviewProposal("run-tool-denormalized-update", "request-stable"),
+        runAuthority: "other-run",
+      },
+      occurredAt: "2026-08-04T00:00:02.000Z",
+    } satisfies AgentToolExecutionRecord;
+    store.recordToolRequest?.(initial);
+    store.recordToolRequest?.(stable);
+    store.recordToolRequest?.({
+      ...initial,
+      proposal: proposalB,
+      decision: decisionB,
+      outcome: "outcome-unknown",
+      occurredAt: "2026-08-04T00:00:03.000Z",
+    });
+    store.close();
+
+    const db = openLedgerDatabase(root);
+    const rows = db.prepare(`
+      SELECT request_id, outcome, result_json, proposal_json, decision_json, occurred_at, record_json
+      FROM agent_tool_outcomes
+      WHERE run_id = ?
+      ORDER BY occurred_at, request_id
+    `).all("run-tool-denormalized-update") as Array<{
+      request_id: string;
+      outcome: string;
+      result_json: string | null;
+      proposal_json: string;
+      decision_json: string;
+      occurred_at: string;
+      record_json: string;
+    }>;
+    assert.deepEqual(rows.map((row) => row.request_id), ["request-stable", requestId]);
+    const updated = rows.find((row) => row.request_id === requestId);
+    assert.ok(updated);
+    const persisted = JSON.parse(updated.record_json) as {
+      record: AgentToolExecutionRecord;
+    };
+    assert.equal(updated.proposal_json, JSON.stringify(persisted.record.proposal));
+    assert.equal(updated.decision_json, JSON.stringify(persisted.record.decision));
+    assert.deepEqual(persisted.record.proposal, proposalB);
+    assert.deepEqual(persisted.record.decision, decisionB);
+    assert.equal(updated.outcome, "outcome-unknown");
+    assert.equal(updated.result_json, null);
+    assert.equal(updated.occurred_at, "2026-08-04T00:00:03.000Z");
+    db.close();
+
+    const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.deepEqual(reopened.getToolRequest?.("run-tool-denormalized-update", requestId), {
+      ...initial,
+      proposal: proposalB,
+      decision: decisionB,
+      outcome: "outcome-unknown",
+      occurredAt: "2026-08-04T00:00:03.000Z",
+    });
+    assert.deepEqual(
+      reopened.listToolRequests?.("run-tool-denormalized-update").map((item) => [
+        item.requestId,
+        item.outcome,
+        item.occurredAt,
+        item.result,
+      ]),
+      [
+        ["request-stable", "not-dispatched", "2026-08-04T00:00:02.000Z", null],
+        [requestId, "outcome-unknown", "2026-08-04T00:00:03.000Z", null],
+      ],
+    );
+    reopened.close();
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/src/lib/agent/server/store.check.ts
+++ b/src/lib/agent/server/store.check.ts
@@ -552,6 +552,168 @@ test("SQLite Agent lineage rejects a malformed tool payload at the existing inva
   }
 });
 
+test("SQLite Agent lineage requires canonical nested tool decision values in persisted records", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-lineage-decision-canonical-"));
+  const baseRecord = (runId: string, decision: Record<string, unknown>): Record<string, unknown> => ({
+    runId,
+    analysisId: null,
+    seq: 1,
+    kind: "tool.decision",
+    status: "allowed",
+    occurredAt: "2026-08-03T00:00:01.000Z",
+    dataClasses: ["prompt", "model-output"],
+    providerIdentity: "test-provider",
+    osBuild: "test",
+    providerAssurance: "unverified-build",
+    transitionReason: null,
+    secretFields: [],
+    tool: {
+      requestId: `request-${runId}`,
+      toolName: "read_financial_overview",
+      decision,
+      decisionReason: "allowed",
+    },
+  });
+  const rejectPersisted = (
+    runId: string,
+    record: Record<string, unknown>,
+    envelope: boolean,
+    sensitiveValue: string,
+  ) => {
+    insertRun(root, runId, {
+      runId,
+      analysisId: null,
+      phase: "completed",
+      startedAt: "2026-08-03T00:00:00.000Z",
+      finishedAt: "2026-08-03T00:00:01.000Z",
+    });
+    insertLineage(
+      root,
+      runId,
+      envelope ? { recordVersion: 1, record } : record,
+      { kind: "tool.decision", status: "allowed" },
+    );
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    try {
+      let error: Error | undefined;
+      try {
+        store.getLineage(runId);
+      } catch (caught) {
+        error = caught as Error;
+      }
+      assert.ok(error);
+      assert.equal(error.message, "Invalid Agent lineage record.");
+      assert.equal(error.message.includes(sensitiveValue), false);
+    } finally {
+      store.close();
+    }
+  };
+
+  try {
+    rejectPersisted(
+      "run-lineage-bogus-decision-version",
+      baseRecord("run-lineage-bogus-decision-version", {
+        decisionVersion: "tampered-decision-version-secret",
+        allowed: true,
+        reason: "allowed",
+      }),
+      true,
+      "tampered-decision-version-secret",
+    );
+    rejectPersisted(
+      "run-lineage-bogus-decision-reason",
+      baseRecord("run-lineage-bogus-decision-reason", {
+        decisionVersion: "agent-tool-decision.v1",
+        allowed: true,
+        reason: "unbounded-sensitive-decision-reason-secret",
+      }),
+      true,
+      "unbounded-sensitive-decision-reason-secret",
+    );
+    rejectPersisted(
+      "run-lineage-legacy-bogus-decision",
+      baseRecord("run-lineage-legacy-bogus-decision", {
+        decisionVersion: "legacy-tampered-decision-version-secret",
+        allowed: true,
+        reason: "legacy-sensitive-decision-reason-secret",
+      }),
+      false,
+      "legacy-tampered-decision-version-secret",
+    );
+    rejectPersisted(
+      "run-lineage-legacy-bogus-reason",
+      baseRecord("run-lineage-legacy-bogus-reason", {
+        decisionVersion: "agent-tool-decision.v1",
+        allowed: true,
+        reason: "legacy-sensitive-decision-reason-secret",
+      }),
+      false,
+      "legacy-sensitive-decision-reason-secret",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SQLite Agent lineage roundtrips canonical nested tool decisions across reopen", () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-store-lineage-decision-roundtrip-"));
+  try {
+    const record = {
+      runId: "run-lineage-canonical-decision",
+      analysisId: null,
+      seq: 1,
+      kind: "tool.decision" as const,
+      status: "allowed" as const,
+      occurredAt: "2026-08-03T00:00:01.000Z",
+      dataClasses: ["financial.derived"],
+      providerIdentity: "test-provider",
+      osBuild: "test",
+      providerAssurance: "unverified-build" as const,
+      transitionReason: null,
+      secretFields: [] as const,
+      tool: {
+        requestId: "request-lineage-canonical-decision",
+        toolName: "read_financial_overview",
+        decision: {
+          decisionVersion: "agent-tool-decision.v1",
+          allowed: true,
+          reason: "allowed",
+        },
+        decisionReason: "allowed",
+      },
+    };
+    const optionalDecisionRecord = {
+      ...record,
+      seq: 2,
+      status: "blocked" as const,
+      tool: {
+        requestId: "request-lineage-optional-decision",
+        toolName: "read_financial_overview",
+        decisionReason: "permission-denied",
+      },
+    };
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: record.runId,
+      analysisId: null,
+      phase: "completed",
+      startedAt: "2026-08-03T00:00:00.000Z",
+      finishedAt: "2026-08-03T00:00:01.000Z",
+      output: "",
+      failureReason: null,
+    });
+    store.appendLineage(record);
+    store.appendLineage(optionalDecisionRecord);
+    store.close();
+
+    const reopened = createSqliteAgentRunStore(root, { secretValues: [] });
+    assert.deepEqual(reopened.getLineage(record.runId), [record, optionalDecisionRecord]);
+    reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("SQLite tool outcomes are monotonic and never regress a terminal result", () => {
   const root = mkdtempSync(join(tmpdir(), "agent-store-tool-monotonic-"));
   try {

--- a/src/lib/agent/server/store.ts
+++ b/src/lib/agent/server/store.ts
@@ -10,6 +10,17 @@ import {
   type SecretBoundaryDependencies,
   type SecretBoundaryGate,
 } from "./harness.ts";
+import {
+  AGENT_TOOL_DECISION_REASONS,
+  AGENT_TOOL_OUTCOMES,
+  AGENT_TOOL_PROPOSAL_VERSION,
+  AGENT_TOOL_DECISION_VERSION,
+  AGENT_TOOL_RESULT_VERSION,
+  AGENT_TOOL_REFERENCE_VERSION,
+  AGENT_TOOL_SETTLEMENTS,
+  validateAgentToolResult,
+  type AgentToolExecutionRecord,
+} from "./tool-gateway.ts";
 
 type AgentStoreOptions = {
   secretValues?: readonly string[];
@@ -29,10 +40,15 @@ const AGENT_LINEAGE_KINDS: readonly AgentLineageEvent["kind"][] = [
   "run.completed",
   "run.cancelled",
   "run.failed",
+  "tool.proposal",
+  "tool.decision",
+  "tool.outcome",
 ];
 const AGENT_LINEAGE_STATUSES: readonly AgentLineageEvent["status"][] = [
   "allowed",
   "observed",
+  "proposed",
+  "blocked",
 ];
 const AGENT_PROVIDER_ASSURANCES: readonly AgentLineageEvent["providerAssurance"][] = [
   "verified-build",
@@ -42,6 +58,32 @@ const AGENT_TRANSITION_REASONS: readonly Exclude<
   AgentLineageEvent["transitionReason"],
   null
 >[] = [...AGENT_FAILURE_REASONS, "user-cancelled"];
+
+const AGENT_TOOL_OUTCOME_RANK = {
+  "not-dispatched": 1,
+  "outcome-unknown": 2,
+  completed: 3,
+} as const;
+
+/**
+ * A durable unknown outcome is terminal. The one explicitly recorded
+ * cancellation settlement is the only case where a later, already in-flight
+ * completion may be retained; all other writes are monotonic no-ops.
+ */
+function canUpgradeAgentToolOutcome(
+  next: AgentToolExecutionRecord,
+  current: AgentToolExecutionRecord,
+): boolean {
+  if (AGENT_TOOL_OUTCOME_RANK[next.outcome] <= AGENT_TOOL_OUTCOME_RANK[current.outcome]) {
+    return false;
+  }
+  if (current.outcome === "outcome-unknown") {
+    return current.settlement === "cancelled-in-flight"
+      && next.outcome === "completed"
+      && next.settlement === "cancelled-in-flight";
+  }
+  return current.outcome === "not-dispatched";
+}
 
 const RUN_RECORD_KEYS = [
   "runId",
@@ -67,6 +109,7 @@ const LINEAGE_RECORD_KEYS = [
   "transitionReason",
   "secretFields",
 ] as const;
+const LINEAGE_ALLOWED_KEYS = [...LINEAGE_RECORD_KEYS, "tool"] as const;
 const LEGACY_LINEAGE_REQUIRED_KEYS = [
   "runId",
   "analysisId",
@@ -77,7 +120,6 @@ const LEGACY_LINEAGE_REQUIRED_KEYS = [
   "dataClasses",
   "secretFields",
 ] as const;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -196,9 +238,69 @@ function isValidV1LineageState(value: Record<string, unknown>) {
       return value.status === "observed" && value.transitionReason === "user-cancelled";
     case "run.failed":
       return value.status === "observed" && isAgentFailureReason(value.transitionReason);
+    case "tool.proposal":
+      return value.status === "proposed" && value.transitionReason === null;
+    case "tool.decision":
+      return (value.status === "allowed" || value.status === "blocked")
+        && value.transitionReason === null;
+    case "tool.outcome":
+      return value.status === "observed" && value.transitionReason === null;
     default:
       return false;
   }
+}
+
+function decodeToolLineage(value: unknown): AgentLineageEvent["tool"] {
+  if (!isRecord(value)
+    || !hasOnlyExpectedKeys(
+      value,
+      ["requestId", "toolName", "proposal", "decision", "decisionReason", "outcome", "resultReference", "settlement"],
+      ["requestId", "toolName"],
+    )
+    || typeof value.requestId !== "string"
+    || value.requestId.length === 0
+    || typeof value.toolName !== "string"
+    || value.toolName.length === 0
+    || (value.proposal !== undefined && !isRecord(value.proposal))
+    || (value.decision !== undefined
+      && (!isRecord(value.decision)
+        || !hasOnlyExpectedKeys(value.decision, ["decisionVersion", "allowed", "reason"], ["decisionVersion", "allowed", "reason"])
+        || typeof value.decision.decisionVersion !== "string"
+        || typeof value.decision.allowed !== "boolean"
+        || typeof value.decision.reason !== "string"))
+    || (value.decisionReason !== undefined
+      && !AGENT_TOOL_DECISION_REASONS.includes(value.decisionReason as never))
+    || (value.outcome !== undefined
+      && !AGENT_TOOL_OUTCOMES.includes(value.outcome as never))
+    || (value.resultReference !== undefined
+      && value.resultReference !== null
+      && typeof value.resultReference !== "string")
+    || (value.settlement !== undefined
+      && !AGENT_TOOL_SETTLEMENTS.includes(value.settlement as never))) {
+    throw new Error("Invalid Agent lineage record.");
+  }
+  return {
+    requestId: value.requestId,
+    toolName: value.toolName,
+    ...(value.proposal ? { proposal: value.proposal } : {}),
+    ...(value.decision ? {
+      decision: {
+        decisionVersion: value.decision.decisionVersion as string,
+        allowed: value.decision.allowed as boolean,
+        reason: value.decision.reason as string,
+      },
+    } : {}),
+    ...(typeof value.decisionReason === "string" ? { decisionReason: value.decisionReason } : {}),
+    ...(typeof value.outcome === "string"
+      ? { outcome: value.outcome as "not-dispatched" | "completed" | "outcome-unknown" }
+      : {}),
+    ...(Object.hasOwn(value, "resultReference")
+      ? { resultReference: value.resultReference as string | null }
+      : {}),
+    ...(typeof value.settlement === "string"
+      ? { settlement: value.settlement as "normal" | "cancelled-in-flight" }
+      : {}),
+  };
 }
 
 function decodeLineageRecord(
@@ -208,7 +310,7 @@ function decodeLineageRecord(
   if (!isRecord(value)
     || !hasOnlyExpectedKeys(
       value,
-      LINEAGE_RECORD_KEYS,
+      LINEAGE_ALLOWED_KEYS,
       legacy ? LEGACY_LINEAGE_REQUIRED_KEYS : LINEAGE_RECORD_KEYS,
     )
     || typeof value.runId !== "string"
@@ -245,6 +347,8 @@ function decodeLineageRecord(
       ))
     || !Array.isArray(value.secretFields)
     || value.secretFields.length !== 0
+    || (Object.hasOwn(value, "tool") && !decodeToolLineage(value.tool))
+    || (typeof value.kind === "string" && value.kind.startsWith("tool.") && !Object.hasOwn(value, "tool"))
     || (!legacy && !isValidV1LineageState(value))) {
     throw new Error("Invalid Agent lineage record.");
   }
@@ -267,6 +371,7 @@ function decodeLineageRecord(
       ? null
       : value.transitionReason as AgentLineageEvent["transitionReason"],
     secretFields: [],
+    ...(Object.hasOwn(value, "tool") ? { tool: decodeToolLineage(value.tool) } : {}),
   };
 }
 
@@ -299,7 +404,7 @@ function encodeRecord(
 
 function protectRecord<T extends Record<string, unknown>>(
   gate: SecretBoundaryGate,
-  schema: "agent-run" | "agent-lineage",
+  schema: "agent-run" | "agent-lineage" | "agent-tool-outcome",
   record: T,
 ) {
   const protectedRecord = gate.protectRecord("sqlite-persistence", schema, record);
@@ -372,6 +477,56 @@ export function createSqliteAgentRunStore(
       | undefined;
     if (!row) throw new Error("Agent run not found.");
     return row;
+  }
+
+  function decodeToolRecord(raw: unknown): AgentToolExecutionRecord {
+    const value = parseJsonRecord(raw, "Invalid Agent tool outcome record.");
+    if (value.recordVersion !== 1
+      || !hasOnlyExpectedKeys(value, ["recordVersion", "record"], ["recordVersion", "record"])) {
+      throw new Error("Unsupported Agent tool outcome record version.");
+    }
+    const record = value.record;
+    if (!isRecord(record)
+      || !hasOnlyExpectedKeys(
+        record,
+        ["runId", "requestId", "proposal", "decision", "outcome", "result", "resultReference", "occurredAt", "settlement"],
+        ["runId", "requestId", "proposal", "decision", "outcome", "result", "resultReference", "occurredAt"],
+      )
+      || typeof record.runId !== "string"
+      || typeof record.requestId !== "string"
+      || typeof record.occurredAt !== "string"
+      || !AGENT_TOOL_OUTCOMES.includes(record.outcome as never)
+      || !isRecord(record.proposal)
+      || record.proposal.proposalVersion !== AGENT_TOOL_PROPOSAL_VERSION
+      || !isRecord(record.decision)
+      || record.decision.decisionVersion !== AGENT_TOOL_DECISION_VERSION
+      || typeof record.decision.allowed !== "boolean"
+      || !AGENT_TOOL_DECISION_REASONS.includes(record.decision.reason as never)
+      || (record.settlement !== undefined && !AGENT_TOOL_SETTLEMENTS.includes(record.settlement as never))
+      || (record.resultReference !== null && !isRecord(record.resultReference))
+      || (record.result !== null && !isRecord(record.result))) {
+      throw new Error("Invalid Agent tool outcome record.");
+    }
+    if (record.resultReference !== null
+      && (record.resultReference.referenceVersion !== AGENT_TOOL_REFERENCE_VERSION
+        || typeof record.resultReference.value !== "string")) {
+      throw new Error("Invalid Agent tool outcome record.");
+    }
+    if (record.result !== null && (record.result.resultVersion !== AGENT_TOOL_RESULT_VERSION
+      || !validateAgentToolResult(record.result))) {
+      throw new Error("Invalid Agent tool outcome record.");
+    }
+    if ((!record.decision.allowed && record.outcome !== "not-dispatched")
+      || (record.settlement !== undefined && record.outcome === "not-dispatched")
+      || (record.outcome === "completed" && (record.result === null || record.resultReference === null))
+      || (record.outcome !== "completed" && (record.result !== null || record.resultReference !== null))
+      || (record.result !== null && record.resultReference?.value !== record.result.reference.value)) {
+      throw new Error("Invalid Agent tool outcome record.");
+    }
+    return {
+      ...record,
+      ...(typeof record.settlement === "string" ? { settlement: record.settlement } : {}),
+    } as unknown as AgentToolExecutionRecord;
   }
 
   return {
@@ -450,6 +605,65 @@ export function createSqliteAgentRunStore(
         ORDER BY seq ASC
       `).all(runId) as Record<string, unknown>[];
       return rows.map(rowToLineage);
+    },
+    recordToolRequest(record) {
+      const protectedRecord = protectRecord(
+        gate,
+        "agent-tool-outcome",
+        record as unknown as Record<string, unknown>,
+      ) as unknown as AgentToolExecutionRecord;
+      const encoded = JSON.stringify({ recordVersion: 1, record: protectedRecord });
+      const existing = db.prepare(
+        "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? AND request_id = ?",
+      ).get(protectedRecord.runId, protectedRecord.requestId) as { record_json: string } | undefined;
+      if (existing) {
+        const current = decodeToolRecord(existing.record_json);
+        if (canUpgradeAgentToolOutcome(protectedRecord, current)) {
+          db.prepare(`
+            UPDATE agent_tool_outcomes
+            SET outcome = ?, result_reference = ?, result_json = ?, record_json = ?, updated_at = ?
+            WHERE run_id = ? AND request_id = ?
+          `).run(
+            protectedRecord.outcome,
+            protectedRecord.resultReference?.value ?? null,
+            protectedRecord.result ? JSON.stringify(protectedRecord.result) : null,
+            encoded,
+            protectedRecord.occurredAt,
+            protectedRecord.runId,
+            protectedRecord.requestId,
+          );
+        }
+        return;
+      }
+      db.prepare(`
+        INSERT INTO agent_tool_outcomes (
+          run_id, request_id, outcome, result_reference, result_json,
+          proposal_json, decision_json, occurred_at, updated_at, record_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        protectedRecord.runId,
+        protectedRecord.requestId,
+        protectedRecord.outcome,
+        protectedRecord.resultReference?.value ?? null,
+        protectedRecord.result ? JSON.stringify(protectedRecord.result) : null,
+        JSON.stringify(protectedRecord.proposal),
+        JSON.stringify(protectedRecord.decision),
+        protectedRecord.occurredAt,
+        protectedRecord.occurredAt,
+        encoded,
+      );
+    },
+    getToolRequest(runId, requestId) {
+      const row = db.prepare(
+        "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? AND request_id = ?",
+      ).get(runId, requestId) as { record_json: string } | undefined;
+      return row ? decodeToolRecord(row.record_json) : null;
+    },
+    listToolRequests(runId) {
+      const rows = db.prepare(
+        "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? ORDER BY occurred_at, request_id",
+      ).all(runId) as Array<{ record_json: string }>;
+      return rows.map((row) => decodeToolRecord(row.record_json));
     },
     close() {
       db.close();

--- a/src/lib/agent/server/store.ts
+++ b/src/lib/agent/server/store.ts
@@ -265,9 +265,9 @@ function decodeToolLineage(value: unknown): AgentLineageEvent["tool"] {
     || (value.decision !== undefined
       && (!isRecord(value.decision)
         || !hasOnlyExpectedKeys(value.decision, ["decisionVersion", "allowed", "reason"], ["decisionVersion", "allowed", "reason"])
-        || typeof value.decision.decisionVersion !== "string"
+        || value.decision.decisionVersion !== AGENT_TOOL_DECISION_VERSION
         || typeof value.decision.allowed !== "boolean"
-        || typeof value.decision.reason !== "string"))
+        || !AGENT_TOOL_DECISION_REASONS.includes(value.decision.reason as never)))
     || (value.decisionReason !== undefined
       && !AGENT_TOOL_DECISION_REASONS.includes(value.decisionReason as never))
     || (value.outcome !== undefined

--- a/src/lib/agent/server/store.ts
+++ b/src/lib/agent/server/store.ts
@@ -621,12 +621,13 @@ export function createSqliteAgentRunStore(
         if (canUpgradeAgentToolOutcome(protectedRecord, current)) {
           db.prepare(`
             UPDATE agent_tool_outcomes
-            SET outcome = ?, result_reference = ?, result_json = ?, record_json = ?, updated_at = ?
+            SET outcome = ?, result_reference = ?, result_json = ?, occurred_at = ?, record_json = ?, updated_at = ?
             WHERE run_id = ? AND request_id = ?
           `).run(
             protectedRecord.outcome,
             protectedRecord.resultReference?.value ?? null,
             protectedRecord.result ? JSON.stringify(protectedRecord.result) : null,
+            protectedRecord.occurredAt,
             encoded,
             protectedRecord.occurredAt,
             protectedRecord.runId,

--- a/src/lib/agent/server/store.ts
+++ b/src/lib/agent/server/store.ts
@@ -307,6 +307,8 @@ function decodeLineageRecord(
   value: unknown,
   legacy: boolean,
 ): AgentLineageEvent {
+  const hasTool = isRecord(value) && Object.hasOwn(value, "tool");
+  const decodedTool = hasTool ? decodeToolLineage(value.tool) : undefined;
   if (!isRecord(value)
     || !hasOnlyExpectedKeys(
       value,
@@ -347,7 +349,7 @@ function decodeLineageRecord(
       ))
     || !Array.isArray(value.secretFields)
     || value.secretFields.length !== 0
-    || (Object.hasOwn(value, "tool") && !decodeToolLineage(value.tool))
+    || (hasTool && !decodedTool)
     || (typeof value.kind === "string" && value.kind.startsWith("tool.") && !Object.hasOwn(value, "tool"))
     || (!legacy && !isValidV1LineageState(value))) {
     throw new Error("Invalid Agent lineage record.");
@@ -371,7 +373,7 @@ function decodeLineageRecord(
       ? null
       : value.transitionReason as AgentLineageEvent["transitionReason"],
     secretFields: [],
-    ...(Object.hasOwn(value, "tool") ? { tool: decodeToolLineage(value.tool) } : {}),
+    ...(decodedTool ? { tool: decodedTool } : {}),
   };
 }
 
@@ -621,12 +623,15 @@ export function createSqliteAgentRunStore(
         if (canUpgradeAgentToolOutcome(protectedRecord, current)) {
           db.prepare(`
             UPDATE agent_tool_outcomes
-            SET outcome = ?, result_reference = ?, result_json = ?, occurred_at = ?, record_json = ?, updated_at = ?
+            SET outcome = ?, result_reference = ?, result_json = ?, proposal_json = ?, decision_json = ?,
+              occurred_at = ?, record_json = ?, updated_at = ?
             WHERE run_id = ? AND request_id = ?
           `).run(
             protectedRecord.outcome,
             protectedRecord.resultReference?.value ?? null,
             protectedRecord.result ? JSON.stringify(protectedRecord.result) : null,
+            JSON.stringify(protectedRecord.proposal),
+            JSON.stringify(protectedRecord.decision),
             protectedRecord.occurredAt,
             encoded,
             protectedRecord.occurredAt,

--- a/src/lib/agent/server/store.ts
+++ b/src/lib/agent/server/store.ts
@@ -13,11 +13,11 @@ import {
 import {
   AGENT_TOOL_DECISION_REASONS,
   AGENT_TOOL_OUTCOMES,
-  AGENT_TOOL_PROPOSAL_VERSION,
   AGENT_TOOL_DECISION_VERSION,
   AGENT_TOOL_RESULT_VERSION,
   AGENT_TOOL_REFERENCE_VERSION,
   AGENT_TOOL_SETTLEMENTS,
+  validateAgentToolProposal,
   validateAgentToolResult,
   type AgentToolExecutionRecord,
 } from "./tool-gateway.ts";
@@ -488,6 +488,9 @@ export function createSqliteAgentRunStore(
       throw new Error("Unsupported Agent tool outcome record version.");
     }
     const record = value.record;
+    const validatedProposal = isRecord(record)
+      ? validateAgentToolProposal(record.proposal).value
+      : null;
     if (!isRecord(record)
       || !hasOnlyExpectedKeys(
         record,
@@ -498,8 +501,9 @@ export function createSqliteAgentRunStore(
       || typeof record.requestId !== "string"
       || typeof record.occurredAt !== "string"
       || !AGENT_TOOL_OUTCOMES.includes(record.outcome as never)
-      || !isRecord(record.proposal)
-      || record.proposal.proposalVersion !== AGENT_TOOL_PROPOSAL_VERSION
+      || !validatedProposal
+      || validatedProposal.runId !== record.runId
+      || validatedProposal.requestId !== record.requestId
       || !isRecord(record.decision)
       || record.decision.decisionVersion !== AGENT_TOOL_DECISION_VERSION
       || typeof record.decision.allowed !== "boolean"
@@ -661,15 +665,34 @@ export function createSqliteAgentRunStore(
     },
     getToolRequest(runId, requestId) {
       const row = db.prepare(
-        "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? AND request_id = ?",
-      ).get(runId, requestId) as { record_json: string } | undefined;
-      return row ? decodeToolRecord(row.record_json) : null;
+        "SELECT run_id, request_id, record_json FROM agent_tool_outcomes WHERE run_id = ? AND request_id = ?",
+      ).get(runId, requestId) as {
+        run_id: string;
+        request_id: string;
+        record_json: string;
+      } | undefined;
+      if (!row) return null;
+      const record = decodeToolRecord(row.record_json);
+      if (record.runId !== row.run_id || record.requestId !== row.request_id) {
+        throw new Error("Invalid Agent tool outcome record.");
+      }
+      return record;
     },
     listToolRequests(runId) {
       const rows = db.prepare(
-        "SELECT record_json FROM agent_tool_outcomes WHERE run_id = ? ORDER BY occurred_at, request_id",
-      ).all(runId) as Array<{ record_json: string }>;
-      return rows.map((row) => decodeToolRecord(row.record_json));
+        "SELECT run_id, request_id, record_json FROM agent_tool_outcomes WHERE run_id = ? ORDER BY occurred_at, request_id",
+      ).all(runId) as Array<{
+        run_id: string;
+        request_id: string;
+        record_json: string;
+      }>;
+      return rows.map((row) => {
+        const record = decodeToolRecord(row.record_json);
+        if (record.runId !== row.run_id || record.requestId !== row.request_id) {
+          throw new Error("Invalid Agent tool outcome record.");
+        }
+        return record;
+      });
     },
     close() {
       db.close();

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -223,6 +223,80 @@ test("completed replay requires the same canonical proposal and an active run", 
   assert.equal(calls, 1);
 });
 
+test("a mismatched duplicate never replaces a completed durable record or its canonical replay", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-monotonicity");
+  const completed = await gateway.submit(proposal);
+  assert.equal(completed.outcome, "completed");
+  const durableBefore = store.getToolRequest?.("run-tool-1", "request-monotonicity");
+  assert.equal(durableBefore?.outcome, "completed");
+  assert.deepEqual(durableBefore?.result, completed.result);
+
+  const changed = await gateway.submit({ ...proposal, runAuthority: "run-tool-other" });
+  assert.equal(changed.outcome, "not-dispatched");
+  assert.equal(changed.result, null);
+  assert.equal(changed.resultReference, null);
+  assert.equal(calls, 1);
+  assert.equal(store.getToolRequest?.("run-tool-1", "request-monotonicity")?.outcome, "completed");
+
+  const malformed = await gateway.submit({ ...proposal, input: { unexpected: true } });
+  assert.equal(malformed.outcome, "not-dispatched");
+  assert.equal(malformed.result, null);
+  assert.equal(malformed.resultReference, null);
+  assert.equal(calls, 1);
+  assert.equal(store.getToolRequest?.("run-tool-1", "request-monotonicity")?.outcome, "completed");
+
+  const replay = await gateway.submit(proposal);
+  assert.deepEqual(replay, completed);
+  assert.equal(replay.outcome, "completed");
+  assert.deepEqual(store.getToolRequest?.("run-tool-1", "request-monotonicity")?.result, completed.result);
+  assert.equal(calls, 1);
+});
+
+test("a fresh durable terminal record supersedes a stale nonterminal cache across gateways", async () => {
+  const store = runningStore();
+  let gatewayACalls = 0;
+  let gatewayBCalls = 0;
+  const gatewayA = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      gatewayACalls += 1;
+      return result();
+    },
+  });
+  const gatewayB = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      gatewayBCalls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-shared-store");
+
+  const denied = await gatewayA.submit({ ...proposal, runAuthority: "wrong-authority" });
+  assert.equal(denied.outcome, "not-dispatched");
+  assert.equal(store.getToolRequest?.("run-tool-1", "request-shared-store")?.outcome, "not-dispatched");
+
+  const completed = await gatewayB.submit(proposal);
+  assert.equal(completed.outcome, "completed");
+  assert.equal(gatewayBCalls, 1);
+  assert.equal(store.getToolRequest?.("run-tool-1", "request-shared-store")?.outcome, "completed");
+
+  const replay = await gatewayA.submit(proposal);
+  assert.deepEqual(replay, completed);
+  assert.equal(replay.outcome, "completed");
+  assert.equal(gatewayACalls, 0);
+  assert.equal(gatewayBCalls, 1);
+});
+
 test("a not-dispatched request is revalidated and dispatches after authority becomes valid", async () => {
   const store = runningStore();
   let calls = 0;

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -72,6 +72,52 @@ function result(): AgentToolResult {
   };
 }
 
+function alternatingAccessorResult(): AgentToolResult {
+  const candidate = result();
+  const variantA = structuredClone(candidate.data);
+  const variantB = structuredClone(candidate.data);
+  variantA.totalsByCurrency.TWD!.assets = 101;
+  variantA.totalsByCurrency.TWD!.net = 81;
+  variantB.totalsByCurrency.TWD!.assets = 202;
+  variantB.totalsByCurrency.TWD!.net = 182;
+  let reads = 0;
+  Object.defineProperty(candidate.data, "totalsByCurrency", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      reads += 1;
+      return reads % 2 === 0 ? variantB.totalsByCurrency : variantA.totalsByCurrency;
+    },
+  });
+  candidate.reference.value = `immutable-result-ref.v1:${hashBytes(stableStringify(variantB))}`;
+  return candidate;
+}
+
+function symbolBearingResult(): AgentToolResult {
+  const candidate = result();
+  Object.defineProperty(candidate.data, Symbol("hostile-result-key"), {
+    configurable: true,
+    enumerable: true,
+    value: "must-not-be-persisted",
+  });
+  return candidate;
+}
+
+function throwingProxyResult(): AgentToolResult {
+  const candidate = result();
+  return new Proxy(candidate, {
+    ownKeys() {
+      throw new Error("hostile-own-keys");
+    },
+  });
+}
+
+function nonPlainResult(): AgentToolResult {
+  const candidate = result();
+  candidate.data = Object.assign(new Date("2026-08-04T00:00:00.000Z"), candidate.data) as unknown as AgentToolResult["data"];
+  return candidate;
+}
+
 test("proposal validation is strict and rejects unknown, malformed, and credential-bearing requests", () => {
   const valid = createReadFinancialOverviewProposal("run-tool-1", "request-1");
   assert.equal(validateAgentToolProposal(valid).reason, null);
@@ -411,6 +457,97 @@ test("concurrent same-identity submissions dispatch the adapter once", async () 
   const [one, two] = await Promise.all([first, second]);
   assert.deepEqual(one, two);
   assert.equal(one.outcome, "completed");
+});
+
+test("accessor-bearing adapter results fail closed in memory and replay a stable unknown outcome", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return alternatingAccessorResult();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-accessor-memory");
+  const first = await gateway.submit(proposal);
+  assert.equal(first.outcome, "outcome-unknown");
+  assert.equal(first.result, null);
+  assert.equal(first.resultReference, null);
+  assert.equal(calls, 1);
+  const replay = await gateway.submit(proposal);
+  assert.deepEqual(replay, first);
+  assert.equal(calls, 1);
+  assert.equal(store.getToolRequest?.("run-tool-1", proposal.requestId)?.outcome, "outcome-unknown");
+  assert.equal(store.getToolRequest?.("run-tool-1", proposal.requestId)?.result, null);
+});
+
+test("accessor-bearing adapter results fail closed in SQLite without an invalid completed row", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-tool-accessor-sqlite-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-accessor-sqlite",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    let calls = 0;
+    const gateway = createFinancialOverviewToolGateway({
+      ledgerDir: root,
+      runStore: store,
+      adapter: async () => {
+        calls += 1;
+        return alternatingAccessorResult();
+      },
+    });
+    const proposal = createReadFinancialOverviewProposal("run-accessor-sqlite", "request-accessor-sqlite");
+    const first = await gateway.submit(proposal);
+    assert.equal(first.outcome, "outcome-unknown");
+    assert.equal(first.result, null);
+    assert.equal(first.resultReference, null);
+    assert.equal(calls, 1);
+    const replay = await gateway.submit(proposal);
+    assert.deepEqual(replay, first);
+    assert.equal(calls, 1);
+    const durable = store.getToolRequest?.("run-accessor-sqlite", proposal.requestId);
+    assert.equal(durable?.outcome, "outcome-unknown");
+    assert.equal(durable?.result, null);
+    assert.equal(durable?.resultReference, null);
+    store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("symbol-bearing, proxy, and non-plain adapter results fail closed and replay without retry", async () => {
+  const variants: Array<[string, () => AgentToolResult]> = [
+    ["symbol", symbolBearingResult],
+    ["proxy", throwingProxyResult],
+    ["non-plain", nonPlainResult],
+  ];
+  for (const [name, hostileResult] of variants) {
+    const store = runningStore();
+    let calls = 0;
+    const gateway = createFinancialOverviewToolGateway({
+      runStore: store,
+      adapter: async () => {
+        calls += 1;
+        return hostileResult();
+      },
+    });
+    const proposal = createReadFinancialOverviewProposal("run-tool-1", `request-hostile-${name}`);
+    const first = await gateway.submit(proposal);
+    assert.equal(first.outcome, "outcome-unknown", name);
+    assert.equal(first.result, null, name);
+    assert.equal(first.resultReference, null, name);
+    const replay = await gateway.submit(proposal);
+    assert.deepEqual(replay, first, name);
+    assert.equal(calls, 1, name);
+  }
 });
 
 test("direct malformed unknown-run proposals fail closed without an invalid foreign-key insert", async () => {

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -140,6 +140,315 @@ test("proposal validation is strict and rejects unknown, malformed, and credenti
   );
 });
 
+test("direct proposal validation snapshots hostile accessors and prototypes without reads", () => {
+  const accessorProposal = createReadFinancialOverviewProposal("run-tool-1", "request-direct-accessor");
+  let accessorReads = 0;
+  Object.defineProperty(accessorProposal, "requestId", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      accessorReads += 1;
+      return "request-direct-accessor";
+    },
+  });
+  const accessorValidation = validateAgentToolProposal(accessorProposal);
+  assert.equal(accessorValidation.value, null);
+  assert.notEqual(accessorValidation.reason, null);
+  assert.equal(accessorReads, 0);
+
+  const proxyTarget = createReadFinancialOverviewProposal("run-tool-1", "request-direct-proxy");
+  let proxyReads = 0;
+  const proxyProposal = new Proxy(proxyTarget, {
+    get(target, key, receiver) {
+      proxyReads += 1;
+      return Reflect.get(target, key, receiver);
+    },
+  });
+  const proxyValidation = validateAgentToolProposal(proxyProposal);
+  assert.ok(proxyValidation.value);
+  assert.equal(proxyValidation.reason, null);
+  assert.notEqual(proxyValidation.value, proxyProposal);
+  assert.equal(Object.getPrototypeOf(proxyValidation.value), null);
+  assert.equal(proxyReads, 0);
+
+  const lyingProxy = new Proxy(proxyTarget, {
+    get(target, key, receiver) {
+      proxyReads += 1;
+      return Reflect.get(target, key, receiver);
+    },
+    getOwnPropertyDescriptor() {
+      throw new Error("lying-descriptor");
+    },
+  });
+  const lyingValidation = validateAgentToolProposal(lyingProxy);
+  assert.equal(lyingValidation.value, null);
+  assert.notEqual(lyingValidation.reason, null);
+  assert.equal(proxyReads, 0);
+
+  let inheritedReads = 0;
+  const customPrototype = Object.create({
+    get inheritedSecret() {
+      inheritedReads += 1;
+      return "inherited-secret-canary";
+    },
+  });
+  const customProposal = Object.assign(
+    customPrototype,
+    createReadFinancialOverviewProposal("run-tool-1", "request-direct-custom"),
+  );
+  const customValidation = validateAgentToolProposal(customProposal);
+  assert.equal(customValidation.value, null);
+  assert.notEqual(customValidation.reason, null);
+  assert.equal(inheritedReads, 0);
+
+  const nestedPrototype = Object.create({
+    get password() {
+      inheritedReads += 1;
+      return "nested-inherited-secret-canary";
+    },
+  });
+  const nestedProposal = createReadFinancialOverviewProposal("run-tool-1", "request-direct-nested");
+  nestedProposal.input = nestedPrototype;
+  const nestedValidation = validateAgentToolProposal(nestedProposal);
+  assert.equal(nestedValidation.value, null);
+  assert.notEqual(nestedValidation.reason, null);
+  assert.equal(inheritedReads, 0);
+});
+
+test("proposal own-key validation rejects hidden credential and symbol fields before dispatch", async () => {
+  const store = runningStore();
+  const canary = "hidden-password-canary";
+  const hiddenSymbol = Symbol("hidden-symbol-key");
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-hidden-fields");
+  let hiddenGetterReads = 0;
+  Object.defineProperty(proposal, "password", {
+    configurable: true,
+    enumerable: false,
+    value: canary,
+  });
+  Object.defineProperty(proposal, "hiddenAccessor", {
+    configurable: true,
+    enumerable: false,
+    get() {
+      hiddenGetterReads += 1;
+      throw new Error("hidden-accessor-must-not-be-read");
+    },
+  });
+  Object.defineProperty(proposal, hiddenSymbol, {
+    configurable: true,
+    enumerable: false,
+    value: "hidden-symbol-value",
+  });
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [canary],
+    adapter: async ({ proposal: dispatched }) => {
+      calls += 1;
+      assert.equal(Object.hasOwn(dispatched, "password"), true);
+      assert.equal((dispatched as Record<string, unknown>).password, canary);
+      return result();
+    },
+  });
+
+  const submission = await gateway.submit(proposal);
+  assert.equal(calls, 0);
+  assert.equal(hiddenGetterReads, 0);
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.ok(["malformed-proposal", "credential-boundary"].includes(submission.decision.reason));
+  assert.equal(submission.result, null);
+  assert.equal(submission.resultReference, null);
+  assert.equal(JSON.stringify(submission).includes(canary), false);
+  assert.equal(JSON.stringify(submission).includes("hidden-symbol-value"), false);
+  assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(canary), false);
+  assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes("hidden-symbol-value"), false);
+  assert.equal(Object.getOwnPropertySymbols(submission).length, 0);
+
+  const replay = await gateway.submit(proposal);
+  assert.deepEqual(replay, submission);
+  assert.equal(calls, 0);
+});
+
+test("proposal preflight rejects accessors before authority validation or dispatch", async () => {
+  const store = runningStore();
+  const target = createReadFinancialOverviewProposal("run-tool-1", "request-accessor-proposal");
+  let getterReads = 0;
+  let proxyReads = 0;
+  let dispatched = false;
+  Object.defineProperty(target, "requestId", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      getterReads += 1;
+      return "request-accessor-proposal";
+    },
+  });
+  Object.defineProperty(target, "runAuthority", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      getterReads += 1;
+      return dispatched ? "evil-run" : target.runId;
+    },
+  });
+  const proposal = new Proxy(target, {
+    get(current, key, receiver) {
+      proxyReads += 1;
+      return Reflect.get(current, key, receiver);
+    },
+  });
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async ({ proposal: received }) => {
+      dispatched = true;
+      calls += 1;
+      assert.equal(received.runAuthority, "evil-run");
+      return result();
+    },
+  });
+
+  const submission = await gateway.submit(proposal);
+  assert.equal(calls, 0);
+  assert.equal(getterReads, 0);
+  assert.equal(proxyReads, 0);
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.decision.reason, "malformed-proposal");
+  assert.equal(submission.result, null);
+  assert.equal(submission.resultReference, null);
+});
+
+test("proposal preflight rejects inherited credential material before dispatch", async () => {
+  const store = runningStore();
+  const canary = "inherited-password-canary";
+  const nestedCanary = "nested-inherited-password-canary";
+  const proposal = Object.assign(
+    Object.create({ password: canary }),
+    createReadFinancialOverviewProposal("run-tool-1", "request-inherited-password"),
+  );
+  const nestedProposal = createReadFinancialOverviewProposal(
+    "run-tool-1",
+    "request-nested-inherited-password",
+  );
+  nestedProposal.input = Object.create({ password: nestedCanary });
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [canary, nestedCanary],
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const submission = await gateway.submit(proposal);
+  assert.equal(calls, 0);
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.decision.reason, "malformed-proposal");
+  assert.equal(JSON.stringify(submission).includes(canary), false);
+
+  const nestedSubmission = await gateway.submit(nestedProposal);
+  assert.equal(calls, 0);
+  assert.equal(nestedSubmission.outcome, "not-dispatched");
+  assert.equal(nestedSubmission.decision.reason, "malformed-proposal");
+  assert.equal(JSON.stringify(nestedSubmission).includes(nestedCanary), false);
+});
+
+test("proposal preflight never passes a proxy or hidden configurable field to the adapter", async () => {
+  const store = runningStore();
+  const canary = "proxy-hidden-password-canary";
+  const target = createReadFinancialOverviewProposal("run-tool-1", "request-proxy-hidden-password");
+  Object.defineProperty(target, "password", {
+    configurable: true,
+    enumerable: false,
+    value: canary,
+  });
+  const proposal = new Proxy(target, {
+    ownKeys(current) {
+      return Reflect.ownKeys(current).filter((key) => key !== "password");
+    },
+  });
+  let received: Record<string, unknown> | null = null;
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [canary],
+    adapter: async ({ proposal: dispatched }) => {
+      calls += 1;
+      received = dispatched as unknown as Record<string, unknown>;
+      return result();
+    },
+  });
+  const submission = await gateway.submit(proposal);
+  assert.equal(submission.outcome, "completed");
+  assert.equal(calls, 1);
+  assert.notEqual(received, proposal);
+  assert.ok(received);
+  assert.equal(Object.getPrototypeOf(received), null);
+  assert.equal(Object.hasOwn(received, "password"), false);
+  assert.equal(JSON.stringify(submission).includes(canary), false);
+});
+
+test("own-key validation handles revoked proxies and non-enumerable expected fields without throwing", async () => {
+  const canonical = createReadFinancialOverviewProposal("run-tool-1", "request-own-key-controls");
+  const throwingProxy = new Proxy(canonical, {
+    ownKeys() {
+      throw new Error("hostile-own-keys");
+    },
+  });
+  const revocable = Proxy.revocable(canonical, {});
+  revocable.revoke();
+  for (const hostile of [throwingProxy, revocable.proxy]) {
+    let validation: ReturnType<typeof validateAgentToolProposal> | undefined;
+    assert.doesNotThrow(() => {
+      validation = validateAgentToolProposal(hostile);
+    });
+    assert.equal(validation?.reason, "malformed-proposal");
+  }
+
+  const nonEnumerableProposal = createReadFinancialOverviewProposal(
+    "run-tool-1",
+    "request-own-key-non-enumerable",
+  );
+  Object.defineProperty(nonEnumerableProposal, "requestId", {
+    configurable: true,
+    enumerable: false,
+    value: nonEnumerableProposal.requestId,
+  });
+  assert.doesNotThrow(() => validateAgentToolProposal(nonEnumerableProposal));
+  assert.equal(validateAgentToolProposal(nonEnumerableProposal).reason, null);
+
+  const nonEnumerableResult = result();
+  Object.defineProperty(nonEnumerableResult.data, "aggregateVersion", {
+    configurable: true,
+    enumerable: false,
+    value: nonEnumerableResult.data.aggregateVersion,
+  });
+  nonEnumerableResult.reference.value = `immutable-result-ref.v1:${hashBytes(
+    stableStringify(nonEnumerableResult.data),
+  )}`;
+  assert.doesNotThrow(() => validateAgentToolResult(nonEnumerableResult));
+  assert.equal(validateAgentToolResult(nonEnumerableResult), true);
+
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  for (const hostile of [throwingProxy, revocable.proxy]) {
+    let submission: AgentToolSubmission | undefined;
+    await assert.doesNotReject(async () => {
+      submission = await gateway.submit(hostile);
+    });
+    assert.equal(submission?.outcome, "not-dispatched");
+    assert.equal(submission?.decision.reason, "malformed-proposal");
+  }
+  assert.equal(calls, 0);
+});
+
 test("v1 financial result currency keys accept only UNKNOWN or exactly three ASCII uppercase letters", () => {
   const validKeys = ["TWD", "USD", "JPY", "EUR", "HKD", "CNY", "BTC", "UNKNOWN"];
   for (const currency of validKeys) {
@@ -276,6 +585,66 @@ test("read_financial_overview returns a deterministic safe aggregate and immutab
   assert.equal(JSON.stringify(first).includes("credential"), false);
   assert.equal(first.resultReference?.referenceVersion, "immutable-result-ref.v1");
   assert.equal(first.settlement, "normal");
+});
+
+test("adapter mutation cannot alter authoritative proposal identity or replay", async () => {
+  const canary = "adapter-mutation-password-canary";
+  for (const mode of ["memory", "sqlite"] as const) {
+    const root = mode === "sqlite"
+      ? mkdtempSync(join(tmpdir(), "agent-tool-adapter-mutation-"))
+      : null;
+    try {
+      const store = mode === "sqlite"
+        ? createSqliteAgentRunStore(root!, { secretValues: [canary] })
+        : runningStore();
+      if (mode === "sqlite") {
+        store.createRun({
+          runId: "run-adapter-mutation",
+          analysisId: null,
+          phase: "running",
+          startedAt: "2026-08-04T00:00:00.000Z",
+          finishedAt: null,
+          output: "",
+          failureReason: null,
+        });
+      }
+      const runId = mode === "sqlite" ? "run-adapter-mutation" : "run-tool-1";
+      const requestId = `request-adapter-mutation-${mode}`;
+      const proposal = createReadFinancialOverviewProposal(runId, requestId);
+      let calls = 0;
+      const gateway = createFinancialOverviewToolGateway({
+        ledgerDir: root ?? "data/ledger",
+        runStore: store,
+        secretValues: [canary],
+        adapter: async ({ proposal: received }) => {
+          calls += 1;
+          const mutable = received as unknown as Record<string, unknown>;
+          mutable.runAuthority = "evil-authority";
+          mutable.requestId = "evil-request";
+          mutable.input = { password: canary };
+          return result();
+        },
+      });
+      const first = await gateway.submit(proposal);
+      assert.equal(first.outcome, "completed");
+      assert.equal(first.requestId, requestId);
+      assert.equal(first.decision.reason, "allowed");
+      assert.equal(calls, 1);
+      assert.equal(JSON.stringify(first).includes(canary), false);
+      const durable = store.getToolRequest?.(runId, requestId);
+      assert.equal(durable?.outcome, "completed");
+      assert.equal(durable?.proposal.runId, runId);
+      assert.equal(durable?.proposal.requestId, requestId);
+      assert.equal(durable?.proposal.runAuthority, runId);
+      assert.deepEqual(durable?.proposal.input, {});
+      const replay = await gateway.submit(createReadFinancialOverviewProposal(runId, requestId));
+      assert.deepEqual(replay, first);
+      assert.equal(calls, 1);
+      assert.equal(JSON.stringify(replay).includes(canary), false);
+    } finally {
+      if (root) rmSync(root, { recursive: true, force: true });
+    }
+  }
 });
 
 test("completed requests replay the persisted result and unknown outcomes never retry", async () => {

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -445,9 +445,110 @@ test("malformed proposals are durably sanitized before persistence", async () =>
     extra: { accountId: canary, password: canary },
   });
   assert.equal(submission.outcome, "not-dispatched");
-  assert.equal(submission.decision.reason, "malformed-proposal");
+  assert.equal(submission.decision.reason, "credential-boundary");
   assert.equal(store.getToolRequest?.("redacted", "redacted"), null);
   assert.equal(JSON.stringify(submission).includes(canary), false);
+});
+
+test("serialized malformed canaries in runId or requestId are redacted before persistence", async () => {
+  const store = runningStore();
+  const runIdCanary = "serialized-run-id-secret-canary";
+  const requestIdCanary = "serialized-request-id-secret-canary";
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [runIdCanary, requestIdCanary],
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+
+  for (const proposal of [
+    {
+      runId: runIdCanary,
+      requestId: "safe-request-id",
+      malformedExtra: "unknown-field",
+    },
+    {
+      runId: "run-tool-1",
+      requestId: requestIdCanary,
+      malformedExtra: "unknown-field",
+    },
+  ]) {
+    const submission = await gateway.submit(proposal);
+    assert.equal(submission.decision.reason, "credential-boundary");
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.result, null);
+    assert.equal(submission.resultReference, null);
+    assert.equal(JSON.stringify(submission).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(submission).includes(requestIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(requestIdCanary), false);
+  }
+  assert.equal(calls, 0);
+});
+
+test("raw escaped identifier canaries are redacted before persistence", async () => {
+  const store = runningStore();
+  const runIdCanary = "escaped\nrun-id-secret\\\"";
+  const requestIdCanary = "escaped\nrequest-id-secret\\\"";
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [runIdCanary, requestIdCanary],
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+
+  for (const proposal of [
+    { runId: runIdCanary, requestId: "safe-request-id", malformedExtra: "unknown-field" },
+    { runId: "run-tool-1", requestId: requestIdCanary, malformedExtra: "unknown-field" },
+  ]) {
+    const submission = await gateway.submit(proposal);
+    assert.equal(submission.decision.reason, "credential-boundary");
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.result, null);
+    assert.equal(submission.resultReference, null);
+    assert.equal(JSON.stringify(submission).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(submission).includes(requestIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(requestIdCanary), false);
+  }
+  assert.equal(calls, 0);
+});
+
+test("unserializable malformed extras still redact secret identifiers before persistence", async () => {
+  const store = runningStore();
+  const runIdCanary = "unserializable-run-id-secret";
+  const requestIdCanary = "unserializable-request-id-secret";
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [runIdCanary, requestIdCanary],
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+
+  for (const proposal of [
+    { runId: runIdCanary, requestId: "safe-request-id", malformedExtra: 1n },
+    { runId: "run-tool-1", requestId: requestIdCanary, malformedExtra: 1n },
+  ]) {
+    const submission = await gateway.submit(proposal);
+    assert.equal(submission.decision.reason, "credential-boundary");
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.result, null);
+    assert.equal(submission.resultReference, null);
+    assert.equal(JSON.stringify(submission).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(submission).includes(requestIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(runIdCanary), false);
+    assert.equal(JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(requestIdCanary), false);
+  }
+  assert.equal(calls, 0);
 });
 
 test("quantitative resource limits deny an oversized ledger before dispatch", async () => {

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -1,0 +1,824 @@
+import assert from "node:assert/strict";
+import { appendFileSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { hashBytes, stableStringify } from "../../../ledger/content-hash.ts";
+import {
+  createFinancialOverviewToolGateway,
+  createReadFinancialOverviewProposal,
+  readFinancialOverviewResult,
+  AGENT_TOOL_RESOURCE_LIMITS,
+  validateAgentToolProposal,
+  type AgentToolResult,
+  type AgentToolSubmission,
+} from "./tool-gateway.ts";
+import {
+  createAgentHarnessService,
+  createInMemoryAgentRunStore,
+  type AgentProvider,
+} from "./harness.ts";
+import { createSqliteAgentRunStore } from "./store.ts";
+
+function runningStore() {
+  const store = createInMemoryAgentRunStore();
+  store.createRun({
+    runId: "run-tool-1",
+    analysisId: null,
+    phase: "running",
+    startedAt: "2026-08-04T00:00:00.000Z",
+    finishedAt: null,
+    output: "",
+    failureReason: null,
+  });
+  return store;
+}
+
+function result(): AgentToolResult {
+  const data: AgentToolResult["data"] = {
+    aggregateVersion: "financial-overview.aggregate.v1",
+    snapshot: {
+      snapshotId: "financial-overview.aggregate.v1:snapshot",
+      importedAt: "2026-08-04T00:00:00.000Z",
+      snapshotDate: "2026-08-04",
+    },
+    totalsByCurrency: { TWD: { assets: 100, liabilities: 20, net: 80 } },
+    overview: {
+      cashAssets: { TWD: 100 },
+      foreignAssets: {},
+      investmentAssets: {},
+      unbilledCreditCard: {},
+      loans: { TWD: 20 },
+      netAssets: { TWD: 80 },
+    },
+    counts: {
+      normalizedTransactions: 3,
+      assetPositions: 2,
+      includedPositions: 2,
+      assetSnapshots: 1,
+    },
+    quality: { status: "pass", issueCount: 0 },
+  };
+  return {
+    resultVersion: "agent-tool-result.v1",
+    toolName: "read_financial_overview",
+    data,
+    reference: {
+      referenceVersion: "immutable-result-ref.v1",
+      value: `immutable-result-ref.v1:${hashBytes(stableStringify(data))}`,
+    },
+    secretFields: [],
+  };
+}
+
+test("proposal validation is strict and rejects unknown, malformed, and credential-bearing requests", () => {
+  const valid = createReadFinancialOverviewProposal("run-tool-1", "request-1");
+  assert.equal(validateAgentToolProposal(valid).reason, null);
+  assert.equal(
+    validateAgentToolProposal({ ...valid, extra: true }).reason,
+    "malformed-proposal",
+  );
+  assert.equal(
+    validateAgentToolProposal({ ...valid, toolName: "read_credentials" }).reason,
+    "tool-not-allowlisted",
+  );
+  assert.equal(
+    validateAgentToolProposal({ ...valid, input: { token: "do-not-dispatch" } }).reason,
+    "credential-boundary",
+  );
+  assert.equal(
+    validateAgentToolProposal({ ...valid, runAuthority: "other-run" }).reason,
+    null,
+    "run authority is checked by the host with the active run, not by schema parsing",
+  );
+});
+
+test("host gates permission, sensitivity, resource, and run authority before dispatch with bounded reasons", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const base = createReadFinancialOverviewProposal("run-tool-1", "request-gates");
+  for (const [field, value, reason] of [
+    ["permission", "filesystem.read", "permission-denied"],
+    ["sensitivity", "raw-financial", "sensitivity-denied"],
+    ["resource", "filesystem", "resource-denied"],
+  ] as const) {
+    const submission = await gateway.submit({ ...base, requestId: `${field}-request`, [field]: value });
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.decision.reason, reason);
+  }
+  const noAuthority = await gateway.submit({ ...base, requestId: "authority-request", runAuthority: "other-run" });
+  assert.equal(noAuthority.outcome, "not-dispatched");
+  assert.equal(noAuthority.decision.reason, "run-authority-denied");
+  assert.equal(calls, 0);
+});
+
+test("credential material in an otherwise schema-valid proposal is rejected before dispatch", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const canary = "authentication-canary-tool-request";
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [canary],
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", canary);
+  const submission = await gateway.submit(proposal);
+  assert.equal(submission.decision.reason, "credential-boundary");
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(calls, 0);
+  assert.equal(JSON.stringify(submission).includes(canary), false);
+});
+
+test("read_financial_overview returns a deterministic safe aggregate and immutable reference", async () => {
+  const store = runningStore();
+  const expected = result();
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => expected,
+  });
+  const first = await gateway.submit(createReadFinancialOverviewProposal("run-tool-1", "request-safe"));
+  assert.equal(first.outcome, "completed");
+  assert.deepEqual(first.result, expected);
+  assert.equal(JSON.stringify(first).includes("accountId"), false);
+  assert.equal(JSON.stringify(first).includes("transaction"), false);
+  assert.equal(JSON.stringify(first).includes("credential"), false);
+  assert.equal(first.resultReference?.referenceVersion, "immutable-result-ref.v1");
+  assert.equal(first.settlement, "normal");
+});
+
+test("completed requests replay the persisted result and unknown outcomes never retry", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-replay");
+  const completed = await gateway.submit(proposal);
+  const replay = await gateway.submit(proposal);
+  assert.deepEqual(replay, completed);
+  assert.equal(calls, 1);
+
+  const unknownGateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      throw new Error("dispatch lost");
+    },
+  });
+  const unknownProposal = createReadFinancialOverviewProposal("run-tool-1", "request-unknown");
+  const unknown = await unknownGateway.submit(unknownProposal);
+  const unknownReplay = await unknownGateway.submit(unknownProposal);
+  assert.equal(unknown.outcome, "outcome-unknown");
+  assert.deepEqual(unknownReplay, unknown);
+  assert.equal(calls, 2);
+});
+
+test("completed replay requires the same canonical proposal and an active run", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-identity");
+  const completed = await gateway.submit(proposal);
+  assert.equal(completed.outcome, "completed");
+
+  const changed = await gateway.submit({ ...proposal, runAuthority: "run-tool-other" });
+  assert.equal(changed.requestId, "request-identity");
+  assert.equal(changed.decision.reason, "run-authority-denied");
+  assert.equal(changed.outcome, "not-dispatched");
+  assert.equal(changed.result, null);
+  const malformedChanged = await gateway.submit({ ...proposal, input: { unexpected: true } });
+  assert.equal(malformedChanged.outcome, "not-dispatched");
+  assert.equal(malformedChanged.decision.reason, "schema-invalid");
+  assert.equal(malformedChanged.result, null);
+  assert.equal(calls, 1);
+
+  store.updateRun("run-tool-1", {
+    phase: "cancelled",
+    finishedAt: "2026-08-04T00:00:02.000Z",
+  });
+  const cancelled = await gateway.submit(proposal);
+  assert.equal(cancelled.outcome, "not-dispatched");
+  assert.equal(cancelled.decision.reason, "run-authority-denied");
+  assert.equal(cancelled.result, null);
+  assert.equal(calls, 1);
+});
+
+test("a not-dispatched request is revalidated and dispatches after authority becomes valid", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-revalidate");
+  const denied = await gateway.submit({ ...proposal, runAuthority: "wrong-authority" });
+  assert.equal(denied.outcome, "not-dispatched");
+  const completed = await gateway.submit(proposal);
+  assert.equal(completed.outcome, "completed");
+  assert.equal(calls, 1);
+});
+
+test("concurrent same-identity submissions dispatch the adapter once", async () => {
+  const store = runningStore();
+  let calls = 0;
+  let release!: (value: AgentToolResult) => void;
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return new Promise<AgentToolResult>((resolve) => { release = resolve; });
+    },
+  });
+  const proposal = createReadFinancialOverviewProposal("run-tool-1", "request-concurrent");
+  const first = gateway.submit(proposal);
+  const second = gateway.submit({ ...proposal });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(calls, 1);
+  release(result());
+  const [one, two] = await Promise.all([first, second]);
+  assert.deepEqual(one, two);
+  assert.equal(one.outcome, "completed");
+});
+
+test("direct malformed unknown-run proposals fail closed without an invalid foreign-key insert", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-tool-malformed-direct-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    const gateway = createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() });
+    const submission = await gateway.submit({ runId: "unknown", requestId: "bad", executable: { shell: "no" } });
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.decision.reason, "malformed-proposal");
+    assert.equal(store.getToolRequest?.("unknown", "bad"), null);
+    store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("hostile cyclic proposals fail closed into sanitized bounded denial", async () => {
+  const store = runningStore();
+  const gateway = createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() });
+  const hostile: Record<string, unknown> = createReadFinancialOverviewProposal(
+    "run-tool-1",
+    "request-hostile",
+  );
+  hostile.input = hostile;
+  const submission = await gateway.submit(hostile);
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.result, null);
+  assert.equal(JSON.stringify(submission).includes("hostile"), false);
+});
+
+test("pre-dispatch ledger byte bounds reject an oversized SQLite file before the adapter", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-tool-ledger-bound-"));
+  try {
+    writeFileSync(join(root, "ledger.sqlite"), "");
+    truncateSync(join(root, "ledger.sqlite"), 64 * 1024 * 1024 + 1);
+    const store = runningStore();
+    let calls = 0;
+    const gateway = createFinancialOverviewToolGateway({
+      ledgerDir: root,
+      runStore: store,
+      adapter: async () => {
+        calls += 1;
+        return result();
+      },
+    });
+    const submission = await gateway.submit(
+      createReadFinancialOverviewProposal("run-tool-1", "request-ledger-bytes"),
+    );
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.decision.reason, "resource-denied");
+    assert.equal(calls, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("pre-dispatch ledger byte bounds include SQLite WAL and shared-memory sidecars", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-tool-ledger-footprint-bound-"));
+  const store = createSqliteAgentRunStore(root, { secretValues: [] });
+  try {
+    store.createRun({
+      runId: "run-tool-1",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    writeFileSync(
+      `${join(root, "ledger.sqlite")}-shm`,
+      Buffer.alloc(AGENT_TOOL_RESOURCE_LIMITS.maxLedgerBytes),
+    );
+    let calls = 0;
+    const gateway = createFinancialOverviewToolGateway({
+      ledgerDir: root,
+      runStore: store,
+      adapter: async () => {
+        calls += 1;
+        return result();
+      },
+    });
+    const submission = await gateway.submit(
+      createReadFinancialOverviewProposal("run-tool-1", "request-ledger-footprint"),
+    );
+    assert.equal(submission.outcome, "not-dispatched");
+    assert.equal(submission.decision.reason, "resource-denied");
+    assert.equal(calls, 0);
+  } finally {
+    store.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("malformed proposals are durably sanitized before persistence", async () => {
+  const store = runningStore();
+  const canary = "credential-canary-not-persisted";
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    secretValues: [canary],
+    adapter: async () => result(),
+  });
+  const submission = await gateway.submit({
+    runId: canary,
+    requestId: canary,
+    toolName: "read_financial_overview",
+    extra: { accountId: canary, password: canary },
+  });
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.decision.reason, "malformed-proposal");
+  assert.equal(store.getToolRequest?.("redacted", "redacted"), null);
+  assert.equal(JSON.stringify(submission).includes(canary), false);
+});
+
+test("quantitative resource limits deny an oversized ledger before dispatch", async () => {
+  const store = runningStore();
+  let calls = 0;
+  const gateway = createFinancialOverviewToolGateway({
+    ledgerDir: "x".repeat(AGENT_TOOL_RESOURCE_LIMITS.maxLedgerPathBytes + 1),
+    runStore: store,
+    adapter: async () => {
+      calls += 1;
+      return result();
+    },
+  });
+  const submission = await gateway.submit(
+    createReadFinancialOverviewProposal("run-tool-1", "request-resource-limit"),
+  );
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.decision.reason, "resource-denied");
+  assert.equal(calls, 0);
+});
+
+test("financial model processing rejects an over-limit model before projection", async () => {
+  await assert.rejects(
+    () => readFinancialOverviewResult("data/ledger", async () => ({
+      counts: {
+        normalizedTransactions: AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount + 1,
+        assetPositions: 0,
+        includedPositions: 0,
+        duplicateNormalizedTransactions: 0,
+        assetSnapshots: 0,
+        auditOnlyRows: 0,
+        unsupportedRows: 0,
+      },
+    } as never)),
+    /tool-resource-limit-exceeded/,
+  );
+});
+
+test("provider proposal capability has no direct execute, ledger, filesystem, network, shell, or credential authority", async () => {
+  const store = runningStore();
+  const gateway = createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() });
+  const providerCapability = { submit: gateway.submit };
+  assert.deepEqual(Object.keys(providerCapability), ["submit"]);
+  assert.equal(Object.hasOwn(providerCapability, "execute"), false);
+  assert.equal(Object.hasOwn(providerCapability, "readLedger"), false);
+  assert.equal(Object.hasOwn(providerCapability, "readCredentials"), false);
+});
+
+test("provider capability is bound to the host run and denies wrong-run proposals in active-run lineage", async () => {
+  const store = createInMemoryAgentRunStore();
+  let capability: { submit(proposal: unknown): Promise<unknown> } | null = null;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ toolGateway: toolCapability }) {
+      capability = toolCapability;
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: createFinancialOverviewToolGateway({
+      runStore: store,
+      adapter: async () => result(),
+    }),
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-host-a",
+  });
+  await service.activate();
+  service.start({});
+  assert.ok(capability);
+  const boundCapability = capability as { submit(proposal: unknown): Promise<unknown> };
+  const submission = await boundCapability.submit(
+    createReadFinancialOverviewProposal("run-host-b", "wrong-run-request"),
+  );
+  assert.equal((submission as { outcome: string }).outcome, "not-dispatched");
+  assert.equal((submission as { decision: { reason: string } }).decision.reason, "run-authority-denied");
+  assert.equal(store.getToolRequest?.("run-host-b", "wrong-run-request"), null);
+  const activeLineage = service.lineage("run-host-a");
+  assert.deepEqual(activeLineage.map((event) => event.kind), [
+    "run.started", "tool.proposal", "tool.decision", "tool.outcome",
+  ]);
+  assert.equal(activeLineage[1]?.runId, "run-host-a");
+  assert.equal(JSON.stringify(activeLineage).includes("run-host-b"), false);
+});
+
+test("credential-bearing provider proposals are durably denied with redacted active-run lineage", async () => {
+  const store = createInMemoryAgentRunStore();
+  const canary = "provider-credential-canary";
+  let capability: { submit(proposal: unknown): Promise<unknown> } | null = null;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ toolGateway: toolCapability }) {
+      capability = toolCapability;
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: createFinancialOverviewToolGateway({
+      runStore: store,
+      secretValues: [canary],
+      adapter: async () => result(),
+    }),
+    secretValues: [canary],
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-provider-secret",
+  });
+  await service.activate();
+  service.start({});
+  assert.ok(capability);
+  const boundCapability = capability as { submit(proposal: unknown): Promise<unknown> };
+  const submission = await boundCapability.submit(
+    createReadFinancialOverviewProposal("run-provider-secret", canary),
+  );
+  assert.equal((submission as { outcome: string }).outcome, "not-dispatched");
+  assert.equal(store.getToolRequest?.("run-provider-secret", "redacted")?.outcome, "not-dispatched");
+  assert.equal(JSON.stringify(service.lineage("run-provider-secret")).includes(canary), false);
+});
+
+test("outcome-unknown terminalizes the active run and records proposal, decision, and outcome lineage", async () => {
+  const store = runningStore();
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => { throw new Error("dispatch lost"); },
+  });
+  let observedRunId = "";
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: capability, onComplete }) {
+      observedRunId = runId;
+      void capability.submit(createReadFinancialOverviewProposal(runId, "request-terminal"))
+        .then(() => onComplete());
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-tool-terminal",
+  });
+  await service.activate();
+  service.start({});
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(observedRunId, "run-tool-terminal");
+  assert.equal(service.status(observedRunId).phase, "failed");
+  assert.equal(service.status(observedRunId).toolState?.outcome, "outcome-unknown");
+  assert.deepEqual(service.lineage(observedRunId).map((event) => event.kind), [
+    "run.started", "tool.proposal", "tool.decision", "tool.outcome", "run.failed",
+  ]);
+  const toolLineage = service.lineage(observedRunId).filter((event) => event.kind.startsWith("tool."));
+  assert.equal(toolLineage[0]?.tool?.proposal?.proposalVersion, "agent-tool-proposal.v1");
+  assert.equal(toolLineage[1]?.tool?.decision?.decisionVersion, "agent-tool-decision.v1");
+  assert.equal(toolLineage[2]?.tool?.resultReference, null);
+  assert.equal(service.lineage(observedRunId).at(-1)?.transitionReason, "tool-outcome-unknown");
+});
+
+test("an in-flight completion settles after cancellation without completing or consuming the cancelled run", async () => {
+  const store = createInMemoryAgentRunStore();
+  let release!: (value: AgentToolResult) => void;
+  let dispatchStarted!: () => void;
+  const started = new Promise<void>((resolve) => { dispatchStarted = resolve; });
+  let submissionDone!: () => void;
+  const done = new Promise<void>((resolve) => { submissionDone = resolve; });
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: toolCapability }) {
+      void toolCapability.submit(createReadFinancialOverviewProposal(runId, "request-late-completion"))
+        .finally(submissionDone);
+    },
+    cancel() {},
+  };
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      dispatchStarted();
+      return new Promise<AgentToolResult>((resolve) => { release = resolve; });
+    },
+  });
+  const diagnostics: Array<{ kind: string }> = [];
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record(event) { diagnostics.push(event); } },
+    idFactory: () => "run-late-completion",
+  });
+  await service.activate();
+  service.start({});
+  await started;
+  assert.equal(service.cancel("run-late-completion").phase, "cancelled");
+  release(result());
+  await done;
+  assert.equal(service.status("run-late-completion").phase, "cancelled");
+  assert.equal(service.status("run-late-completion").output, "");
+  assert.equal(store.getToolRequest?.("run-late-completion", "request-late-completion")?.outcome, "completed");
+  assert.deepEqual(service.lineage("run-late-completion").map((event) => event.kind), [
+    "run.started", "tool.proposal", "run.cancelled", "tool.decision", "tool.outcome",
+  ]);
+  assert.equal(diagnostics.filter((event) => event.kind === "tool.outcome").length, 1);
+  assert.equal(service.lineage("run-late-completion").some((event) => event.kind === "run.completed"), false);
+});
+
+test("a completed settlement after cancellation is withheld from the provider while durable lineage keeps its reference", async () => {
+  const store = createInMemoryAgentRunStore();
+  let release!: (value: AgentToolResult) => void;
+  let submit!: Promise<AgentToolSubmission>;
+  let resolveDispatch!: () => void;
+  const dispatchStarted = new Promise<void>((resolve) => { resolveDispatch = resolve; });
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: toolCapability }) {
+      submit = toolCapability.submit(createReadFinancialOverviewProposal(runId, "request-withhold"));
+    },
+    cancel() {},
+  };
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => {
+      resolveDispatch();
+      return new Promise<AgentToolResult>((resolve) => { release = resolve; });
+    },
+  });
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-withhold",
+  });
+  await service.activate();
+  service.start({});
+  await dispatchStarted;
+  service.cancel("run-withhold");
+  release(result());
+  const providerSubmission = await submit;
+  assert.equal((providerSubmission as { result: unknown }).result, null);
+  assert.notEqual((providerSubmission as { outcome: string }).outcome, "completed");
+  assert.equal((providerSubmission as { settlement: string }).settlement, "cancelled-in-flight");
+  assert.equal(store.getToolRequest?.("run-withhold", "request-withhold")?.outcome, "completed");
+  assert.equal(store.getToolRequest?.("run-withhold", "request-withhold")?.resultReference?.value.startsWith("immutable-result-ref.v1:"), true);
+});
+
+test("early provider completion waits for a pending tool and unknown settlement fails the run", async () => {
+  const store = createInMemoryAgentRunStore();
+  let rejectDispatch!: (error: Error) => void;
+  let submission!: Promise<unknown>;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: toolCapability, onComplete }) {
+      submission = toolCapability.submit(createReadFinancialOverviewProposal(runId, "request-early-complete"));
+      onComplete();
+    },
+    cancel() {},
+  };
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    adapter: async () => new Promise<AgentToolResult>((_, reject) => { rejectDispatch = reject; }),
+  });
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-early-complete",
+  });
+  await service.activate();
+  service.start({});
+  assert.equal(service.status("run-early-complete").phase, "running");
+  rejectDispatch(new Error("dispatch lost"));
+  await submission;
+  assert.equal(service.status("run-early-complete").phase, "failed");
+  assert.equal(service.status("run-early-complete").toolState?.outcome, "outcome-unknown");
+});
+
+test("host diagnostics carry bounded tool metadata without proposal or result payloads", async () => {
+  const store = runningStore();
+  const diagnostics: Array<Record<string, unknown>> = [];
+  const gateway = createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() });
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: toolCapability }) {
+      void toolCapability.submit(createReadFinancialOverviewProposal(runId, "request-diagnostic"));
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record(event) { diagnostics.push(event as unknown as Record<string, unknown>); } },
+    idFactory: () => "run-diagnostic-metadata",
+  });
+  await service.activate();
+  service.start({});
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const toolDiagnostic = diagnostics.find((event) => event.kind === "tool.outcome");
+  assert.deepEqual(toolDiagnostic?.tool, {
+    requestId: "request-diagnostic",
+    toolName: "read_financial_overview",
+    decision: { decisionVersion: "agent-tool-decision.v1", allowed: true, reason: "allowed" },
+    outcome: "completed",
+    resultReference: store.getToolRequest?.("run-diagnostic-metadata", "request-diagnostic")?.resultReference?.value,
+    settlement: "normal",
+  });
+  assert.equal(JSON.stringify(toolDiagnostic).includes("proposal"), false);
+  assert.equal(JSON.stringify(toolDiagnostic).includes("totalsByCurrency"), false);
+});
+
+test("concurrent ledger mutation is rejected after the actual adapter read", async () => {
+  const root = mkdtempSync(join(tmpdir(), "agent-tool-ledger-toctou-"));
+  try {
+    const store = createSqliteAgentRunStore(root, { secretValues: [] });
+    store.createRun({
+      runId: "run-toctou",
+      analysisId: null,
+      phase: "running",
+      startedAt: "2026-08-04T00:00:00.000Z",
+      finishedAt: null,
+      output: "",
+      failureReason: null,
+    });
+    const gateway = createFinancialOverviewToolGateway({
+      ledgerDir: root,
+      runStore: store,
+      adapter: async () => {
+        appendFileSync(join(root, "ledger.sqlite"), "concurrent-change");
+        return result();
+      },
+    });
+    const submission = await gateway.submit(createReadFinancialOverviewProposal("run-toctou", "request-toctou"));
+    assert.equal(submission.outcome, "outcome-unknown");
+    store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a never-settling adapter reaches bounded outcome-unknown after cancellation and releases late output", async () => {
+  const store = createInMemoryAgentRunStore();
+  let stream!: (content: string) => void;
+  let dispatchStarted!: () => void;
+  const started = new Promise<void>((resolve) => { dispatchStarted = resolve; });
+  let submission!: Promise<unknown>;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ runId, toolGateway: toolCapability, onStream }) {
+      stream = onStream;
+      submission = toolCapability.submit(createReadFinancialOverviewProposal(runId, "request-timeout"));
+    },
+    cancel() {},
+  };
+  const gateway = createFinancialOverviewToolGateway({
+    runStore: store,
+    executionTimeoutMs: 10,
+    adapter: async () => {
+      dispatchStarted();
+      return new Promise<AgentToolResult>(() => {});
+    },
+  });
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: gateway,
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-timeout",
+  });
+  await service.activate();
+  service.start({});
+  await started;
+  assert.equal(service.cancel("run-timeout").phase, "cancelled");
+  stream("late continuation must be ignored");
+  await submission;
+  assert.equal(store.getToolRequest?.("run-timeout", "request-timeout")?.outcome, "outcome-unknown");
+  assert.equal(service.status("run-timeout").phase, "cancelled");
+  assert.equal(service.status("run-timeout").output, "");
+});
+
+test("a pre-submit sanitization exception still releases pending authority", async () => {
+  const store = createInMemoryAgentRunStore();
+  let stream!: (content: string) => void;
+  let submit!: (proposal: unknown) => Promise<unknown>;
+  const provider: AgentProvider = {
+    async activate() {
+      return { availability: "available", providerIdentity: "test-provider", osBuild: "test" };
+    },
+    start({ toolGateway: toolCapability, onStream }) {
+      submit = toolCapability.submit;
+      stream = onStream;
+    },
+    cancel() {},
+  };
+  const service = createAgentHarnessService({
+    helper: { launch(input) { input.provider.start(input); }, cancel() {} },
+    provider,
+    runStore: store,
+    toolGateway: createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() }),
+    clock: { now: () => "2026-08-04T00:00:00.000Z" },
+    diagnosticsSink: { record() {} },
+    idFactory: () => "run-pre-submit-error",
+  });
+  await service.activate();
+  service.start({});
+  const circular: Record<string, unknown> = createReadFinancialOverviewProposal(
+    "run-pre-submit-error",
+    "request-circular",
+  );
+  circular.input = circular;
+  await assert.rejects(() => submit(circular));
+  assert.equal(service.cancel("run-pre-submit-error").phase, "cancelled");
+  stream("late output after pre-submit error");
+  assert.equal(service.status("run-pre-submit-error").output, "");
+});

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -10,6 +10,7 @@ import {
   readFinancialOverviewResult,
   AGENT_TOOL_RESOURCE_LIMITS,
   validateAgentToolProposal,
+  validateAgentToolResult,
   type AgentToolResult,
   type AgentToolSubmission,
 } from "./tool-gateway.ts";
@@ -91,6 +92,81 @@ test("proposal validation is strict and rejects unknown, malformed, and credenti
     null,
     "run authority is checked by the host with the active run, not by schema parsing",
   );
+});
+
+test("v1 financial result currency keys accept only UNKNOWN or exactly three ASCII uppercase letters", () => {
+  const validKeys = ["TWD", "USD", "JPY", "EUR", "HKD", "CNY", "BTC", "UNKNOWN"];
+  for (const currency of validKeys) {
+    const candidate = result();
+    candidate.data.totalsByCurrency = {
+      [currency]: { assets: 1, liabilities: 0, net: 1 },
+    };
+    candidate.data.overview = {
+      cashAssets: { [currency]: 1 },
+      foreignAssets: { [currency]: 1 },
+      investmentAssets: { [currency]: 1 },
+      unbilledCreditCard: { [currency]: 1 },
+      loans: { [currency]: 1 },
+      netAssets: { [currency]: 1 },
+    };
+    candidate.reference.value = `immutable-result-ref.v1:${hashBytes(stableStringify(candidate.data))}`;
+    assert.equal(validateAgentToolResult(candidate), true, currency);
+  }
+  for (const currency of ["usd", "美金", "", "$", "1234567890", "USDT"]) {
+    const candidate = result();
+    candidate.data.totalsByCurrency = {
+      [currency]: { assets: 1, liabilities: 0, net: 1 },
+    };
+    candidate.reference.value = `immutable-result-ref.v1:${hashBytes(stableStringify(candidate.data))}`;
+    assert.equal(validateAgentToolResult(candidate), false, currency);
+  }
+});
+
+test("secret-bearing currency object keys fail closed after one adapter call without persistence", async () => {
+  for (const [index, secretCurrency] of ["ABC", "USD"].entries()) {
+    const proposal = createReadFinancialOverviewProposal("run-tool-1", `request-secret-currency-${index}`);
+    assert.equal(JSON.stringify(proposal).includes(secretCurrency), false);
+
+    const controlStore = runningStore();
+    const controlCandidate = result();
+    let controlCalls = 0;
+    const controlGateway = createFinancialOverviewToolGateway({
+      runStore: controlStore,
+      adapter: async () => {
+        controlCalls += 1;
+        return controlCandidate;
+      },
+    });
+    const control = await controlGateway.submit(proposal);
+    assert.equal(controlCalls, 1);
+    assert.equal(control.outcome, "completed");
+
+    const store = runningStore();
+    let calls = 0;
+    const candidate = result();
+    candidate.data.totalsByCurrency = {
+      [secretCurrency]: { assets: 1, liabilities: 0, net: 1 },
+    };
+    candidate.reference.value = `immutable-result-ref.v1:${hashBytes(stableStringify(candidate.data))}`;
+    const gateway = createFinancialOverviewToolGateway({
+      runStore: store,
+      secretValues: [secretCurrency],
+      adapter: async () => {
+        calls += 1;
+        return candidate;
+      },
+    });
+    const submission = await gateway.submit(proposal);
+    assert.equal(calls, 1);
+    assert.equal(submission.outcome, "outcome-unknown");
+    assert.equal(submission.result, null);
+    assert.equal(submission.resultReference, null);
+    assert.equal(JSON.stringify(submission).includes(secretCurrency), false);
+    assert.equal(
+      JSON.stringify(store.listToolRequests?.("run-tool-1")).includes(secretCurrency),
+      false,
+    );
+  }
 });
 
 test("host gates permission, sensitivity, resource, and run authority before dispatch with bounded reasons", async () => {

--- a/src/lib/agent/server/tool-gateway.check.ts
+++ b/src/lib/agent/server/tool-gateway.check.ts
@@ -789,6 +789,8 @@ test("a never-settling adapter reaches bounded outcome-unknown after cancellatio
 
 test("a pre-submit sanitization exception still releases pending authority", async () => {
   const store = createInMemoryAgentRunStore();
+  const diagnostics: unknown[] = [];
+  const canary = "cyclic-provider-secret";
   let stream!: (content: string) => void;
   let submit!: (proposal: unknown) => Promise<unknown>;
   const provider: AgentProvider = {
@@ -805,10 +807,15 @@ test("a pre-submit sanitization exception still releases pending authority", asy
     helper: { launch(input) { input.provider.start(input); }, cancel() {} },
     provider,
     runStore: store,
-    toolGateway: createFinancialOverviewToolGateway({ runStore: store, adapter: async () => result() }),
+    toolGateway: createFinancialOverviewToolGateway({
+      runStore: store,
+      secretValues: [canary],
+      adapter: async () => result(),
+    }),
     clock: { now: () => "2026-08-04T00:00:00.000Z" },
-    diagnosticsSink: { record() {} },
+    diagnosticsSink: { record(event) { diagnostics.push(event); } },
     idFactory: () => "run-pre-submit-error",
+    secretValues: [canary],
   });
   await service.activate();
   service.start({});
@@ -817,8 +824,25 @@ test("a pre-submit sanitization exception still releases pending authority", asy
     "request-circular",
   );
   circular.input = circular;
-  await assert.rejects(() => submit(circular));
+  circular.runAuthority = canary;
+  const submission = await submit(circular) as {
+    outcome: string;
+    result: unknown;
+    decision: { reason: string };
+  };
+  assert.equal(submission.outcome, "not-dispatched");
+  assert.equal(submission.result, null);
+  assert.equal(submission.decision.reason, "malformed-proposal");
+  const lineage = service.lineage("run-pre-submit-error");
+  const proposalEvent = lineage.find((event) => event.kind === "tool.proposal");
+  assert.equal(proposalEvent?.tool?.requestId, "redacted");
+  assert.equal(Object.hasOwn(proposalEvent?.tool?.proposal ?? {}, "input"), false);
+  assert.equal(JSON.stringify(lineage).includes(canary), false);
+  assert.ok(JSON.stringify(lineage).length < 4_096);
+  assert.equal(JSON.stringify(diagnostics).includes(canary), false);
+  assert.ok(diagnostics.length <= 2);
   assert.equal(service.cancel("run-pre-submit-error").phase, "cancelled");
+  assert.equal(service.complete("run-pre-submit-error").phase, "cancelled");
   stream("late output after pre-submit error");
   assert.equal(service.status("run-pre-submit-error").output, "");
 });

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -279,6 +279,17 @@ function isFiniteNumberRecord(value: unknown): value is Record<string, number> {
     && Object.values(value).every((item) => typeof item === "number" && Number.isFinite(item));
 }
 
+const CURRENCY_KEY_PATTERN = /^[A-Z]{3}$/;
+
+function isCurrencyKey(value: string): boolean {
+  return value === "UNKNOWN" || CURRENCY_KEY_PATTERN.test(value);
+}
+
+function isFiniteCurrencyRecord(value: unknown): value is Record<string, number> {
+  return isFiniteNumberRecord(value)
+    && Object.keys(value).every(isCurrencyKey);
+}
+
 export function validateAgentToolResult(value: unknown): value is AgentToolResult {
   if (!isRecord(value)
     || !exactRecordKeys(value, ["resultVersion", "toolName", "data", "reference", "secretFields"])
@@ -298,6 +309,7 @@ export function validateAgentToolResult(value: unknown): value is AgentToolResul
     || (value.data.snapshot.importedAt !== null && typeof value.data.snapshot.importedAt !== "string")
     || (value.data.snapshot.snapshotDate !== null && typeof value.data.snapshot.snapshotDate !== "string")
     || !isRecord(value.data.totalsByCurrency)
+    || Object.keys(value.data.totalsByCurrency).some((currency) => !isCurrencyKey(currency))
     || Object.values(value.data.totalsByCurrency).some((totals) =>
       !isRecord(totals)
       || !exactRecordKeys(totals, ["assets", "liabilities", "net"])
@@ -306,7 +318,7 @@ export function validateAgentToolResult(value: unknown): value is AgentToolResul
     || !exactRecordKeys(value.data.overview, [
       "cashAssets", "foreignAssets", "investmentAssets", "unbilledCreditCard", "loans", "netAssets",
     ])
-    || !Object.values(value.data.overview).every(isFiniteNumberRecord)
+    || !Object.values(value.data.overview).every(isFiniteCurrencyRecord)
     || !isRecord(value.data.counts)
     || !exactRecordKeys(value.data.counts, ["normalizedTransactions", "assetPositions", "includedPositions", "assetSnapshots"])
     || Object.values(value.data.counts).some((item) => !Number.isSafeInteger(item) || (item as number) < 0)
@@ -413,6 +425,41 @@ function resultWithinResourceLimits(result: AgentToolResult): boolean {
   return utf8Bytes(stableStringify(result)) <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes
     && currencyCount <= AGENT_TOOL_RESOURCE_LIMITS.maxCurrencyBuckets
     && counts.every((count) => count <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount);
+}
+
+const MAX_SECRET_KEY_SCAN_DEPTH = 32;
+const MAX_SECRET_KEY_SCAN_NODES = 100_000;
+
+/**
+ * Secret-boundary protection covers record values, while result maps also
+ * carry untrusted data in their object keys (for example currency codes).
+ * Scan those keys before any result is protected or persisted. A bounded
+ * fail-closed walk keeps hostile object graphs from turning this guard into
+ * an unbounded traversal.
+ */
+function containsSecretObjectKey(
+  value: unknown,
+  secretBoundary: SecretBoundaryGate,
+): boolean {
+  const seen = new WeakSet<object>();
+  let remaining = MAX_SECRET_KEY_SCAN_NODES;
+  function visit(current: unknown, depth: number): boolean {
+    if (remaining-- <= 0 || depth > MAX_SECRET_KEY_SCAN_DEPTH) return true;
+    if (Array.isArray(current)) return current.some((item) => visit(item, depth + 1));
+    if (!isRecord(current)) return false;
+    if (seen.has(current)) return false;
+    seen.add(current);
+    for (const [key, child] of Object.entries(current)) {
+      try {
+        if (secretBoundary.protectText("diagnostic-export", key).failure) return true;
+      } catch {
+        return true;
+      }
+      if (visit(child, depth + 1)) return true;
+    }
+    return false;
+  }
+  return visit(value, 0);
 }
 
 function modelWithinResourceLimits(model: FinancialModel): boolean {
@@ -757,6 +804,9 @@ export function createFinancialOverviewToolGateway({
           ]);
           if (!validateAgentToolResult(adapterResult) || !resultWithinResourceLimits(adapterResult)) {
             throw new Error("invalid-tool-result");
+          }
+          if (containsSecretObjectKey(adapterResult, secretBoundary)) {
+            throw new Error("secret-key-detected");
           }
           if (!ledgerBefore || !sameLedgerSnapshot(ledgerBefore, ledgerResourceSnapshot(ledgerDir, snapshotDb))) {
             throw new Error("ledger-changed-during-tool-read");

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -585,28 +585,60 @@ export function createFinancialOverviewToolGateway({
       } catch {
         containsSecret = true;
       }
-      const exactProposal = isRecord(rawProposal) && hasExactKeys(rawProposal, TOP_LEVEL_PROPOSAL_KEYS);
+      let serializedProposal = "";
+      let serializedSecretDetected = false;
+      try {
+        const serialized = stableStringify(rawProposal);
+        serializedProposal = typeof serialized === "string" ? serialized : String(serialized);
+        try {
+          serializedSecretDetected = Boolean(
+            secretBoundary.protectText("diagnostic-export", serializedProposal).failure,
+          );
+        } catch {
+          serializedSecretDetected = true;
+        }
+      } catch {
+        serializedProposal = "[unserializable]";
+      }
+      const rawProposalRecord = isRecord(rawProposal) ? rawProposal : null;
+      let rawRunId: unknown;
+      let rawRequestId: unknown;
+      let rawIdentifierSecretDetected = false;
+      if (rawProposalRecord) {
+        try {
+          rawRunId = rawProposalRecord.runId;
+          rawRequestId = rawProposalRecord.requestId;
+        } catch {
+          rawIdentifierSecretDetected = true;
+        }
+      }
+      for (const identifier of [rawRunId, rawRequestId]) {
+        if (typeof identifier !== "string") continue;
+        try {
+          rawIdentifierSecretDetected ||= Boolean(
+            secretBoundary.protectText("diagnostic-export", identifier).failure,
+          );
+        } catch {
+          rawIdentifierSecretDetected = true;
+        }
+      }
+      const exactProposal = rawProposalRecord !== null
+        && hasExactKeys(rawProposalRecord, TOP_LEVEL_PROPOSAL_KEYS);
       let proposalHasSecret = false;
       if (exactProposal) {
         try {
           const protectedProposal = secretBoundary.protectRecord(
             "diagnostic-export",
             "agent-tool-proposal",
-            rawProposal,
+            rawProposalRecord,
           );
           proposalHasSecret = Boolean(protectedProposal.failure) || containsSecret;
         } catch {
           proposalHasSecret = true;
         }
       }
+      proposalHasSecret ||= serializedSecretDetected || rawIdentifierSecretDetected;
       containsSecret ||= proposalHasSecret;
-      let serializedProposal = "";
-      try {
-        const serialized = stableStringify(rawProposal);
-        serializedProposal = typeof serialized === "string" ? serialized : String(serialized);
-      } catch {
-        serializedProposal = "[unserializable]";
-      }
       const proposalTooLarge = utf8Bytes(serializedProposal) > AGENT_TOOL_RESOURCE_LIMITS.maxProposalBytes;
       const validation = proposalTooLarge
         ? { value: null, reason: "resource-denied" as const }
@@ -614,8 +646,6 @@ export function createFinancialOverviewToolGateway({
           ? { value: null, reason: "credential-boundary" as const }
           : validateAgentToolProposal(rawProposal);
       const proposal = validation.value;
-      const rawRunId = isRecord(rawProposal) ? rawProposal.runId : undefined;
-      const rawRequestId = isRecord(rawProposal) ? rawProposal.requestId : undefined;
       const runId = containsSecret ? "redacted" : safeIdentifier(rawRunId, "unknown");
       const requestId = containsSecret
         ? "redacted"

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -533,17 +533,17 @@ export function createFinancialOverviewToolGateway({
     return protectedValue.value as T;
   }
 
-  function persist(record: AgentToolExecutionRecord): AgentToolExecutionRecord {
+  function persistRecord(record: AgentToolExecutionRecord): AgentToolExecutionRecord {
     const protectedRecord = protect("agent-tool-outcome", record as unknown as Record<string, unknown>);
     const next = protectedRecord as unknown as AgentToolExecutionRecord;
     const key = `${next.runId}:${next.requestId}`;
     if (!runStore.getRun(next.runId)) return next;
-    const existing = records.get(key) ?? runStore.getToolRequest?.(next.runId, next.requestId) ?? null;
+    const existing = existingRecord(next.runId, next.requestId);
     const identityDiffers = existing
       && agentToolProposalIdentity(existing.proposal) !== agentToolProposalIdentity(next.proposal);
     if (identityDiffers && existing?.outcome !== "not-dispatched") {
       records.set(key, existing);
-      return next;
+      return existing;
     }
     if (existing && !isMoreFinalOutcome(next.outcome, existing.outcome)) {
       records.set(key, existing);
@@ -553,6 +553,28 @@ export function createFinancialOverviewToolGateway({
     const persisted = runStore.getToolRequest?.(next.runId, next.requestId) ?? next;
     records.set(key, persisted);
     return persisted;
+  }
+
+  function persistSubmission(record: AgentToolExecutionRecord): AgentToolSubmission {
+    const durable = persistRecord(record);
+    const caller = agentToolProposalIdentity(durable.proposal)
+      === agentToolProposalIdentity(record.proposal)
+      ? durable
+      : record;
+    return replaySubmission(caller);
+  }
+
+  function existingRecord(runId: string, requestId: string): AgentToolExecutionRecord | null {
+    const key = `${runId}:${requestId}`;
+    const cached = records.get(key) ?? null;
+    const durable = runStore.getToolRequest?.(runId, requestId) ?? null;
+    if (durable && durable.outcome !== "not-dispatched") {
+      records.set(key, durable);
+      return durable;
+    }
+    if (cached) return cached;
+    if (durable) records.set(key, durable);
+    return durable;
   }
 
   return {
@@ -617,14 +639,12 @@ export function createFinancialOverviewToolGateway({
           resultReference: null,
           occurredAt: clock.now(),
         };
-        return replaySubmission(persist(record));
+        return persistSubmission(record);
       }
 
       const run = runStore.getRun(proposal.runId);
       const active = Boolean(run && run.phase === "running" && proposal.runAuthority === proposal.runId);
-      const existing = records.get(`${proposal.runId}:${proposal.requestId}`)
-        ?? runStore.getToolRequest?.(proposal.runId, proposal.requestId)
-        ?? null;
+      const existing = existingRecord(proposal.runId, proposal.requestId);
       if (existing) {
         if (active && agentToolProposalIdentity(existing.proposal) === agentToolProposalIdentity(proposal)) {
           if (existing.outcome !== "not-dispatched") {
@@ -661,7 +681,7 @@ export function createFinancialOverviewToolGateway({
           resultReference: null,
           occurredAt: clock.now(),
         };
-        return replaySubmission(persist(record));
+        return persistSubmission(record);
       }
       const key = `${proposal.runId}:${proposal.requestId}`;
       const identity = agentToolProposalIdentity(proposal);
@@ -690,7 +710,7 @@ export function createFinancialOverviewToolGateway({
           resultReference: null,
           occurredAt: clock.now(),
         };
-        return replaySubmission(persist(record));
+        return persistSubmission(record);
       }
 
       const dispatch = (async (): Promise<AgentToolSubmission> => {
@@ -726,7 +746,7 @@ export function createFinancialOverviewToolGateway({
             occurredAt: clock.now(),
             settlement,
           };
-          return replaySubmission(persist(record));
+          return persistSubmission(record);
         } catch {
           const record = {
             runId: proposal.runId,
@@ -741,7 +761,7 @@ export function createFinancialOverviewToolGateway({
               ? "cancelled-in-flight"
               : "normal") as AgentToolSettlement,
           };
-          return replaySubmission(persist(record));
+          return persistSubmission(record);
         } finally {
           if (timeout) clearTimeout(timeout);
           snapshotDb?.close();

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -161,12 +161,35 @@ const TOP_LEVEL_PROPOSAL_KEYS = [
 const INPUT_KEYS: readonly string[] = [];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+  if (value === null || typeof value !== "object") return false;
+  try {
+    return !Array.isArray(value);
+  } catch {
+    // A revoked proxy can throw even for the array brand check. Treat it as
+    // malformed input so validators and the gateway fail closed outwardly.
+    return false;
+  }
 }
 
 function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]) {
-  return Object.keys(value).length === keys.length
-    && keys.every((key) => Object.hasOwn(value, key));
+  return hasExactOwnKeys(value, keys);
+}
+
+/**
+ * Validate an object's complete own-key set without reading any property
+ * values. Reflect.ownKeys includes non-enumerable properties and symbols;
+ * both must be accounted for before a record can cross a trust boundary.
+ * Hostile proxies may throw from ownKeys, so schema validation fails closed.
+ */
+function hasExactOwnKeys(value: Record<string, unknown>, keys: readonly string[]) {
+  try {
+    const ownKeys = Reflect.ownKeys(value);
+    return ownKeys.length === keys.length
+      && ownKeys.every((key): key is string => typeof key === "string")
+      && keys.every((key) => ownKeys.includes(key) && Object.hasOwn(value, key));
+  } catch {
+    return false;
+  }
 }
 
 function hasCredentialKey(key: string) {
@@ -194,6 +217,140 @@ function safeIdentifier(value: unknown, fallback: string): string {
   return value;
 }
 
+const MAX_PROPOSAL_SNAPSHOT_DEPTH = 32;
+const MAX_PROPOSAL_SNAPSHOT_NODES = 10_000;
+const PROPOSAL_SNAPSHOT_FAILURE = Symbol("agent-tool-proposal-snapshot-failure");
+
+type ProposalSnapshotValue = unknown | typeof PROPOSAL_SNAPSHOT_FAILURE;
+type ProposalSnapshot = {
+  value: Record<string, unknown> | null;
+  runId: unknown;
+  requestId: unknown;
+};
+
+/**
+ * Materialize one bounded plain-data view of a provider proposal. Descriptors
+ * are read once so validation, authority checks, persistence, and adapter
+ * dispatch never observe the provider's original object or an accessor.
+ */
+function snapshotAgentToolProposal(value: unknown): ProposalSnapshot {
+  let nodes = 0;
+  let bytes = 0;
+  let runId: unknown;
+  let requestId: unknown;
+  const active = new WeakSet<object>();
+
+  function account(amount: number): boolean {
+    if (!Number.isSafeInteger(amount) || amount < 0) return false;
+    bytes += amount;
+    return bytes <= AGENT_TOOL_RESOURCE_LIMITS.maxProposalBytes;
+  }
+
+  function primitive(current: unknown): ProposalSnapshotValue {
+    if (current === null) return account(4) ? null : PROPOSAL_SNAPSHOT_FAILURE;
+    if (typeof current === "string") {
+      try {
+        const encoded = JSON.stringify(current);
+        return typeof encoded === "string" && account(utf8Bytes(encoded))
+          ? current
+          : PROPOSAL_SNAPSHOT_FAILURE;
+      } catch {
+        return PROPOSAL_SNAPSHOT_FAILURE;
+      }
+    }
+    if (typeof current === "boolean") {
+      return account(current ? 4 : 5) ? current : PROPOSAL_SNAPSHOT_FAILURE;
+    }
+    if (typeof current === "number") {
+      if (!Number.isFinite(current)) return PROPOSAL_SNAPSHOT_FAILURE;
+      try {
+        const encoded = JSON.stringify(current);
+        return typeof encoded === "string" && account(utf8Bytes(encoded))
+          ? current
+          : PROPOSAL_SNAPSHOT_FAILURE;
+      } catch {
+        return PROPOSAL_SNAPSHOT_FAILURE;
+      }
+    }
+    return PROPOSAL_SNAPSHOT_FAILURE;
+  }
+
+  function visit(current: unknown, depth: number): ProposalSnapshotValue {
+    if (depth > MAX_PROPOSAL_SNAPSHOT_DEPTH) return PROPOSAL_SNAPSHOT_FAILURE;
+    if (current === null || typeof current !== "object") return primitive(current);
+    if (active.has(current)) return PROPOSAL_SNAPSHOT_FAILURE;
+    if (++nodes > MAX_PROPOSAL_SNAPSHOT_NODES || !account(1)) {
+      return PROPOSAL_SNAPSHOT_FAILURE;
+    }
+    active.add(current);
+    try {
+      let prototype: object | null;
+      let descriptors: PropertyDescriptorMap;
+      try {
+        prototype = Object.getPrototypeOf(current);
+        descriptors = Object.getOwnPropertyDescriptors(current);
+      } catch {
+        return PROPOSAL_SNAPSHOT_FAILURE;
+      }
+      let array = false;
+      try {
+        array = Array.isArray(current);
+      } catch {
+        return PROPOSAL_SNAPSHOT_FAILURE;
+      }
+      if (array || (prototype !== null && prototype !== Object.prototype)) {
+        return PROPOSAL_SNAPSHOT_FAILURE;
+      }
+
+      const keys = Reflect.ownKeys(descriptors);
+      if (keys.some((key) => typeof key !== "string")) return PROPOSAL_SNAPSHOT_FAILURE;
+      const clone = Object.create(null) as Record<string, unknown>;
+      if (!account(2)) return PROPOSAL_SNAPSHOT_FAILURE;
+      for (const key of keys) {
+        const descriptor = descriptors[key];
+        if (!descriptor
+          || descriptor.get !== undefined
+          || descriptor.set !== undefined
+          || !Object.hasOwn(descriptor, "value")) {
+          return PROPOSAL_SNAPSHOT_FAILURE;
+        }
+        if (depth === 0 && key === "runId") runId = descriptor.value;
+        if (depth === 0 && key === "requestId") requestId = descriptor.value;
+        const encodedKey = JSON.stringify(key);
+        if (typeof encodedKey !== "string" || !account(utf8Bytes(encodedKey))) {
+          return PROPOSAL_SNAPSHOT_FAILURE;
+        }
+        const child = visit(descriptor.value, depth + 1);
+        if (child === PROPOSAL_SNAPSHOT_FAILURE) return PROPOSAL_SNAPSHOT_FAILURE;
+        Object.defineProperty(clone, key, {
+          value: child,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+      return clone;
+    } finally {
+      active.delete(current);
+    }
+  }
+
+  const snapshot = visit(value, 0);
+  return {
+    value: snapshot === PROPOSAL_SNAPSHOT_FAILURE || !isRecord(snapshot)
+      ? null
+      : snapshot,
+    runId,
+    requestId,
+  };
+}
+
+function cloneAgentToolProposalForAdapter(value: AgentToolProposal): AgentToolProposal {
+  const snapshot = snapshotAgentToolProposal(value).value;
+  if (snapshot === null) throw new Error("invalid-adapter-proposal-clone");
+  return snapshot as AgentToolProposal;
+}
+
 export function agentToolProposalIdentity(proposal: AgentToolProposal): string {
   return hashBytes(stableStringify(proposal));
 }
@@ -216,6 +373,24 @@ export function createReadFinancialOverviewProposal(
 }
 
 export function validateAgentToolProposal(value: unknown):
+  | { value: AgentToolProposal; reason: null }
+  | { value: null; reason: Exclude<AgentToolDecisionReason, "allowed"> } {
+  const snapshot = snapshotAgentToolProposal(value).value;
+  if (snapshot === null) return { value: null, reason: "malformed-proposal" };
+  return validateAgentToolProposalSnapshot(snapshot);
+}
+
+function validateAgentToolProposalSnapshot(value: unknown):
+  | { value: AgentToolProposal; reason: null }
+  | { value: null; reason: Exclude<AgentToolDecisionReason, "allowed"> } {
+  try {
+    return validateAgentToolProposalUnsafe(value);
+  } catch {
+    return { value: null, reason: "malformed-proposal" };
+  }
+}
+
+function validateAgentToolProposalUnsafe(value: unknown):
   | { value: AgentToolProposal; reason: null }
   | { value: null; reason: Exclude<AgentToolDecisionReason, "allowed"> } {
   if (!isRecord(value) || !hasExactKeys(value, TOP_LEVEL_PROPOSAL_KEYS)) {
@@ -270,8 +445,7 @@ function resultReference(data: FinancialOverviewAggregate): AgentToolResultRefer
 }
 
 function exactRecordKeys(value: Record<string, unknown>, keys: readonly string[]) {
-  return Object.keys(value).length === keys.length
-    && keys.every((key) => Object.hasOwn(value, key));
+  return hasExactOwnKeys(value, keys);
 }
 
 function isFiniteNumberRecord(value: unknown): value is Record<string, number> {
@@ -291,6 +465,14 @@ function isFiniteCurrencyRecord(value: unknown): value is Record<string, number>
 }
 
 export function validateAgentToolResult(value: unknown): value is AgentToolResult {
+  try {
+    return validateAgentToolResultUnsafe(value);
+  } catch {
+    return false;
+  }
+}
+
+function validateAgentToolResultUnsafe(value: unknown): value is AgentToolResult {
   if (!isRecord(value)
     || !exactRecordKeys(value, ["resultVersion", "toolName", "data", "reference", "secretFields"])
     || value.resultVersion !== AGENT_TOOL_RESULT_VERSION
@@ -791,32 +973,34 @@ export function createFinancialOverviewToolGateway({
 
   return {
     async submit(rawProposal) {
-      let containsSecret = false;
-      try {
-        containsSecret = containsCredentialMaterial(rawProposal);
-      } catch {
-        containsSecret = true;
-      }
+      const proposalPreflight = snapshotAgentToolProposal(rawProposal);
+      const proposalSnapshot = proposalPreflight.value;
+      let containsSecret = proposalSnapshot === null;
       let serializedProposal = "";
       let serializedSecretDetected = false;
-      try {
-        const serialized = stableStringify(rawProposal);
-        serializedProposal = typeof serialized === "string" ? serialized : String(serialized);
+      if (proposalSnapshot) {
         try {
-          serializedSecretDetected = Boolean(
-            secretBoundary.protectText("diagnostic-export", serializedProposal).failure,
-          );
+          const serialized = stableStringify(proposalSnapshot);
+          serializedProposal = typeof serialized === "string" ? serialized : String(serialized);
+          try {
+            serializedSecretDetected = Boolean(
+              secretBoundary.protectText("diagnostic-export", serializedProposal).failure,
+            );
+          } catch {
+            serializedSecretDetected = true;
+          }
         } catch {
-          serializedSecretDetected = true;
+          serializedProposal = "[unserializable]";
+          containsSecret = true;
         }
-      } catch {
+      } else {
         serializedProposal = "[unserializable]";
       }
-      const rawProposalRecord = isRecord(rawProposal) ? rawProposal : null;
-      let rawRunId: unknown;
-      let rawRequestId: unknown;
+      const rawProposalRecord = proposalSnapshot;
+      let rawRunId: unknown = proposalPreflight.runId;
+      let rawRequestId: unknown = proposalPreflight.requestId;
       let rawIdentifierSecretDetected = false;
-      if (rawProposalRecord) {
+      if (rawProposalRecord && rawRunId === undefined && rawRequestId === undefined) {
         try {
           rawRunId = rawProposalRecord.runId;
           rawRequestId = rawProposalRecord.requestId;
@@ -844,7 +1028,8 @@ export function createFinancialOverviewToolGateway({
             "agent-tool-proposal",
             rawProposalRecord,
           );
-          proposalHasSecret = Boolean(protectedProposal.failure) || containsSecret;
+          proposalHasSecret = Boolean(protectedProposal.failure)
+            || containsCredentialMaterial(rawProposalRecord);
         } catch {
           proposalHasSecret = true;
         }
@@ -856,7 +1041,9 @@ export function createFinancialOverviewToolGateway({
         ? { value: null, reason: "resource-denied" as const }
         : proposalHasSecret
           ? { value: null, reason: "credential-boundary" as const }
-          : validateAgentToolProposal(rawProposal);
+          : proposalSnapshot === null
+            ? { value: null, reason: "malformed-proposal" as const }
+            : validateAgentToolProposalSnapshot(proposalSnapshot);
       const proposal = validation.value;
       const runId = containsSecret ? "redacted" : safeIdentifier(rawRunId, "unknown");
       const requestId = containsSecret
@@ -958,11 +1145,12 @@ export function createFinancialOverviewToolGateway({
       const dispatch = (async (): Promise<AgentToolSubmission> => {
         let timeout: ReturnType<typeof setTimeout> | undefined;
         try {
+          const adapterProposal = cloneAgentToolProposalForAdapter(proposal);
           const timeoutMs = Number.isFinite(executionTimeoutMs) && executionTimeoutMs > 0
             ? executionTimeoutMs
             : AGENT_TOOL_DEFAULT_EXECUTION_TIMEOUT_MS;
           const adapterResult = await Promise.race([
-            adapter({ ledgerDir, proposal }),
+            adapter({ ledgerDir, proposal: adapterProposal }),
             new Promise<never>((_, reject) => {
               timeout = setTimeout(() => reject(new Error("tool-execution-timeout")), timeoutMs);
             }),

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -427,6 +427,154 @@ function resultWithinResourceLimits(result: AgentToolResult): boolean {
     && counts.every((count) => count <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount);
 }
 
+const MAX_RESULT_SNAPSHOT_DEPTH = 32;
+const MAX_RESULT_SNAPSHOT_NODES = 100_000;
+const SNAPSHOT_FAILURE = Symbol("agent-tool-snapshot-failure");
+
+type SnapshotValue = unknown | typeof SNAPSHOT_FAILURE;
+
+/**
+ * Materialize one immutable, plain-data view of an adapter result. Reading an
+ * adapter result directly during validation, hashing, or protection can make
+ * those checks observe different values when the result contains an accessor.
+ * Descriptors let this preflight reject accessors without invoking them.
+ */
+function snapshotAgentToolResult(value: unknown): AgentToolResult | null {
+  let nodes = 0;
+  let bytes = 0;
+  const active = new WeakSet<object>();
+
+  function account(amount: number): boolean {
+    if (!Number.isSafeInteger(amount) || amount < 0) return false;
+    bytes += amount;
+    return bytes <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes;
+  }
+
+  function primitive(current: unknown): SnapshotValue {
+    if (current === null) return account(4) ? null : SNAPSHOT_FAILURE;
+    if (typeof current === "string") {
+      if (current.length > AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes) return SNAPSHOT_FAILURE;
+      try {
+        const encoded = JSON.stringify(current);
+        return typeof encoded === "string" && account(utf8Bytes(encoded))
+          ? current
+          : SNAPSHOT_FAILURE;
+      } catch {
+        return SNAPSHOT_FAILURE;
+      }
+    }
+    if (typeof current === "boolean") return account(current ? 4 : 5) ? current : SNAPSHOT_FAILURE;
+    if (typeof current === "number") {
+      if (!Number.isFinite(current)) return SNAPSHOT_FAILURE;
+      const encoded = JSON.stringify(current);
+      return typeof encoded === "string" && account(utf8Bytes(encoded))
+        ? current
+        : SNAPSHOT_FAILURE;
+    }
+    return SNAPSHOT_FAILURE;
+  }
+
+  function visit(current: unknown, depth: number): SnapshotValue {
+    if (depth > MAX_RESULT_SNAPSHOT_DEPTH) return SNAPSHOT_FAILURE;
+    if (current === null || typeof current !== "object") return primitive(current);
+    if (active.has(current)) return SNAPSHOT_FAILURE;
+    if (++nodes > MAX_RESULT_SNAPSHOT_NODES || !account(1)) return SNAPSHOT_FAILURE;
+    active.add(current);
+    try {
+      let prototype: object | null;
+      let descriptors: PropertyDescriptorMap;
+      try {
+        prototype = Object.getPrototypeOf(current);
+        descriptors = Object.getOwnPropertyDescriptors(current);
+      } catch {
+        return SNAPSHOT_FAILURE;
+      }
+      if (prototype !== null && prototype !== Object.prototype
+        && prototype !== Array.prototype) {
+        return SNAPSHOT_FAILURE;
+      }
+
+      const keys = Reflect.ownKeys(descriptors);
+      if (keys.some((key) => typeof key !== "string")) return SNAPSHOT_FAILURE;
+      if (Array.isArray(current)) {
+        if (prototype !== Array.prototype) return SNAPSHOT_FAILURE;
+        const lengthDescriptor = descriptors.length;
+        if (!lengthDescriptor
+          || lengthDescriptor.get !== undefined
+          || lengthDescriptor.set !== undefined
+          || !Object.hasOwn(lengthDescriptor, "value")
+          || !Number.isSafeInteger(lengthDescriptor.value)
+          || lengthDescriptor.value < 0
+          || lengthDescriptor.value > AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes) {
+          return SNAPSHOT_FAILURE;
+        }
+        const clone: unknown[] = new Array(lengthDescriptor.value);
+        if (!account(2)) return SNAPSHOT_FAILURE;
+        for (const key of keys) {
+          if (typeof key !== "string") return SNAPSHOT_FAILURE;
+          if (key === "length") continue;
+          if (!/^\d+$/.test(key)) return SNAPSHOT_FAILURE;
+          const index = Number(key);
+          if (!Number.isSafeInteger(index)
+            || index < 0
+            || index >= lengthDescriptor.value
+            || String(index) !== key) {
+            return SNAPSHOT_FAILURE;
+          }
+          const descriptor = descriptors[key];
+          if (!descriptor
+            || !descriptor.enumerable
+            || descriptor.get !== undefined
+            || descriptor.set !== undefined
+            || !Object.hasOwn(descriptor, "value")) {
+            return SNAPSHOT_FAILURE;
+          }
+          if (!account(1)) return SNAPSHOT_FAILURE;
+          const child = visit(descriptor.value, depth + 1);
+          if (child === SNAPSHOT_FAILURE) return SNAPSHOT_FAILURE;
+          clone[index] = child;
+        }
+        return clone;
+      }
+
+      if (prototype !== null && prototype !== Object.prototype) return SNAPSHOT_FAILURE;
+      const clone = Object.create(null) as Record<string, unknown>;
+      if (!account(2)) return SNAPSHOT_FAILURE;
+      for (const key of keys) {
+        if (typeof key !== "string") return SNAPSHOT_FAILURE;
+        const descriptor = descriptors[key];
+        if (!descriptor
+          || !descriptor.enumerable
+          || descriptor.get !== undefined
+          || descriptor.set !== undefined
+          || !Object.hasOwn(descriptor, "value")) {
+          return SNAPSHOT_FAILURE;
+        }
+        if (key.length > AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes
+          || !account(utf8Bytes(JSON.stringify(key)))) {
+          return SNAPSHOT_FAILURE;
+        }
+        const child = visit(descriptor.value, depth + 1);
+        if (child === SNAPSHOT_FAILURE) return SNAPSHOT_FAILURE;
+        Object.defineProperty(clone, key, {
+          value: child,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+      return clone;
+    } finally {
+      active.delete(current);
+    }
+  }
+
+  const snapshot = visit(value, 0);
+  return snapshot === SNAPSHOT_FAILURE || !isRecord(snapshot)
+    ? null
+    : snapshot as AgentToolResult;
+}
+
 const MAX_SECRET_KEY_SCAN_DEPTH = 32;
 const MAX_SECRET_KEY_SCAN_NODES = 100_000;
 
@@ -611,10 +759,27 @@ export function createFinancialOverviewToolGateway({
     return replaySubmission(caller);
   }
 
+  function persistUnknownSafely(record: AgentToolExecutionRecord): AgentToolSubmission {
+    try {
+      return persistSubmission(record);
+    } catch {
+      // A malformed terminal row must not turn a bounded tool failure into an
+      // outward store exception. Cache the sanitized terminal state so this
+      // gateway also replays it without retrying the adapter.
+      records.set(`${record.runId}:${record.requestId}`, record);
+      return replaySubmission(record);
+    }
+  }
+
   function existingRecord(runId: string, requestId: string): AgentToolExecutionRecord | null {
     const key = `${runId}:${requestId}`;
     const cached = records.get(key) ?? null;
-    const durable = runStore.getToolRequest?.(runId, requestId) ?? null;
+    let durable: AgentToolExecutionRecord | null = null;
+    try {
+      durable = runStore.getToolRequest?.(runId, requestId) ?? null;
+    } catch {
+      return cached;
+    }
     if (durable && durable.outcome !== "not-dispatched") {
       records.set(key, durable);
       return durable;
@@ -802,10 +967,13 @@ export function createFinancialOverviewToolGateway({
               timeout = setTimeout(() => reject(new Error("tool-execution-timeout")), timeoutMs);
             }),
           ]);
-          if (!validateAgentToolResult(adapterResult) || !resultWithinResourceLimits(adapterResult)) {
+          const snapshot = snapshotAgentToolResult(adapterResult);
+          if (!snapshot
+            || !validateAgentToolResult(snapshot)
+            || !resultWithinResourceLimits(snapshot)) {
             throw new Error("invalid-tool-result");
           }
-          if (containsSecretObjectKey(adapterResult, secretBoundary)) {
+          if (containsSecretObjectKey(snapshot, secretBoundary)) {
             throw new Error("secret-key-detected");
           }
           if (!ledgerBefore || !sameLedgerSnapshot(ledgerBefore, ledgerResourceSnapshot(ledgerDir, snapshotDb))) {
@@ -814,7 +982,7 @@ export function createFinancialOverviewToolGateway({
           const settlement: AgentToolSettlement = runStore.getRun(proposal.runId)?.phase === "cancelled"
             ? "cancelled-in-flight" as const
             : "normal";
-          const protectedResult = protect("agent-tool-result", adapterResult as unknown as Record<string, unknown>) as unknown as AgentToolResult;
+          const protectedResult = protect("agent-tool-result", snapshot as unknown as Record<string, unknown>) as unknown as AgentToolResult;
           const record = {
             runId: proposal.runId,
             requestId: proposal.requestId,
@@ -841,7 +1009,7 @@ export function createFinancialOverviewToolGateway({
               ? "cancelled-in-flight"
               : "normal") as AgentToolSettlement,
           };
-          return persistSubmission(record);
+          return persistUnknownSafely(record);
         } finally {
           if (timeout) clearTimeout(timeout);
           snapshotDb?.close();

--- a/src/lib/agent/server/tool-gateway.ts
+++ b/src/lib/agent/server/tool-gateway.ts
@@ -1,0 +1,758 @@
+import { existsSync, statSync } from "node:fs";
+import { hashBytes, stableStringify } from "../../../ledger/content-hash.ts";
+import { ledgerSqlitePath, openLedgerDatabase, type LedgerDatabase } from "../../../ledger/db/client.ts";
+import { buildFinancialModel } from "../../../ledger/financial-dashboard-model.ts";
+import { TYPED_STATEMENT_TABLES, type FinancialModel } from "../../../ledger/financial-dashboard-types.ts";
+import {
+  createAgentSecretBoundaryGate,
+  type AgentRunStore,
+  type SecretBoundaryDependencies,
+  type SecretBoundaryGate,
+} from "./harness.ts";
+
+export const AGENT_TOOL_PROPOSAL_VERSION = "agent-tool-proposal.v1" as const;
+export const AGENT_TOOL_DECISION_VERSION = "agent-tool-decision.v1" as const;
+export const AGENT_TOOL_RESULT_VERSION = "agent-tool-result.v1" as const;
+export const AGENT_TOOL_REFERENCE_VERSION = "immutable-result-ref.v1" as const;
+export const FINANCIAL_OVERVIEW_AGGREGATE_VERSION = "financial-overview.aggregate.v1" as const;
+
+/** Quantitative host-owned limits for the first allowlisted tool. */
+export const AGENT_TOOL_RESOURCE_LIMITS = Object.freeze({
+  maxLedgerPathBytes: 4_096,
+  maxLedgerBytes: 64 * 1024 * 1024,
+  maxLedgerRows: 500_000,
+  maxProposalBytes: 16_384,
+  maxAggregateBytes: 262_144,
+  maxCurrencyBuckets: 128,
+  maxAggregateCount: 1_000_000,
+});
+export const AGENT_TOOL_DEFAULT_EXECUTION_TIMEOUT_MS = 5_000;
+
+export const AGENT_TOOL_OUTCOMES = [
+  "not-dispatched",
+  "completed",
+  "outcome-unknown",
+] as const;
+export type AgentToolOutcome = (typeof AGENT_TOOL_OUTCOMES)[number];
+
+export const AGENT_TOOL_DECISION_REASONS = [
+  "allowed",
+  "malformed-proposal",
+  "tool-not-allowlisted",
+  "schema-invalid",
+  "permission-denied",
+  "sensitivity-denied",
+  "resource-denied",
+  "run-authority-denied",
+  "credential-boundary",
+  "secret-boundary-violation",
+] as const;
+export type AgentToolDecisionReason = (typeof AGENT_TOOL_DECISION_REASONS)[number];
+
+export type ReadFinancialOverviewInput = Record<string, never>;
+
+export type AgentToolProposal = {
+  proposalVersion: typeof AGENT_TOOL_PROPOSAL_VERSION;
+  requestId: string;
+  runId: string;
+  toolName: "read_financial_overview";
+  input: ReadFinancialOverviewInput;
+  permission: "financial.overview.read";
+  sensitivity: "derived-financial";
+  resource: "ledger.overview";
+  runAuthority: string;
+};
+
+export type AgentToolResultReference = {
+  referenceVersion: typeof AGENT_TOOL_REFERENCE_VERSION;
+  value: string;
+};
+
+export type AgentToolDecision = {
+  decisionVersion: typeof AGENT_TOOL_DECISION_VERSION;
+  allowed: boolean;
+  reason: AgentToolDecisionReason;
+};
+
+export type FinancialOverviewAggregate = {
+  aggregateVersion: typeof FINANCIAL_OVERVIEW_AGGREGATE_VERSION;
+  snapshot: {
+    snapshotId: string;
+    importedAt: string | null;
+    snapshotDate: string | null;
+  };
+  totalsByCurrency: Record<string, {
+    assets: number;
+    liabilities: number;
+    net: number;
+  }>;
+  overview: {
+    cashAssets: Record<string, number>;
+    foreignAssets: Record<string, number>;
+    investmentAssets: Record<string, number>;
+    unbilledCreditCard: Record<string, number>;
+    loans: Record<string, number>;
+    netAssets: Record<string, number>;
+  };
+  counts: {
+    normalizedTransactions: number;
+    assetPositions: number;
+    includedPositions: number;
+    assetSnapshots: number;
+  };
+  quality: {
+    status: FinancialModel["quality"]["status"];
+    issueCount: number;
+  };
+};
+
+export type AgentToolResult = {
+  resultVersion: typeof AGENT_TOOL_RESULT_VERSION;
+  toolName: "read_financial_overview";
+  data: FinancialOverviewAggregate;
+  reference: AgentToolResultReference;
+  secretFields: readonly [];
+};
+
+export const AGENT_TOOL_SETTLEMENTS = ["normal", "cancelled-in-flight"] as const;
+export type AgentToolSettlement = (typeof AGENT_TOOL_SETTLEMENTS)[number];
+
+export type AgentToolExecutionRecord = {
+  runId: string;
+  requestId: string;
+  proposal: AgentToolProposal;
+  decision: AgentToolDecision;
+  outcome: AgentToolOutcome;
+  result: AgentToolResult | null;
+  resultReference: AgentToolResultReference | null;
+  occurredAt: string;
+  settlement?: AgentToolSettlement;
+};
+
+export type AgentToolSubmission = {
+  requestId: string;
+  decision: AgentToolDecision;
+  outcome: AgentToolOutcome;
+  result: AgentToolResult | null;
+  resultReference: AgentToolResultReference | null;
+  settlement: AgentToolSettlement;
+};
+
+export type AgentProviderToolGateway = {
+  submit(proposal: unknown): Promise<AgentToolSubmission>;
+};
+
+type FinancialOverviewAdapter = (input: {
+  ledgerDir: string;
+  proposal: AgentToolProposal;
+}) => Promise<AgentToolResult>;
+
+const TOP_LEVEL_PROPOSAL_KEYS = [
+  "proposalVersion",
+  "requestId",
+  "runId",
+  "toolName",
+  "input",
+  "permission",
+  "sensitivity",
+  "resource",
+  "runAuthority",
+] as const;
+const INPUT_KEYS: readonly string[] = [];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]) {
+  return Object.keys(value).length === keys.length
+    && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function hasCredentialKey(key: string) {
+  return /(?:credential|password|passcode|secret|token|cookie|api[-_]?key|authorization)/i.test(key);
+}
+
+function containsCredentialMaterial(value: unknown, key = ""): boolean {
+  if (hasCredentialKey(key)) return value !== null && value !== undefined && value !== "";
+  if (typeof value === "string") return false;
+  if (Array.isArray(value)) return value.some((item) => containsCredentialMaterial(item));
+  if (isRecord(value)) {
+    return Object.entries(value).some(([childKey, childValue]) =>
+      containsCredentialMaterial(childValue, childKey));
+  }
+  return false;
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function safeIdentifier(value: unknown, fallback: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > 200) return fallback;
+  if (containsCredentialMaterial(value)) return "redacted";
+  return value;
+}
+
+export function agentToolProposalIdentity(proposal: AgentToolProposal): string {
+  return hashBytes(stableStringify(proposal));
+}
+
+export function createReadFinancialOverviewProposal(
+  runId: string,
+  requestId: string,
+): AgentToolProposal {
+  return {
+    proposalVersion: AGENT_TOOL_PROPOSAL_VERSION,
+    requestId,
+    runId,
+    toolName: "read_financial_overview",
+    input: {},
+    permission: "financial.overview.read",
+    sensitivity: "derived-financial",
+    resource: "ledger.overview",
+    runAuthority: runId,
+  };
+}
+
+export function validateAgentToolProposal(value: unknown):
+  | { value: AgentToolProposal; reason: null }
+  | { value: null; reason: Exclude<AgentToolDecisionReason, "allowed"> } {
+  if (!isRecord(value) || !hasExactKeys(value, TOP_LEVEL_PROPOSAL_KEYS)) {
+    return { value: null, reason: "malformed-proposal" };
+  }
+  if (containsCredentialMaterial(value)) {
+    return { value: null, reason: "credential-boundary" };
+  }
+  if (value.proposalVersion !== AGENT_TOOL_PROPOSAL_VERSION
+    || typeof value.requestId !== "string"
+    || value.requestId.length === 0
+    || value.requestId.length > 200
+    || typeof value.runId !== "string"
+    || value.runId.length === 0
+    || value.runId.length > 200) {
+    return { value: null, reason: "schema-invalid" };
+  }
+  if (value.toolName !== "read_financial_overview") {
+    return { value: null, reason: "tool-not-allowlisted" };
+  }
+  if (!isRecord(value.input) || !hasExactKeys(value.input, INPUT_KEYS)) {
+    return { value: null, reason: "schema-invalid" };
+  }
+  if (value.permission !== "financial.overview.read") {
+    return { value: null, reason: "permission-denied" };
+  }
+  if (value.sensitivity !== "derived-financial") {
+    return { value: null, reason: "sensitivity-denied" };
+  }
+  if (value.resource !== "ledger.overview") {
+    return { value: null, reason: "resource-denied" };
+  }
+  if (typeof value.runAuthority !== "string" || value.runAuthority.length === 0) {
+    return { value: null, reason: "run-authority-denied" };
+  }
+  return { value: value as AgentToolProposal, reason: null };
+}
+
+function emptyDecision(reason: AgentToolDecisionReason): AgentToolDecision {
+  return {
+    decisionVersion: AGENT_TOOL_DECISION_VERSION,
+    allowed: reason === "allowed",
+    reason,
+  };
+}
+
+function resultReference(data: FinancialOverviewAggregate): AgentToolResultReference {
+  return {
+    referenceVersion: AGENT_TOOL_REFERENCE_VERSION,
+    value: `${AGENT_TOOL_REFERENCE_VERSION}:${hashBytes(stableStringify(data))}`,
+  };
+}
+
+function exactRecordKeys(value: Record<string, unknown>, keys: readonly string[]) {
+  return Object.keys(value).length === keys.length
+    && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function isFiniteNumberRecord(value: unknown): value is Record<string, number> {
+  return isRecord(value)
+    && Object.values(value).every((item) => typeof item === "number" && Number.isFinite(item));
+}
+
+export function validateAgentToolResult(value: unknown): value is AgentToolResult {
+  if (!isRecord(value)
+    || !exactRecordKeys(value, ["resultVersion", "toolName", "data", "reference", "secretFields"])
+    || value.resultVersion !== AGENT_TOOL_RESULT_VERSION
+    || value.toolName !== "read_financial_overview"
+    || !Array.isArray(value.secretFields)
+    || value.secretFields.length !== 0
+    || !isRecord(value.reference)
+    || value.reference.referenceVersion !== AGENT_TOOL_REFERENCE_VERSION
+    || typeof value.reference.value !== "string"
+    || !isRecord(value.data)
+    || !exactRecordKeys(value.data, ["aggregateVersion", "snapshot", "totalsByCurrency", "overview", "counts", "quality"])
+    || value.data.aggregateVersion !== FINANCIAL_OVERVIEW_AGGREGATE_VERSION
+    || !isRecord(value.data.snapshot)
+    || !exactRecordKeys(value.data.snapshot, ["snapshotId", "importedAt", "snapshotDate"])
+    || typeof value.data.snapshot.snapshotId !== "string"
+    || (value.data.snapshot.importedAt !== null && typeof value.data.snapshot.importedAt !== "string")
+    || (value.data.snapshot.snapshotDate !== null && typeof value.data.snapshot.snapshotDate !== "string")
+    || !isRecord(value.data.totalsByCurrency)
+    || Object.values(value.data.totalsByCurrency).some((totals) =>
+      !isRecord(totals)
+      || !exactRecordKeys(totals, ["assets", "liabilities", "net"])
+      || Object.values(totals).some((item) => typeof item !== "number" || !Number.isFinite(item)))
+    || !isRecord(value.data.overview)
+    || !exactRecordKeys(value.data.overview, [
+      "cashAssets", "foreignAssets", "investmentAssets", "unbilledCreditCard", "loans", "netAssets",
+    ])
+    || !Object.values(value.data.overview).every(isFiniteNumberRecord)
+    || !isRecord(value.data.counts)
+    || !exactRecordKeys(value.data.counts, ["normalizedTransactions", "assetPositions", "includedPositions", "assetSnapshots"])
+    || Object.values(value.data.counts).some((item) => !Number.isSafeInteger(item) || (item as number) < 0)
+    || !isRecord(value.data.quality)
+    || !exactRecordKeys(value.data.quality, ["status", "issueCount"])
+    || !["pass", "warn", "fail"].includes(value.data.quality.status as string)
+    || !Number.isSafeInteger(value.data.quality.issueCount)
+    || (value.data.quality.issueCount as number) < 0) {
+    return false;
+  }
+  const canonical = resultReference(value.data as unknown as FinancialOverviewAggregate);
+  return value.reference.value === canonical.value;
+}
+
+function aggregateFromModel(model: FinancialModel): FinancialOverviewAggregate {
+  const snapshots = model.snapshotHistory.snapshots;
+  const latestSnapshot = snapshots.at(-1) ?? null;
+  const snapshotIdentity = hashBytes(stableStringify(snapshots.map((snapshot) => ({
+    importRunId: snapshot.importRunId,
+    importedAt: snapshot.importedAt,
+    snapshotDate: snapshot.snapshotDate,
+  }))));
+  const overview = model.dashboard.overview;
+  const totalsByCurrency = Object.fromEntries(
+    Object.entries(model.totals.includedByCurrency)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([currency, totals]) => [currency, {
+        assets: totals.assets,
+        liabilities: totals.liabilities,
+        net: totals.net,
+      }]),
+  );
+  const data: FinancialOverviewAggregate = {
+    aggregateVersion: FINANCIAL_OVERVIEW_AGGREGATE_VERSION,
+    snapshot: {
+      snapshotId: `${FINANCIAL_OVERVIEW_AGGREGATE_VERSION}:${snapshotIdentity}`,
+      importedAt: latestSnapshot?.importedAt ?? null,
+      snapshotDate: latestSnapshot?.snapshotDate ?? null,
+    },
+    totalsByCurrency,
+    overview: {
+      cashAssets: { ...overview.assets.totalTwdAssets },
+      foreignAssets: { ...overview.assets.totalForeignAssets },
+      investmentAssets: { ...overview.assets.totalInvestmentAssets },
+      unbilledCreditCard: { ...overview.liabilities.unbilledCreditCardAmount },
+      loans: { ...overview.liabilities.loanTotalBalance },
+      netAssets: { ...overview.netAssets },
+    },
+    counts: {
+      normalizedTransactions: model.counts.normalizedTransactions,
+      assetPositions: model.counts.assetPositions,
+      includedPositions: model.counts.includedPositions,
+      assetSnapshots: model.counts.assetSnapshots,
+    },
+    quality: {
+      status: model.quality.status,
+      issueCount: model.quality.issues.length,
+    },
+  };
+  return data;
+}
+
+export async function readFinancialOverviewResult(
+  ledgerDir: string,
+  buildModel: (input: { ledgerDir: string; outputDir: string }) => Promise<FinancialModel> = buildFinancialModel,
+): Promise<AgentToolResult> {
+  const model = await buildModel({ ledgerDir, outputDir: ledgerDir });
+  if (!modelWithinResourceLimits(model)) throw new Error("tool-resource-limit-exceeded");
+  const data = aggregateFromModel(model);
+  return {
+    resultVersion: AGENT_TOOL_RESULT_VERSION,
+    toolName: "read_financial_overview",
+    data,
+    reference: resultReference(data),
+    secretFields: [],
+  };
+}
+
+function replaySubmission(record: AgentToolExecutionRecord): AgentToolSubmission {
+  return {
+    requestId: record.requestId,
+    decision: record.decision,
+    outcome: record.outcome,
+    result: record.result,
+    resultReference: record.resultReference,
+    settlement: record.settlement ?? "normal",
+  };
+}
+
+const TOOL_OUTCOME_RANK: Record<AgentToolOutcome, number> = {
+  "not-dispatched": 1,
+  "outcome-unknown": 2,
+  completed: 3,
+};
+
+function isMoreFinalOutcome(next: AgentToolOutcome, current: AgentToolOutcome): boolean {
+  return TOOL_OUTCOME_RANK[next] > TOOL_OUTCOME_RANK[current];
+}
+
+function resultWithinResourceLimits(result: AgentToolResult): boolean {
+  const currencyCount = Object.keys(result.data.totalsByCurrency).length
+    + Object.values(result.data.overview).reduce((total, bucket) => total + Object.keys(bucket).length, 0);
+  const counts = Object.values(result.data.counts);
+  return utf8Bytes(stableStringify(result)) <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateBytes
+    && currencyCount <= AGENT_TOOL_RESOURCE_LIMITS.maxCurrencyBuckets
+    && counts.every((count) => count <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount);
+}
+
+function modelWithinResourceLimits(model: FinancialModel): boolean {
+  return model.counts.normalizedTransactions <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount
+    && model.counts.assetPositions <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount
+    && model.counts.assetSnapshots <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount
+    && model.normalizedTransactions.length <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount
+    && model.assetPositions.length <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount
+    && model.snapshotHistory.snapshots.length <= AGENT_TOOL_RESOURCE_LIMITS.maxAggregateCount;
+}
+
+type LedgerResourceSnapshot = {
+  fileSignature: string;
+  dataVersion: number | null;
+  totalBytes: number;
+  totalRows: number;
+};
+
+function ledgerResourceSnapshot(
+  ledgerDir: string,
+  snapshotDb?: LedgerDatabase,
+): LedgerResourceSnapshot | null {
+  const sqlitePath = ledgerSqlitePath(ledgerDir);
+  try {
+    const files = [sqlitePath, `${sqlitePath}-wal`, `${sqlitePath}-shm`];
+    const fileStats = files.map((file) => {
+      try {
+        const stats = statSync(file);
+        return { file, size: stats.size, mtimeMs: stats.mtimeMs };
+      } catch {
+        return { file, size: 0, mtimeMs: null };
+      }
+    });
+    const totalBytes = fileStats.reduce((total, file) => total + file.size, 0);
+    if (totalBytes > AGENT_TOOL_RESOURCE_LIMITS.maxLedgerBytes) return null;
+    if (!existsSync(sqlitePath)) {
+      return totalBytes === 0
+        ? { fileSignature: "missing", dataVersion: null, totalBytes: 0, totalRows: 0 }
+        : null;
+    }
+    const fileSignature = fileStats.map((file) =>
+      `${file.file}:${file.size}:${file.mtimeMs === null ? "missing" : file.mtimeMs}`).join("|");
+    const db = snapshotDb ?? openLedgerDatabase(ledgerDir, { readOnly: true });
+    try {
+      const dataVersionRow = db.prepare("PRAGMA data_version").get() as { data_version?: number };
+      const tables = ["import_runs", "source_files", ...TYPED_STATEMENT_TABLES] as const;
+      const totalRows = tables.reduce((total, table) => {
+        const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number };
+        return total + Number(row.count);
+      }, 0);
+      return {
+        fileSignature,
+        dataVersion: typeof dataVersionRow.data_version === "number"
+          ? dataVersionRow.data_version
+          : null,
+        totalBytes,
+        totalRows,
+      };
+    } finally {
+      if (!snapshotDb) db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function ledgerSnapshotWithinResourceLimits(snapshot: LedgerResourceSnapshot | null): boolean {
+  return snapshot !== null
+    && snapshot.totalBytes <= AGENT_TOOL_RESOURCE_LIMITS.maxLedgerBytes
+    && snapshot.totalRows <= AGENT_TOOL_RESOURCE_LIMITS.maxLedgerRows;
+}
+
+function sameLedgerSnapshot(
+  before: LedgerResourceSnapshot,
+  after: LedgerResourceSnapshot | null,
+): boolean {
+  return after !== null
+    && before.fileSignature === after.fileSignature
+    && before.totalBytes === after.totalBytes
+    && (before.dataVersion === null
+      || after.dataVersion === null
+      || before.dataVersion === after.dataVersion)
+    && before.totalRows === after.totalRows;
+}
+
+export function createFinancialOverviewToolGateway({
+  ledgerDir = process.env.LEDGER_DIR ?? "data/ledger",
+  runStore,
+  clock = { now: () => new Date().toISOString() },
+  adapter = ({ ledgerDir: root }) => readFinancialOverviewResult(root),
+  executionTimeoutMs = AGENT_TOOL_DEFAULT_EXECUTION_TIMEOUT_MS,
+  secretValues,
+  additionalSecretValues,
+  secretBoundaryDependencies,
+}: {
+  ledgerDir?: string;
+  runStore: AgentRunStore;
+  clock?: { now(): string };
+  adapter?: FinancialOverviewAdapter;
+  executionTimeoutMs?: number;
+  secretValues?: readonly string[];
+  additionalSecretValues?: readonly string[];
+  secretBoundaryDependencies?: Partial<SecretBoundaryDependencies>;
+}): AgentProviderToolGateway {
+  const secretBoundary: SecretBoundaryGate = createAgentSecretBoundaryGate({
+    secretValues,
+    additionalSecretValues,
+    dependencies: secretBoundaryDependencies,
+  });
+  const records = new Map<string, AgentToolExecutionRecord>();
+  const inFlight = new Map<string, { identity: string; submission: Promise<AgentToolSubmission> }>();
+
+  function protect<T extends Record<string, unknown>>(schema: string, value: T) {
+    const protectedValue = secretBoundary.protectRecord("sqlite-persistence", schema, value);
+    if (protectedValue.failure) {
+      throw new Error("SECRET_BOUNDARY_VIOLATION surface=sqlite-persistence reason=authentication-secret-detected");
+    }
+    return protectedValue.value as T;
+  }
+
+  function persist(record: AgentToolExecutionRecord): AgentToolExecutionRecord {
+    const protectedRecord = protect("agent-tool-outcome", record as unknown as Record<string, unknown>);
+    const next = protectedRecord as unknown as AgentToolExecutionRecord;
+    const key = `${next.runId}:${next.requestId}`;
+    if (!runStore.getRun(next.runId)) return next;
+    const existing = records.get(key) ?? runStore.getToolRequest?.(next.runId, next.requestId) ?? null;
+    const identityDiffers = existing
+      && agentToolProposalIdentity(existing.proposal) !== agentToolProposalIdentity(next.proposal);
+    if (identityDiffers && existing?.outcome !== "not-dispatched") {
+      records.set(key, existing);
+      return next;
+    }
+    if (existing && !isMoreFinalOutcome(next.outcome, existing.outcome)) {
+      records.set(key, existing);
+      return existing;
+    }
+    runStore.recordToolRequest?.(next);
+    const persisted = runStore.getToolRequest?.(next.runId, next.requestId) ?? next;
+    records.set(key, persisted);
+    return persisted;
+  }
+
+  return {
+    async submit(rawProposal) {
+      let containsSecret = false;
+      try {
+        containsSecret = containsCredentialMaterial(rawProposal);
+      } catch {
+        containsSecret = true;
+      }
+      const exactProposal = isRecord(rawProposal) && hasExactKeys(rawProposal, TOP_LEVEL_PROPOSAL_KEYS);
+      let proposalHasSecret = false;
+      if (exactProposal) {
+        try {
+          const protectedProposal = secretBoundary.protectRecord(
+            "diagnostic-export",
+            "agent-tool-proposal",
+            rawProposal,
+          );
+          proposalHasSecret = Boolean(protectedProposal.failure) || containsSecret;
+        } catch {
+          proposalHasSecret = true;
+        }
+      }
+      containsSecret ||= proposalHasSecret;
+      let serializedProposal = "";
+      try {
+        const serialized = stableStringify(rawProposal);
+        serializedProposal = typeof serialized === "string" ? serialized : String(serialized);
+      } catch {
+        serializedProposal = "[unserializable]";
+      }
+      const proposalTooLarge = utf8Bytes(serializedProposal) > AGENT_TOOL_RESOURCE_LIMITS.maxProposalBytes;
+      const validation = proposalTooLarge
+        ? { value: null, reason: "resource-denied" as const }
+        : proposalHasSecret
+          ? { value: null, reason: "credential-boundary" as const }
+          : validateAgentToolProposal(rawProposal);
+      const proposal = validation.value;
+      const rawRunId = isRecord(rawProposal) ? rawProposal.runId : undefined;
+      const rawRequestId = isRecord(rawProposal) ? rawProposal.requestId : undefined;
+      const runId = containsSecret ? "redacted" : safeIdentifier(rawRunId, "unknown");
+      const requestId = containsSecret
+        ? "redacted"
+        : safeIdentifier(
+          rawRequestId,
+          `invalid-${hashBytes(serializedProposal).slice(0, 16)}`,
+        );
+
+      if (!proposal) {
+        const decision = emptyDecision(validation.reason);
+        const record = {
+          runId,
+          requestId,
+          proposal: {
+            ...createReadFinancialOverviewProposal(runId, requestId),
+            runAuthority: "invalid",
+          },
+          decision,
+          outcome: "not-dispatched" as const,
+          result: null,
+          resultReference: null,
+          occurredAt: clock.now(),
+        };
+        return replaySubmission(persist(record));
+      }
+
+      const run = runStore.getRun(proposal.runId);
+      const active = Boolean(run && run.phase === "running" && proposal.runAuthority === proposal.runId);
+      const existing = records.get(`${proposal.runId}:${proposal.requestId}`)
+        ?? runStore.getToolRequest?.(proposal.runId, proposal.requestId)
+        ?? null;
+      if (existing) {
+        if (active && agentToolProposalIdentity(existing.proposal) === agentToolProposalIdentity(proposal)) {
+          if (existing.outcome !== "not-dispatched") {
+            records.set(`${proposal.runId}:${proposal.requestId}`, existing);
+            return replaySubmission(existing);
+          }
+        } else if (existing.outcome !== "not-dispatched") {
+          const decision = emptyDecision(active ? "schema-invalid" : "run-authority-denied");
+          return replaySubmission({
+            runId: proposal.runId,
+            requestId: proposal.requestId,
+            proposal,
+            decision,
+            outcome: "not-dispatched",
+            result: null,
+            resultReference: null,
+            occurredAt: clock.now(),
+          });
+        }
+      }
+
+      const reason: AgentToolDecisionReason = !active
+        ? "run-authority-denied"
+        : "allowed";
+      const decision = emptyDecision(reason);
+      if (!decision.allowed) {
+        const record = {
+          runId: proposal.runId,
+          requestId: proposal.requestId,
+          proposal,
+          decision,
+          outcome: "not-dispatched" as const,
+          result: null,
+          resultReference: null,
+          occurredAt: clock.now(),
+        };
+        return replaySubmission(persist(record));
+      }
+      const key = `${proposal.runId}:${proposal.requestId}`;
+      const identity = agentToolProposalIdentity(proposal);
+      const concurrent = inFlight.get(key);
+      if (concurrent?.identity === identity) return concurrent.submission;
+
+      let snapshotDb: LedgerDatabase | undefined;
+      if (existsSync(ledgerSqlitePath(ledgerDir))) {
+        try {
+          snapshotDb = openLedgerDatabase(ledgerDir, { readOnly: true });
+        } catch {
+          snapshotDb = undefined;
+        }
+      }
+      const ledgerBefore = ledgerResourceSnapshot(ledgerDir, snapshotDb);
+      if (utf8Bytes(ledgerDir) > AGENT_TOOL_RESOURCE_LIMITS.maxLedgerPathBytes
+        || !ledgerSnapshotWithinResourceLimits(ledgerBefore)) {
+        snapshotDb?.close();
+        const record = {
+          runId: proposal.runId,
+          requestId: proposal.requestId,
+          proposal,
+          decision: emptyDecision("resource-denied"),
+          outcome: "not-dispatched" as const,
+          result: null,
+          resultReference: null,
+          occurredAt: clock.now(),
+        };
+        return replaySubmission(persist(record));
+      }
+
+      const dispatch = (async (): Promise<AgentToolSubmission> => {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const timeoutMs = Number.isFinite(executionTimeoutMs) && executionTimeoutMs > 0
+            ? executionTimeoutMs
+            : AGENT_TOOL_DEFAULT_EXECUTION_TIMEOUT_MS;
+          const adapterResult = await Promise.race([
+            adapter({ ledgerDir, proposal }),
+            new Promise<never>((_, reject) => {
+              timeout = setTimeout(() => reject(new Error("tool-execution-timeout")), timeoutMs);
+            }),
+          ]);
+          if (!validateAgentToolResult(adapterResult) || !resultWithinResourceLimits(adapterResult)) {
+            throw new Error("invalid-tool-result");
+          }
+          if (!ledgerBefore || !sameLedgerSnapshot(ledgerBefore, ledgerResourceSnapshot(ledgerDir, snapshotDb))) {
+            throw new Error("ledger-changed-during-tool-read");
+          }
+          const settlement: AgentToolSettlement = runStore.getRun(proposal.runId)?.phase === "cancelled"
+            ? "cancelled-in-flight" as const
+            : "normal";
+          const protectedResult = protect("agent-tool-result", adapterResult as unknown as Record<string, unknown>) as unknown as AgentToolResult;
+          const record = {
+            runId: proposal.runId,
+            requestId: proposal.requestId,
+            proposal,
+            decision,
+            outcome: "completed" as const,
+            result: protectedResult,
+            resultReference: protectedResult.reference,
+            occurredAt: clock.now(),
+            settlement,
+          };
+          return replaySubmission(persist(record));
+        } catch {
+          const record = {
+            runId: proposal.runId,
+            requestId: proposal.requestId,
+            proposal,
+            decision,
+            outcome: "outcome-unknown" as const,
+            result: null,
+            resultReference: null,
+            occurredAt: clock.now(),
+            settlement: (runStore.getRun(proposal.runId)?.phase === "cancelled"
+              ? "cancelled-in-flight"
+              : "normal") as AgentToolSettlement,
+          };
+          return replaySubmission(persist(record));
+        } finally {
+          if (timeout) clearTimeout(timeout);
+          snapshotDb?.close();
+        }
+      })();
+      inFlight.set(key, { identity, submission: dispatch });
+      try {
+        return await dispatch;
+      } finally {
+        if (inFlight.get(key)?.submission === dispatch) inFlight.delete(key);
+      }
+    },
+  };
+}

--- a/src/lib/desktop/agent-api.check.ts
+++ b/src/lib/desktop/agent-api.check.ts
@@ -200,6 +200,32 @@ test("renderer projection fails closed when an Agent status contains a canary", 
   );
 });
 
+test("renderer receives only safe tool outcome state and no tool authority", () => {
+  const projected = projectAgentRunStatus({
+    runId: "run-safe-tool-state",
+    phase: "running",
+    action: { type: "cancel" },
+    startedAt: "2026-08-03T00:00:00.000Z",
+    finishedAt: null,
+    output: "",
+    toolState: {
+      outcome: "completed",
+      toolName: "read_financial_overview",
+      resultReference: "immutable-result-ref.v1:abc",
+      settlement: "normal",
+    },
+  }, createAgentSecretBoundaryGate({ secretValues: [] }));
+  assert.deepEqual(projected.toolState, {
+    outcome: "completed",
+    toolName: "read_financial_overview",
+    resultReference: "immutable-result-ref.v1:abc",
+    settlement: "normal",
+  });
+  assert.equal(Object.hasOwn(projected, "execute"), false);
+  assert.equal(Object.hasOwn(projected, "credentials"), false);
+  assert.equal(Object.hasOwn(projected, "rawRows"), false);
+});
+
 test("renderer projection reports the secret-boundary failure metadata returned by the gate", () => {
   const failureGate: SecretBoundaryGate = {
     ...createAgentSecretBoundaryGate({ secretValues: [] }),

--- a/src/lib/desktop/agent-api.ts
+++ b/src/lib/desktop/agent-api.ts
@@ -25,6 +25,12 @@ export type AgentStatusDto = {
   startedAt: string;
   finishedAt: string | null;
   output: string;
+  toolState?: {
+    outcome: "not-dispatched" | "completed" | "outcome-unknown";
+    toolName: string;
+    resultReference: string | null;
+    settlement: "normal" | "cancelled-in-flight";
+  };
 };
 
 export type AgentDesktopService = Pick<AgentHarnessService, "activate" | "startNewRun" | "status" | "cancel">;
@@ -77,6 +83,14 @@ export function projectAgentRunStatus(
     startedAt: status.startedAt,
     finishedAt: status.finishedAt,
     output: status.output,
+    ...(status.toolState ? {
+      toolState: {
+        outcome: status.toolState.outcome,
+        toolName: status.toolState.toolName,
+        resultReference: status.toolState.resultReference,
+        settlement: status.toolState.settlement,
+      },
+    } : {}),
   };
   const protectedProjection = secretBoundary.protectRecord(
     "diagnostic-export",


### PR DESCRIPTION
## What changed

Introduces the first host-gated Authorized tool request path for the agent runtime:

- adds the host-owned proposal/decision/outcome gateway and immutable outcome persistence;
- wires the financial-overview gateway through the desktop host harness;
- keeps renderer projections proposal-only and secret-boundary protected;
- records denied, completed, and outcome-unknown tool states with replay-safe lineage.

## Why

#85 needs an auditable host authority boundary so providers can propose a tool request without receiving direct execution capability, while preserving fail-closed behavior and durable run history.

## Impact

The host now owns authorization and execution of the first read-only financial overview tool. Provider-facing contracts expose proposal submission only; sensitive fields remain protected by the shared secret boundary. Existing no-tool compatibility remains available for callers that have not installed the host gateway.

## Dependencies

This change is prepared against the coordinated #75-#78 foundation and is intended to follow those issue contracts.

## Validation

- Full suite: 429 passed, 0 failed, 2 skipped
- Packaging check: 1 passed, 0 failed
- Code review: Standards PASS; Spec PASS
- Commit: 2f188b278d1ffdfcae2621c094e10647847452b9

Closes #85
