### PR TITLE
Fix Sinopac CAPTCHA click coordinate mapping

### DIFF
--- a/scripts/sinopac-captcha-click.check.mjs
+++ b/scripts/sinopac-captcha-click.check.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+
+const source = readFileSync(
+  new URL("../src/lib/automation/AutomationDashboard.svelte", import.meta.url),
+  "utf8",
+);
+const start = source.indexOf("function viewerPointFromTransformedImage");
+assert.notEqual(start, -1, "the viewer must expose a transformed-image mapping helper");
+const end = source.indexOf("\n  function floatingInputAnchor", start);
+assert.notEqual(end, -1, "the viewer mapping helper must precede its anchor helper");
+const helperSource = stripTypeScriptTypes(source.slice(start, end));
+const viewerPointFromTransformedImage = new Function(
+  `${helperSource}; return viewerPointFromTransformedImage;`,
+)();
+
+const geometry = {
+  imageRect: { left: 35.979583740234375, top: 105.109375, width: 1200.5999755859375, height: 662.3999633789062 },
+  clientWidth: 1044,
+  clientHeight: 576,
+  naturalWidth: 1366,
+  naturalHeight: 768,
+};
+
+const target = { x: 589.03125, y: 487.5, width: 122, height: 35 };
+for (const [clientX, clientY] of [[554, 526], [558, 528], [660, 553]]) {
+  const point = viewerPointFromTransformedImage({ clientX, clientY }, geometry);
+  assert.ok(point, `mapping should resolve (${clientX}, ${clientY})`);
+  assert.ok(point.x >= target.x && point.x <= target.x + target.width, `x mapping for (${clientX}, ${clientY})`);
+  assert.ok(point.y >= target.y && point.y <= target.y + target.height, `y mapping for (${clientX}, ${clientY})`);
+}
+

--- a/src/lib/automation/AutomationDashboard.svelte
+++ b/src/lib/automation/AutomationDashboard.svelte
@@ -939,39 +939,57 @@
       : null;
   }
 
+  type ViewerImageGeometry = {
+    imageRect: Pick<DOMRect, "left" | "top" | "width" | "height">;
+    clientWidth: number;
+    clientHeight: number;
+    naturalWidth: number;
+    naturalHeight: number;
+  };
+
+  function viewerPointFromTransformedImage(
+    event: Pick<PointerEvent, "clientX" | "clientY">,
+    geometry: ViewerImageGeometry,
+  ) {
+    if (
+      !geometry.naturalWidth
+      || !geometry.naturalHeight
+      || !geometry.clientWidth
+      || !geometry.clientHeight
+      || !geometry.imageRect.width
+      || !geometry.imageRect.height
+    ) return null;
+
+    const scaleX = geometry.imageRect.width / geometry.clientWidth;
+    const scaleY = geometry.imageRect.height / geometry.clientHeight;
+    if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY) || scaleX <= 0 || scaleY <= 0) return null;
+
+    const localX = (event.clientX - geometry.imageRect.left) / scaleX;
+    const localY = (event.clientY - geometry.imageRect.top) / scaleY;
+    return {
+      x: localX * (geometry.naturalWidth / geometry.clientWidth),
+      y: localY * (geometry.naturalHeight / geometry.clientHeight),
+      left: localX,
+      top: localY,
+      frameWidth: geometry.clientWidth,
+      frameHeight: geometry.clientHeight,
+    };
+  }
+
   function pointerPoint(event: Pick<PointerEvent, "clientX" | "clientY"> & { currentTarget: EventTarget | null }) {
     const image = viewerImageFromEvent(event);
     if (!image) return null;
-    const frame = image.closest(".viewer-frame") as HTMLElement | null;
-    const focus = image.closest(".viewer-focus") as HTMLElement | null;
-    const frameRect = frame?.getBoundingClientRect() ?? image.getBoundingClientRect();
+    const imageRect = image.getBoundingClientRect();
     const imageWidth = image.clientWidth;
     const imageHeight = image.clientHeight;
     if (!image.naturalWidth || !image.naturalHeight || !imageWidth || !imageHeight) return null;
-
-    const focusStyle = focus ? getComputedStyle(focus) : null;
-    const transform = focusStyle?.transform.match(/^matrix\(([^)]+)\)$/)?.[1]
-      .split(",")
-      .map(Number);
-    const scaleX = transform?.[0] && Number.isFinite(transform[0]) ? transform[0] : 1;
-    const scaleY = transform?.[3] && Number.isFinite(transform[3]) ? transform[3] : 1;
-    const transformOrigin = (focusStyle?.transformOrigin ?? "0px 0px")
-      .split(" ")
-      .map((value) => Number.parseFloat(value));
-    const originX = Number.isFinite(transformOrigin[0]) ? transformOrigin[0] : 0;
-    const originY = Number.isFinite(transformOrigin[1]) ? transformOrigin[1] : 0;
-    const imageLeft = frameRect.left + (frameRect.width - imageWidth) / 2;
-    const imageTop = frameRect.top + (frameRect.height - imageHeight) / 2;
-    const localX = (event.clientX - imageLeft - originX * (1 - scaleX)) / scaleX;
-    const localY = (event.clientY - imageTop - originY * (1 - scaleY)) / scaleY;
-    return {
-      x: localX * (image.naturalWidth / imageWidth),
-      y: localY * (image.naturalHeight / imageHeight),
-      left: localX,
-      top: localY,
-      frameWidth: imageWidth,
-      frameHeight: imageHeight,
-    };
+    return viewerPointFromTransformedImage(event, {
+      imageRect,
+      clientWidth: imageWidth,
+      clientHeight: imageHeight,
+      naturalWidth: image.naturalWidth,
+      naturalHeight: image.naturalHeight,
+    });
   }
 
   function floatingInputAnchor(point: NonNullable<ReturnType<typeof pointerPoint>>) {


### PR DESCRIPTION
## Summary

- Correct pointer-to-image coordinate mapping when the CAPTCHA image is transformed or scaled.
- Extract the mapping logic into a reusable helper with geometry validation.
- Add a regression check covering representative Sinopac CAPTCHA click coordinates.

## Testing

- Added `scripts/sinopac-captcha-click.check.mjs` regression coverage.
- Not run (not requested).