### PR TITLE
Define canonical financial semantics and transaction models

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,10 @@ _Avoid_: Canonical transaction, imported projection
 A processing execution that reads source records and produces or reconciles canonical projections. Reprocessing the same source records creates another import run, not another source capture.
 _Avoid_: Source capture, financial event
 
+**Balance observation**:
+A time-bound balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It preserves effective and collection times plus provenance; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
+_Avoid_: Current account field, transaction amount, assumed live balance
+
 **Local-first AI financial assistant**:
 An assistant that lets a person use a locally available language model to explore their trusted financial overview, learn from it, and assess trends and risks with traceable external information. Product and technical boundaries—including privacy, model providers, advice, and external-information handling—are defined by an implementation-ready specification before build work begins.
 _Avoid_: Cloud financial advisor, autonomous investment manager

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,8 +75,12 @@ A reviewable, traceable view that unifies a person's imported cash, deposits, li
 _Avoid_: Dashboard, portfolio view, financial summary
 
 **Financial account**:
-A persistent deposit or credit-card relationship represented in the trusted financial overview across source captures. When source evidence cannot reliably distinguish or join accounts, its identity remains provisional rather than being treated as verified.
+A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and a financial institution or service provider, used to organize its transactions, balances, liabilities, positions, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
 _Avoid_: Source account row, account-number hash, individual card
+
+**Financial account type**:
+The required top-level classification `depository`, `credit`, `loan`, `investment`, `other`, or `unknown`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. An optional subtype refines the product only when evidence supports it, such as `credit` with subtype `credit_card`.
+_Avoid_: Product-specific table name, workflow label, unsupported inferred subtype
 
 **Multi-currency financial account**:
 A financial account whose transactions and balance observations may carry different currencies without being split into one canonical account per currency. An optional default currency never overrides the required currency of a transaction amount or balance observation; a currency subaccount is introduced only when the source explicitly establishes its identity.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -219,20 +219,48 @@ A provenance-bearing occurrence, authorization, posting, or accounting date/time
 _Avoid_: Exact timestamp for every date, system-timezone conversion, billing-statement date
 
 **Transaction posting status**:
-The required settlement classification `pending`, `posted`, or `unknown` for a financial transaction. Missing source status remains unknown; source removal is projection lifecycle, and billing, payment, refund, or reversal semantics are not posting statuses.
-_Avoid_: Billing status, transaction kind, source removal
+The required account-ledger booking classification `pending`, `posted`, or `unknown`: pending evidence describes authorization, an expected entry, or a reserved amount not yet booked; posted evidence establishes that the Institution recorded the entry in its account ledger; and unknown is an exceptional fail-safe for indeterminate source semantics. Each Supported Source Integration defines and tests a versioned mapping per Source Record kind; billing, payment-network settlement, payment, refund, reversal, and source-removal semantics stay separate, and Taiwan `unbilled` card activity may already be posted.
+_Avoid_: Billing status, unbilled-as-pending, payment-network settlement, transaction kind, source removal
 
 **Credit card transaction detail**:
 An optional, non-independent extension of a financial transaction belonging to a `credit` / `credit_card` financial account. It holds evidence-supported credit-card specifics such as Card Instrument, `unbilled | billed | unknown` billing status, Billing Statement membership, original-currency and FX data, installment detail, and source payment status without acquiring a separate identity or lifecycle.
 _Avoid_: Credit card transaction entity, statement line, financial transaction
 
 **Transaction relation**:
-An optional, provenance-bearing directed relationship between two financial transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`. It is created only from explicit source evidence or a deterministic versioned rule, never merges or deletes either transaction, and is not inferred from source removal alone.
+An optional, provenance-bearing relationship between two Financial Transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`, created only from explicit source evidence, an explicit user assertion, or a validated uniquely deterministic rule. Relations never merge or delete transactions, have no global one-to-one constraint, and do not invent amount allocations or unsupported aggregate events.
 _Avoid_: Transaction identity merge, source removal, ambiguous match
+
+**Transaction match candidate**:
+A provenance-bearing, non-canonical proposal that Financial Transactions may be related, retaining its proposed kind, participants, supporting and contradicting evidence, and producing rule version. Similar amount, direction, date, or description may create a candidate, but it never affects identity or financial computation; confirmation creates a separate Transaction Relation while preserving the candidate and decision history.
+_Avoid_: Transaction relation, fuzzy automatic relation, implicit transfer exclusion, candidate-driven financial calculation
+
+**Pending-to-posted transaction relation**:
+A directed `pending_to_posted` Transaction Relation from a separate pending Financial Transaction to its posted Financial Transaction when explicit source linkage or a validated, versioned source-specific rule establishes the pairing. Each transaction retains its identity and evidence, an unmatched pending transaction remains independent, and similarity alone creates only a match candidate rather than a revision, merge, or reason to delete the pending transaction.
+_Avoid_: Pending-to-posted mutation, transaction revision, fuzzy confirmed relation, pending deletion
+
+**Transaction refund relation**:
+A `refund_of` Transaction Relation from a separately booked return of value to an earlier Financial Transaction that remains an economic event. A refund may be partial, and multiple refunds may refer to the same original transaction; similar descriptions, opposite directions, equal amounts, or nearby dates alone create only a match candidate.
+_Avoid_: Reversal, cancellation, original-transaction deletion, fuzzy confirmed relation
+
+**Transaction reversal relation**:
+A `reversal_of` Transaction Relation from a separately booked compensating transaction to the Financial Transaction whose economic effect it corrects or voids. It is distinct from a refund because the original event is being undone rather than followed by a later return of value; source wording or amount-and-date similarity alone creates only a match candidate.
+_Avoid_: Refund, cancellation, source withdrawal, fuzzy confirmed relation
+
+**Transfer-counterpart transaction relation**:
+A semantically symmetric `transfer_counterpart` Transaction Relation connecting the separate account-side Financial Transactions of one movement between Financial Accounts, never merging them or treating physical endpoint ordering as money direction. A pair involving a `credit / credit_card` account is interpreted as a credit-card payment from account types and transaction directions rather than a separate relation type; a source-reported payment with no observed other side remains a source fact.
+_Avoid_: Cross-account transaction merge, transfer deduplication, credit-card-payment relation type, inferred missing counterpart
+
+**Installment transaction relation**:
+A directed `installment_of` Transaction Relation from a Financial Transaction representing an installment to an evidence-backed original Financial Transaction. A source-reported installment sequence or plan detail without an observed original transaction remains Credit Card Transaction Detail rather than causing OctopusBeak to invent the missing transaction or relation.
+_Avoid_: Inferred original transaction, installment-plan entity without evidence, relation from sequence text alone
 
 **Transaction removal**:
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record
+
+**Transaction cancellation**:
+An explicitly source-reported outcome that a pending authorization or other unposted transaction will not proceed to posting. In the first canonical model it remains a provenance-bearing source fact rather than a posting status or Transaction Relation; disappearance, withdrawal, or a missing posted counterpart never establishes cancellation, while a separately booked compensating movement is evaluated as a refund or reversal.
+_Avoid_: Source withdrawal, cancelled posting status, inferred cancellation, refund, reversal
 
 **Credit card billing statement**:
 An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when the source explicitly identifies a settled statement or supplies enough billing-cycle facts to establish one. Its period, issue and due dates, totals, minimum payment, and transaction membership belong to the Statement rather than becoming transaction date observations; a billed status may exist without Statement membership, and an unbilled list never establishes a Statement.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,14 @@ _Avoid_: Source account row, account-number hash, individual card
 The required top-level classification `depository`, `credit`, `loan`, `investment`, `other`, or `unknown`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. An optional subtype refines the product only when evidence supports it, such as `credit` with subtype `credit_card`.
 _Avoid_: Product-specific table name, workflow label, unsupported inferred subtype
 
+**Crypto financial account**:
+An `investment` financial account with evidence-supported subtype `crypto_exchange` or `non_custodial_wallet`. Provider wallet labels create separate financial accounts only when the source establishes independent ledger, balance, transaction-scope, or wallet identity.
+_Avoid_: Cryptocurrency position, token, UI wallet label
+
+**Crypto position**:
+A quantity or value of an individual cryptocurrency held within a crypto financial account. BTC, ETH, and similar assets are positions rather than separate financial accounts, and a crypto account may contain both asset and liability positions.
+_Avoid_: Crypto financial account, wallet, transaction
+
 **Multi-currency financial account**:
 A financial account whose transactions and balance observations may carry different currencies without being split into one canonical account per currency. An optional default currency never overrides the required currency of a transaction amount or balance observation; a currency subaccount is introduced only when the source explicitly establishes its identity.
 _Avoid_: Account-per-currency, workflow currency folder, inferred currency subaccount

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,14 @@ _Avoid_: Account-per-currency, workflow currency folder, inferred currency subac
 A physical or virtual primary or supplementary card associated with a financial account. A different card number or mask does not by itself establish a separate financial account.
 _Avoid_: Credit-card account, financial account
 
+**Source connection**:
+An optional, persistent operational relationship through which a person authorizes or configures collection from a supported source; it may expose multiple financial accounts, and the same financial account may be observed through multiple connections. Connection failure, replacement, disconnection, or deletion does not close a financial account, manual captures require no connection, and authentication secrets remain outside the canonical model.
+_Avoid_: Financial account, automation task run, credential secret
+
+**Source sync state**:
+Opaque continuation and health state scoped to a source connection, product stream, and optional financial account when required by the provider. A cursor is operational state rather than financial evidence and is advanced only according to the source protocol's complete-update rules.
+_Avoid_: Financial transaction ID, source capture, global connection cursor
+
 **Source capture**:
 An immutable evidence envelope produced by one source-side collection event for a declared scope and observation time. Its mapping and granularity in collection workflows remain revisable during the planned workflow refactor.
 _Avoid_: Import run, canonical financial account

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -187,16 +187,36 @@ An append-only, provenance-bearing merge, split, or supersede decision that corr
 _Avoid_: ID rewrite, destructive deduplication, silent rule-upgrade remapping
 
 **Transaction amount**:
-The required non-negative monetary magnitude of a financial transaction paired with a required currency. A currency inferred from an account or collection workflow remains explicitly marked with its provenance; a source record without a usable amount or currency is not promoted to a financial transaction.
+The required non-negative monetary magnitude actually booked to the financial account, paired with its required currency and an account-relative transaction direction. A currency inferred from an account or collection workflow remains explicitly marked with its provenance; a source record without a usable booked amount or currency is not promoted to a financial transaction.
 _Avoid_: Signed cash flow, currency-free number
 
+**Transaction currency**:
+The required denomination of the account-booked transaction amount, established in order from an explicit source-row value, a currency-specific Source Capture scope, or a versioned fixed-currency Integration contract. A financial account's default currency is not transaction evidence, and a Source Record without traceable currency evidence remains outside the complete financial-transaction projection.
+_Avoid_: Account default currency, display currency, unsupported currency guess
+
+**Exact monetary value**:
+A lossless decimal magnitude paired with an explicitly identified denomination; canonical amounts and rates never use binary floating point, while source formatting remains in the immutable Source Record and display rounding never changes the underlying value. Fiat denominations use ISO 4217, and any non-ISO denomination belongs to a distinct controlled scheme rather than masquerading as an ISO currency.
+_Avoid_: Floating-point money, universal cents integer, formatted source text as calculation input
+
+**Original transaction amount**:
+An optional non-negative amount and currency in which a merchant, counterparty, or source originally denominated a financial transaction before conversion into the account-booked transaction amount. It preserves the source denomination but never replaces the amount used to reconcile the financial account.
+_Avoid_: Canonical transaction amount, display-currency conversion
+
+**Transaction conversion**:
+Optional provenance-bearing conversion evidence connecting an original transaction amount to its account-booked transaction amount, with explicit base and quote currencies and a separate conversion date when known. A source-reported rate and a rate implied by the two amounts remain distinct; their consistency follows a versioned rounding rule, conflicts do not change the booked amount, and neither a discrepancy nor a missing fact is silently explained as a fee or filled from a later market rate.
+_Avoid_: Bare exchange rate, current market conversion, inferred foreign fee
+
 **Transaction direction**:
-The required account-relative movement classification `inflow`, `outflow`, or `unknown`. Signed values used by reports are derived from transaction amount and direction rather than stored with an implicit provider-specific sign convention.
-_Avoid_: Amount sign, debit-or-credit column
+The required classification `inflow` or `outflow` describing money crossing the boundary of the financial account: deposits, refunds, and liability payments enter an account, while withdrawals, card purchases, and loan disbursements leave it. Every Supported Source Integration defines and tests one unambiguous versioned mapping from its signs and debit/credit fields; a conflicting or indeterminate Source Record is retained as a projection data issue rather than promoted to a financial transaction.
+_Avoid_: Amount sign, debit-or-credit column, unknown canonical direction, balance effect, net-worth effect
 
 **Transaction effective date**:
-The required local calendar date selected deterministically for ordering, period queries, and reporting, paired with a required basis of `transaction`, `authorized`, `posted`, `accounting`, or `inferred`. Source-provided authorized, occurrence, posting, and accounting dates remain separate optional observations; absent times or time zones are never fabricated.
+The required local calendar date selected deterministically for ordering, period queries, and reporting, paired with a required basis of `occurred`, `authorized`, `posted`, `accounting`, or `inferred`. It selects the first available basis in that order after source fields have been mapped to their semantic roles; the underlying date observations remain separate, and a UTC storage anchor defaulted from a date-only value never claims that its local-midnight time was source reported.
 _Avoid_: Import date, assumed midnight timestamp, only source date
+
+**Transaction date observation**:
+A provenance-bearing occurrence, authorization, posting, or accounting date/time for a financial transaction, retaining its source-local calendar value, precision, and time origin. Current Integrations normalize otherwise unzoned values with `Asia/Taipei`; a date-only value may use local midnight as a UTC storage anchor only when marked with `date` precision and `defaulted_local_midnight`, so the anchor is never presented as a source-reported event time.
+_Avoid_: Exact timestamp for every date, system-timezone conversion, billing-statement date
 
 **Transaction posting status**:
 The required settlement classification `pending`, `posted`, or `unknown` for a financial transaction. Missing source status remains unknown; source removal is projection lifecycle, and billing, payment, refund, or reversal semantics are not posting statuses.
@@ -215,8 +235,8 @@ A source-sync assertion that a previously projected transaction is no longer pre
 _Avoid_: Refund, reversal, deleted source record
 
 **Credit card billing statement**:
-An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when the source explicitly identifies a settled statement or supplies enough billing-cycle facts to establish one. Its totals, payment due date, minimum payment, and transaction membership remain optional unless the source establishes them.
-_Avoid_: Unbilled transaction list, transaction export, source capture
+An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when the source explicitly identifies a settled statement or supplies enough billing-cycle facts to establish one. Its period, issue and due dates, totals, minimum payment, and transaction membership belong to the Statement rather than becoming transaction date observations; a billed status may exist without Statement membership, and an unbilled list never establishes a Statement.
+_Avoid_: Unbilled transaction list, transaction date, transaction export, source capture
 
 **Statement document**:
 A provider-issued statement file, such as an official PDF, retained as a source record rather than treated as a canonical billing statement by its file form alone.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,8 +75,16 @@ A reviewable, traceable view that unifies a person's imported cash, deposits, li
 _Avoid_: Dashboard, portfolio view, financial summary
 
 **Financial account**:
-A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and a financial institution or service provider, used to organize its transactions, balances, liabilities, positions, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
+A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and an Institution, used to organize its transactions, balances, liabilities, positions, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
 _Avoid_: Source account row, account-number hash, individual card
+
+**Institution**:
+The canonical identity of the real-world provider that maintains a financial account, such as a bank, broker, card issuer, fund platform, or crypto service. Its provider type is a technical taxonomy rather than a regulatory determination; portal IDs, Plaid institution IDs, workflow codes, brands, and other external identifiers may map many-to-one to a confirmed or provisional Institution.
+_Avoid_: Supported source, corporate-group brand, workflow provider code
+
+**Institution source coverage**:
+The many-to-many mapping that records which Institutions and products a supported source can collect or import. Coverage does not make a supported-source identifier the canonical identity of an Institution.
+_Avoid_: Source connection, Institution identity, account ownership
 
 **Financial account type**:
 The required top-level classification `depository`, `credit`, `loan`, `investment`, `other`, or `unknown`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. An optional subtype refines the product only when evidence supports it, such as `credit` with subtype `credit_card`.
@@ -295,8 +303,8 @@ A person in Taiwan who manages at least three bank, credit-card, or investment a
 _Avoid_: macOS user, all personal-finance users
 
 **Supported source**:
-A financial institution or service whose data-collection and import path has been verified for the current Beta. A planned or previously working integration is not a supported source.
-_Avoid_: Supported bank, available integration
+A collection and import integration whose declared Institution and product coverage has been verified for the current Beta. A planned, previously working, or merely registered integration is not a supported source.
+_Avoid_: Institution, supported bank, available integration
 
 **Supported source name**:
 The formal user-facing name of a supported source. In the Traditional Chinese UI, a distinct localized name is followed by its English name in parentheses; brand names without a distinct translation remain unchanged.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -186,6 +186,10 @@ _Avoid_: Billing status, transaction kind, source removal
 An optional, non-independent extension of a financial transaction belonging to a `credit` / `credit_card` financial account. It holds evidence-supported credit-card specifics such as Card Instrument, `unbilled | billed | unknown` billing status, Billing Statement membership, original-currency and FX data, installment detail, and source payment status without acquiring a separate identity or lifecycle.
 _Avoid_: Credit card transaction entity, statement line, financial transaction
 
+**Transaction relation**:
+An optional, provenance-bearing directed relationship between two financial transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`. It is created only from explicit source evidence or a deterministic versioned rule, never merges or deletes either transaction, and is not inferred from source removal alone.
+_Avoid_: Transaction identity merge, source removal, ambiguous match
+
 **Transaction removal**:
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,18 @@ _Avoid_: Canonical transaction, imported projection
 A processing execution that reads source records and produces or reconciles canonical projections. Reprocessing the same source records creates another import run, not another source capture.
 _Avoid_: Source capture, financial event
 
+**Canonical entity lineage**:
+The required relationship from a canonical entity to the source records that support it. Direct source facts may inherit this relationship without duplicating provenance for every field.
+_Avoid_: Import timestamp, source filename only
+
+**Field provenance**:
+The evidence and transformation metadata required for an inferred, normalized, conflicting, or user-asserted canonical field, including its field path, value origin, supporting evidence, and applicable rule version. Confidence is recorded only when the derivation can support it.
+_Avoid_: Entity lineage only, fabricated probability
+
+**Canonical value origin**:
+The classification `source_fact`, `parser_inference`, `normalized_projection`, or `user_assertion` that states how a canonical value was established. A user assertion coexists with source evidence and never rewrites an immutable source record.
+_Avoid_: Verified boolean, importer name
+
 **Balance observation**:
 A time-bound balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It preserves effective and collection times plus provenance; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
 _Avoid_: Current account field, transaction amount, assumed live balance

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,18 @@ _Avoid_: Source account row, account-number hash, individual card
 A physical or virtual primary or supplementary card associated with a financial account. A different card number or mask does not by itself establish a separate financial account.
 _Avoid_: Credit-card account, financial account
 
+**Source capture**:
+An immutable evidence envelope produced by one source-side collection event for a declared scope and observation time. Its mapping and granularity in collection workflows remain revisable during the planned workflow refactor.
+_Avoid_: Import run, canonical financial account
+
+**Source record**:
+An immutable raw file, row, or object contained by a source capture and retained as evidence for canonical projections.
+_Avoid_: Canonical transaction, imported projection
+
+**Import run**:
+A processing execution that reads source records and produces or reconciles canonical projections. Reprocessing the same source records creates another import run, not another source capture.
+_Avoid_: Source capture, financial event
+
 **Local-first AI financial assistant**:
 An assistant that lets a person use a locally available language model to explore their trusted financial overview, learn from it, and assess trends and risks with traceable external information. Product and technical boundaries—including privacy, model providers, advice, and external-information handling—are defined by an implementation-ready specification before build work begins.
 _Avoid_: Cloud financial advisor, autonomous investment manager

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,14 @@ The set of statement types chosen for an enabled credential source to collect.
 A reviewable, traceable view that unifies a person's imported cash, deposits, liabilities, investments, foreign currency, crypto assets, income, spending, and statement activity across supported sources. Analysis must preserve the distinction between verified data, known gaps, and user-supplied assumptions.
 _Avoid_: Dashboard, portfolio view, financial summary
 
+**Financial account**:
+A persistent deposit or credit-card relationship represented in the trusted financial overview across source captures. When source evidence cannot reliably distinguish or join accounts, its identity remains provisional rather than being treated as verified.
+_Avoid_: Source account row, account-number hash, individual card
+
+**Card instrument**:
+A physical or virtual primary or supplementary card associated with a financial account. A different card number or mask does not by itself establish a separate financial account.
+_Avoid_: Credit-card account, financial account
+
 **Local-first AI financial assistant**:
 An assistant that lets a person use a locally available language model to explore their trusted financial overview, learn from it, and assess trends and risks with traceable external information. Product and technical boundaries—including privacy, model providers, advice, and external-information handling—are defined by an implementation-ready specification before build work begins.
 _Avoid_: Cloud financial advisor, autonomous investment manager

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,10 @@ _Avoid_: Dashboard, portfolio view, financial summary
 A persistent deposit or credit-card relationship represented in the trusted financial overview across source captures. When source evidence cannot reliably distinguish or join accounts, its identity remains provisional rather than being treated as verified.
 _Avoid_: Source account row, account-number hash, individual card
 
+**Multi-currency financial account**:
+A financial account whose transactions and balance observations may carry different currencies without being split into one canonical account per currency. An optional default currency never overrides the required currency of a transaction amount or balance observation; a currency subaccount is introduced only when the source explicitly establishes its identity.
+_Avoid_: Account-per-currency, workflow currency folder, inferred currency subaccount
+
 **Card instrument**:
 A physical or virtual primary or supplementary card associated with a financial account. A different card number or mask does not by itself establish a separate financial account.
 _Avoid_: Credit-card account, financial account

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,10 @@ _Avoid_: Signed cash flow, currency-free number
 The required account-relative movement classification `inflow`, `outflow`, or `unknown`. Signed values used by reports are derived from transaction amount and direction rather than stored with an implicit provider-specific sign convention.
 _Avoid_: Amount sign, debit-or-credit column
 
+**Transaction effective date**:
+The required local calendar date selected deterministically for ordering, period queries, and reporting, paired with a required basis of `transaction`, `authorized`, `posted`, `accounting`, or `inferred`. Source-provided authorized, occurrence, posting, and accounting dates remain separate optional observations; absent times or time zones are never fabricated.
+_Avoid_: Import date, assumed midnight timestamp, only source date
+
 **Transaction removal**:
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,10 @@ _Avoid_: Cryptocurrency position, token, UI wallet label
 A quantity or value of an individual cryptocurrency held within a crypto financial account. BTC, ETH, and similar assets are positions rather than separate financial accounts, and a crypto account may contain both asset and liability positions.
 _Avoid_: Crypto financial account, wallet, transaction
 
+**Security**:
+The Plaid-aligned canonical reference for an asset held in an investment financial account, classified by a security type such as equity, ETF, mutual fund, fixed income, derivative, cash, cryptocurrency, loan, or other. Classifying a cryptocurrency as a Security is a technical data-taxonomy choice and does not by itself assert that the asset is legally a security in Taiwan.
+_Avoid_: Financial account, holding, legal securities determination
+
 **Multi-currency financial account**:
 A financial account whose transactions and balance observations may carry different currencies without being split into one canonical account per currency. An optional default currency never overrides the required currency of a transaction amount or balance observation; a currency subaccount is introduced only when the source explicitly establishes its identity.
 _Avoid_: Account-per-currency, workflow currency folder, inferred currency subaccount

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -223,16 +223,20 @@ The normal per-integration synchronization that repopulates an empty canonical s
 _Avoid_: Cutover-time remote dependency, legacy replay, placeholder financial value, all-integrations transaction
 
 **Source assertion**:
-A Canonical Assertion for a fact explicitly supported by a Source Record, preserving the source evidence and its own lifecycle independently of parser interpretations or user corrections.
+A Canonical Assertion for a fact explicitly supported by a Source Record, including a contract-versioned translation or conservative parent mapping only when it preserves the source field's declared semantics without adding an OctopusBeak inference. The original source value and crosswalk version remain in provenance, and its lifecycle stays independent of parser interpretations or user corrections.
 _Avoid_: Derived assertion, user assertion, imported projection
 
 **Derived assertion**:
-A Canonical Assertion produced by a parser, normalization, enrichment, or reconciliation rule from retained evidence, with its producer and rule version. A newer derivation may supersede an older one in the same claim lineage without claiming that the source evidence changed.
+A Canonical Assertion produced when a parser, normalization, enrichment, or reconciliation rule adds an OctopusBeak interpretation not explicitly claimed by the source, such as inferring personal purpose from MCC, merchant name, free text, invoice items, or combined fields. It retains its producer and rule version; a newer derivation may supersede an older one in the same claim lineage without claiming that the source evidence changed.
 _Avoid_: Source fact, user correction, unversioned inference
 
 **Derived assertion lifecycle**:
 The append-only result of an atomic, successful, complete-scope Import Run for one producer, subject, field, and rule lineage: a changed supported value supersedes the prior Derived Assertion, an explicitly unsupported optional fact withdraws it, and an unchanged value only gains run provenance. Failed or partial runs change no assertions or projections, and one producer never supersedes another producer's lineage.
 _Avoid_: Missing-output withdrawal, partial commit, cross-producer overwrite
+
+**Derived enrichment admission**:
+The producer-version-specific gate that emits exactly one optional Transaction Kind, Personal Category, or Counterparty enrichment Assertion only when its versioned and fixture-tested mapping or calibrated confidence threshold supports a unique result. Scores may remain lineage metadata but are never canonical values or comparable authority across producers; a low score, tie, unsupported result, or missing output emits no Assertion, and Automatic Enrichment Authority Routing never ranks candidates at runtime.
+_Avoid_: Global confidence scale, low-confidence canonical value, candidate persistence, score-based producer priority
 
 **User assertion**:
 A Canonical Assertion recording a person's explicit correction or choice for a user-governed field, including actor, decision time, and optional rationale. It may take precedence in the current projection or be withdrawn so projection falls back to the next valid assertion, but never rewrites or supersedes Source or Derived Assertions.
@@ -266,6 +270,10 @@ _Avoid_: Assertion withdrawal, query-hidden archive, forensic erasure guarantee,
 A versioned, immutable contract-defined assignment of exactly one authoritative integration, connection, product stream, and producer to each projection input scope at one Canonical Knowledge Point, preventing duplicate financial facts without merging source-scoped identities. Missing or overlapping routes fail admission or projection rebuild rather than invoking runtime priority; route changes create new knowledge and Historical Financial Projections retain the route valid at their cutoff. Another source may serve a different stream, but no fuzzy or user-selected reconciliation moves facts between identities.
 _Avoid_: Cross-source deduplication, identity merge, last-write-wins
 
+**Automatic enrichment authority route**:
+A versioned projection assignment of exactly one Source or Derived producer for an optional Transaction Kind, Personal Category, Counterparty participation, or display field in a declared subject scope. It is consulted only when no active User Assertion is permitted and present for that field; missing output yields absence, while overlapping authoritative producers fail admission or projection rebuild rather than being ranked by recency or confidence.
+_Avoid_: Latest enrichment wins, confidence auction, cross-producer supersession, user financial authority
+
 **Account display group**:
 A user-governed presentation grouping that may place multiple source-scoped Financial Accounts together without changing identity, relocating facts, deduplicating transactions, or authorizing their values for aggregation. It may be renamed or removed independently of all source evidence.
 _Avoid_: Canonical account, reconciliation group, calculation authority
@@ -289,6 +297,10 @@ _Avoid_: Rolling financial TTL, disconnect-as-delete, projection compaction, exp
 **Canonical schema evolution**:
 A monotonic, forward-only versioning policy in which semantics-preserving structural changes migrate transactionally before the canonical writer and query boundary open, while projection-only rule changes rebuild and atomically switch a shadow projection generation without rewriting canonical history. A model change that requires identity, effective-time, or evidence facts the retained data cannot prove must purge and recollect the affected contract or identity epoch, or perform a Canonical Reset when the incompatibility is global; migrations never invent missing facts, downgrade schemas, or let an older application write a newer database.
 _Avoid_: Best-effort backfill, invented evidence, in-place projection rewrite, schema downgrade
+
+**Taxonomy package**:
+The repository-authored, fixture-tested bundle that immutably defines one version of Transaction Kind, Personal Category, or Counterparty Role codes, parentage, semantics, applicability, localization keys, and producer compatibility. CI rejects cycles, missing parents or labels, duplicate codes, illegal applicability, mutation or deletion of published definitions, and invalid producer output; one source generates runtime types, validators, localization references, and transactional canonical seed migrations. Packages ship only inside an immutable Desktop Release, never as a remote hot update, and installing a version makes its codes available without reclassifying old Assertions.
+_Avoid_: Runtime-editable enum, remote taxonomy update, duplicated hand-written registries, automatic historical rewrite
 
 **Canonical entity lineage**:
 The required relationship from a canonical entity to the source records that support it. Direct source facts may inherit this relationship without duplicating provenance for every field.
@@ -329,6 +341,82 @@ _Avoid_: New observation, duplicate import, parser reinterpretation
 **Financial transaction**:
 A source-scoped canonical projection of a monetary event associated with a Financial Account, identified within one integration namespace, connection, product stream, stable source key, and identity epoch and traced to its Source Records. Occurrences from another integration or connection never share its identity; an integration unable to determine the key uniquely fails admission rather than creating a candidate or duplicate merge.
 _Avoid_: Cross-source transaction, import record, statement line
+
+**Transaction kind**:
+A stable, hierarchical machine classification of what financial operation one Financial Transaction represents, independent of its account-relative direction, posting status, personal purpose, Counterparty, and Transaction Relations. The first-version registry contains the parents `purchase`, `transfer`, `payment`, `cash`, `income`, `fee`, `interest`, `tax`, `refund`, `reversal`, `adjustment`, `loan`, and `investment`, with registered children for internal/external and investment transfers; bill, credit-card, and loan payments; cash deposit/withdrawal; employment, business, pension, benefit, rental, reward, dividend, and investment-distribution income; bank, card, loan, and investment fees; earned/charged interest; payment/refund/withholding tax; loan disbursement; investment buy/sell/short/cover/reinvestment trades; and supported corporate actions. An Assertion uses the most specific contract-proven code, may stop at a valid parent such as `transfer`, and retains its taxonomy version; child codes must aggregate safely to their parent, localized labels never establish identity, and changing an existing code's meaning requires a new taxonomy version. Transaction Kind is optional enrichment unless an integration contract declares it necessary to interpret a particular record kind, such as an investment trade whose buy or sell semantics govern quantity and cash effects; an absent optional kind is not stored as `unknown` or `other`, while an unresolved required kind cancels the attempted Capture. `transfer.internal` may exist from source proof about one transaction without another observed transaction; a `transfer_counterpart` Relation additionally requires both canonical endpoints and contract-proven linkage. Refund and reversal Kinds may likewise stand alone, while their Relations require proof of the original transaction.
+_Avoid_: Personal category, merchant type, transaction direction, posting status, relation
+
+**Personal category**:
+A product-managed, typed, versioned classification of the personal-finance purpose assigned to a Financial Transaction or invoice item. The first version publishes only the top-level codes `food_and_groceries`, `dining`, `alcohol_and_tobacco`, `clothing_and_footwear`, `housing_and_utilities`, `household_goods_and_services`, `healthcare`, `transportation`, `travel`, `information_and_communication`, `recreation_sports_and_culture`, `education`, `personal_and_family_care`, `insurance`, `taxes_and_government`, `gifts_and_donations`, and `work_and_business`; income, transfer, payment, and fee semantics remain Transaction Kinds. Detailed children are added only when a non-overlapping definition, actual use case, contract fixtures, and safe parent aggregation exist, never as speculative placeholders. Each target has at most one current category; absence is presented as unclassified without storing an `uncategorized`, `general`, or `other` value, while a transaction spanning several purposes uses a complete Category Allocation rather than unordered multiple categories. Source and Derived Assertions may propose registered categories, an active User Assertion takes display and analytical precedence without overwriting them, and clearing it falls back to the currently routed automatic producer. First-version users cannot create, rename, move, or delete taxonomy nodes; personal organization uses Transaction Tags. Every Assertion retains taxonomy ID, version, and exact code; code meaning and parentage are immutable, additive children do not rewrite ancestors, deprecated codes remain historically readable but unavailable for new Assertions, and reclassification requires a new evidence-backed Source or Derived Assertion rather than migration by label or old category. Personal Category is independent of Transaction Kind and Counterparty: the same merchant may serve several purposes, and the same purpose may contain purchases, fees, refunds, or other kinds.
+_Avoid_: Transaction kind, merchant identity, source description, tag
+
+**Category applicability**:
+A versioned compatibility rule permitting Personal Category only for `purchase`, general or bill/loan `payment`, `fee`, charged `interest`, payment/refund `tax`, `refund`, `reversal`, and explicitly registered descendants. Transfer, cash movement, income, earned interest, credit-card payment, loan disbursement, investment, and adjustment Kinds reject Source, Derived, or User Categorization; an absent Kind cannot be replaced by Category, though one complete producer may admit a compatible Kind and Category together. Tags remain available for non-category organization.
+_Avoid_: Category-as-kind, categorized cash withdrawal, categorized card payment, user financial reinterpretation
+
+**Category allocation**:
+An immutable, atomically versioned analytical distribution of one Financial Transaction's exact booked amount across two or more Personal Categories. Every component has a non-negative exact amount and the set may participate in aggregation only when its amounts reconcile completely in the booked currency, or through explicit conversion evidence, to the unchanged Transaction amount. Invoice-item categories may derive an allocation only after the invoice-to-transaction identity and complete amount reconciliation are established; otherwise item classifications remain separate enrichment.
+_Avoid_: Multiple category labels, transaction amount correction, partial allocation, guessed remainder
+
+**Current categorization**:
+The mutually exclusive current analytical treatment of one Financial Transaction as one Personal Category, one complete Category Allocation, or absence. An active complete User Categorization takes precedence over the one Source or Derived result selected by Automatic Enrichment Authority Routing; switching between single and allocated modes supersedes the prior mode atomically, and clearing the user lineage returns to the currently routed automatic result. A failed or partial Import Run preserves the prior automatic categorization, while a successful complete-scope run that proves prior reconciliation unsupported withdraws the whole allocation and never retains a partial component or guesses a single category from it.
+_Avoid_: Simultaneous single and allocated category, partial split, run-failure withdrawal, implicit category fallback
+
+**Relation-backed categorization**:
+A versioned Derived Categorization for a refund or reversal that inherits an original transaction's Current Categorization only when a valid `refund_of` or `reversal_of` Relation makes the inheritance safe. A full reversal or a partial refund of a single-category original may inherit, while a partial refund of an allocated original requires its own complete evidence-backed or User Allocation and never receives a proportional guess. Changes to the original categorization or Relation cause a successful complete-scope producer to supersede or withdraw the inherited result; failed runs preserve the prior result, and a refund's own User Categorization remains authoritative.
+_Avoid_: Source category copy, fuzzy refund match, proportional allocation guess, orphaned inherited category
+
+**Unclassified presentation bucket**:
+The query-time sum of transactions that satisfy a report's independent financial inclusion rules but have no Current Categorization at the requested Canonical Knowledge Point. It is never a taxonomy code or Assertion target, remains unavailable for user selection, participates in report totals and classification-coverage metrics, and receives the whole transaction amount when no complete Category Allocation exists.
+_Avoid_: `other` category, persisted unknown, dropped amount, partial-allocation remainder
+
+**Financial report inclusion**:
+A versioned query policy that determines whether and how a Financial Transaction participates in a financial total from account type, direction, Transaction Kind, relations, posting status, Statement facts, and other admitted financial semantics before consulting Personal Category. Category, Tags, Counterparty display, alias, and notes may organize an included amount but never admit, exclude, or change it; if a report requires an absent optional Kind, the query returns an explicit eligibility coverage gap and affected amount rather than silently counting, dropping, or persisting an `unknown` status.
+_Avoid_: Category-controlled cash flow, tag exclusion, silent incomplete total, user financial override
+
+**Classification coverage**:
+A query result describing how much of a financially included result set has a Current Categorization and how much falls into the Unclassified Presentation Bucket at the requested Canonical Knowledge Point. It is computed from Assertions selected by the query rather than persisted as transaction status, so changing a knowledge cutoff, report scope, or successful enrichment result reproduces the corresponding coverage without rewriting financial facts.
+_Avoid_: Categorization status row, `unknown` category, cached authority
+
+**Report eligibility coverage**:
+A query result identifying the count and amount of otherwise relevant Financial Transactions for which a report's versioned inclusion policy lacks a required admitted semantic, such as an optional Transaction Kind that the source did not provide. It reports that the financial total cannot yet be claimed complete; it never resolves the gap by guessing, silently excluding the amount, or storing a conflict or unknown status on the transaction.
+_Avoid_: Silent report omission, guessed kind, persisted eligibility status, partial truth presented as complete
+
+**Current transaction enrichment**:
+A rebuildable query projection that returns the route-selected Transaction Kind, mutually exclusive Current Categorization, all typed Counterparty Participations, selected display label and its origin, and active Transaction Tags at one Canonical Knowledge Point. Every selected value retains its exact taxonomy version, Assertion origin, and provenance; the projection creates no second history because its authority remains the underlying Canonical Financial Commits and Assertion Transitions.
+_Avoid_: Mutable enrichment source of truth, duplicated event log, UI-side precedence, untyped enrichment payload
+
+**Enrichment knowledge time**:
+The Canonical Knowledge Point at which a Transaction Kind, Personal Category, Category Allocation, Counterparty display, alias, or Tag Assertion became known, changed, or was withdrawn. These descriptive and organizational facts inherit the Financial Transaction's financial date for period membership but never receive a separately backdated financial `effective_at`; current-knowledge reports may reorganize old transactions, while a knowledge cutoff reproduces what the product displayed at that earlier point.
+_Avoid_: Backdated user category, enrichment effective date, category-changing transaction time
+
+**User categorization scope**:
+The explicit set of Financial Transactions, invoice items, or complete Category Allocations selected by a person for one category operation. A single or bulk action creates a User Assertion for every named target but never becomes a merchant-name, Counterparty, or future-transaction rule; reusable automatic user rules require a separate versioned producer and precedence specification outside the first version.
+_Avoid_: Always categorize merchant, implicit future rule, fuzzy bulk scope, alias-based categorization
+
+**Counterparty**:
+An optional evidence-backed party participating in a Financial Transaction, typed by its role such as merchant, marketplace, payment platform, financial institution, income source, government, or person. A transaction may retain several typed Counterparty Participations, while Current Projection chooses one reproducible display Counterparty from Transaction Kind and contract-defined role precedence without deleting or authorizing the others. A Counterparty Reference may be reused across transactions only when its source or enrichment producer supplies a stable entity key within that producer namespace; an explicitly provided and contract-validated registered identifier such as a Taiwan seller business number may identify the reference only inside that scheme and producer scope. Different producers never merge references by name, and without a stable key the transaction retains only a transaction-scoped display Assertion. First-version reference descriptions are limited to display and legal names; mutable web profiles, logos, contact details, geolocation, opening hours, inferred corporate groups, and unused source fields are not promoted or retained speculatively. Display normalization may be superseded without changing Financial Transaction identity, while similar names, company groups, user guesses, and a matching Institution label never establish shared identity. A Merchant is one Counterparty role rather than a universal transaction field; transfers, cash activity, and other transactions may have no merchant.
+_Avoid_: Personal category, raw transaction description, canonical Institution identity, guaranteed merchant
+
+**Counterparty participation**:
+An immutable, provenance-bearing association between one Financial Transaction and one transaction-scoped or producer-scoped Counterparty in exactly one registered role, retaining its observed name, optional Counterparty Reference, and optional typed source classification scheme/code. Several participations may coexist, such as marketplace, underlying merchant, and payment platform; an unsupported role is absent rather than stored as `other`, and selecting one participation for display never merges identities or changes financial semantics.
+_Avoid_: Single merchant field, display-name identity, institution merge, personal category
+
+**Merchant classification**:
+An optional source- or producer-scoped scheme and code, such as an evidence-backed ISO 18245 merchant category code, describing a merchant's business activity rather than the purpose of one purchase. It may support a versioned Derived Personal Category but never becomes that category directly, and unsupported addresses, store metadata, websites, logos, or external company information are absent from the first-version canonical projection.
+_Avoid_: Personal category, merchant identity, transaction kind, guessed business profile
+
+**Counterparty display override**:
+A User Assertion that changes only presentation, either for one Financial Transaction or as a shared alias on an existing producer-scoped Counterparty Reference. Transaction-specific text takes precedence over a reference alias and the routed Source or Derived display, while a reference alias is unavailable without a stable producer key; neither scope changes the selected participation, role, identity, Personal Category, Transaction Kind, or similarly named Counterparties.
+_Avoid_: Merchant merge, fuzzy bulk rename, identity correction, category override
+
+**Transaction display label**:
+The current user-facing title selected in order from a transaction-specific User override, the selected Counterparty's User alias, its routed Source or Derived display name, and finally the Financial Transaction's source description. The query returns the selected origin and keeps `display_counterparty` absent when it falls back to transaction text, so a readable label never fabricates Merchant identity or authorizes grouping by similar strings.
+_Avoid_: Description-as-merchant, display-name identity, fuzzy merchant grouping, hidden label origin
+
+**Transaction tag**:
+A reusable user-owned entity applied independently of Transaction Kind, Personal Category, and Counterparty to organize Financial Transactions for a person's own context, such as reimbursable, travel, or renovation. Its stable local ID is separate from a renameable display label whose normalized current form is unique in the user scope; each transaction association has its own User Assertion lifecycle, removal withdraws only that association, and ordinary tag deletion archives the entity while preserving history unless a separate user-data deletion applies. Source and Derived producers cannot create or apply Tags, and a Tag carries no financial calculation, identity, authority, or source meaning.
+_Avoid_: Personal category, source classification, financial fact, transaction relation
 
 **Transaction occurrence matching**:
 The contract-defined reconciliation of repeated Source Record occurrences to one stable Financial Transaction identity within the same integration namespace, connection, product stream, and identity epoch. The mapping must be unique and versioned; a content hash or occurrence ordinal is evidence rather than a permanent key, and ambiguity cancels the attempted Capture.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,15 +84,23 @@ _Avoid_: Product-specific table name, workflow label, unsupported inferred subty
 
 **Crypto financial account**:
 An `investment` financial account with evidence-supported subtype `crypto_exchange` or `non_custodial_wallet`. Provider wallet labels create separate financial accounts only when the source establishes independent ledger, balance, transaction-scope, or wallet identity.
-_Avoid_: Cryptocurrency position, token, UI wallet label
+_Avoid_: Crypto holding observation, token, UI wallet label
 
-**Crypto position**:
-A quantity or value of an individual cryptocurrency held within a crypto financial account. BTC, ETH, and similar assets are positions rather than separate financial accounts, and a crypto account may contain both asset and liability positions.
-_Avoid_: Crypto financial account, wallet, transaction
+**Holding observation**:
+A source-reported, point-in-time quantity, cost, or valuation of a Security held in an investment financial account. Holding observations are retained as evidence checkpoints, while the current holding is a projection from the latest valid observation and transaction history remains a separate event record.
+_Avoid_: Investment transaction, mutable current holding, liability balance
+
+**Crypto holding observation**:
+A holding observation that references a Security classified as `cryptocurrency` within a crypto financial account. BTC, ETH, and similar assets are Securities held by the account rather than separate financial accounts; borrowing is not represented as a negative or liability holding.
+_Avoid_: Crypto financial account, wallet, crypto loan
 
 **Security**:
 The Plaid-aligned canonical reference for an asset held in an investment financial account, classified by a security type such as equity, ETF, mutual fund, fixed income, derivative, cash, cryptocurrency, loan, or other. Classifying a cryptocurrency as a Security is a technical data-taxonomy choice and does not by itself assert that the asset is legally a security in Taiwan.
 _Avoid_: Financial account, holding, legal securities determination
+
+**Investment-account liability**:
+An independently identifiable borrowing associated with investing is represented as a separate `credit` or `loan` financial account. Margin debt that the source reports only as part of an investment account, without independent account identity, remains a `margin_loan` balance observation on that investment account rather than becoming a liability holding or invented account.
+_Avoid_: Liability holding, inferred loan account, negative Security
 
 **Multi-currency financial account**:
 A financial account whose transactions and balance observations may carry different currencies without being split into one canonical account per currency. An optional default currency never overrides the required currency of a transaction amount or balance observation; a currency subaccount is introduced only when the source explicitly establishes its identity.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,6 +102,14 @@ _Avoid_: Current account field, transaction amount, assumed live balance
 A canonical projection of a monetary event associated with a financial account, identified by a stable internal identifier and traced to one or more source records. Provider identifiers and pending-to-posted linkage are optional; uncertain matches remain provisional and potentially duplicated rather than being merged as fact.
 _Avoid_: Source transaction row, import record, statement line
 
+**Transaction amount**:
+The required non-negative monetary magnitude of a financial transaction paired with a required currency. A currency inferred from an account or collection workflow remains explicitly marked with its provenance; a source record without a usable amount or currency is not promoted to a financial transaction.
+_Avoid_: Signed cash flow, currency-free number
+
+**Transaction direction**:
+The required account-relative movement classification `inflow`, `outflow`, or `unknown`. Signed values used by reports are derived from transaction amount and direction rather than stored with an implicit provider-specific sign convention.
+_Avoid_: Amount sign, debit-or-credit column
+
 **Transaction removal**:
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,7 +75,7 @@ A reviewable, traceable view that unifies a person's imported cash, deposits, li
 _Avoid_: Dashboard, portfolio view, financial summary
 
 **Financial account**:
-A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and an Institution, used to organize its transactions, balances, liabilities, positions, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
+A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and an Institution, used to organize its transactions, balances, liabilities, holdings, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
 _Avoid_: Source account row, account-number hash, individual card
 
 **Institution**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,6 +106,14 @@ _Avoid_: Source transaction row, import record, statement line
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record
 
+**Credit card billing statement**:
+An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when the source explicitly identifies a settled statement or supplies enough billing-cycle facts to establish one. Its totals, payment due date, minimum payment, and transaction membership remain optional unless the source establishes them.
+_Avoid_: Unbilled transaction list, transaction export, source capture
+
+**Statement document**:
+A provider-issued statement file, such as an official PDF, retained as a source record rather than treated as a canonical billing statement by its file form alone.
+_Avoid_: Credit card billing statement, CSV transaction export
+
 **Local-first AI financial assistant**:
 An assistant that lets a person use a locally available language model to explore their trusted financial overview, learn from it, and assess trends and risks with traceable external information. Product and technical boundaries—including privacy, model providers, advice, and external-information handling—are defined by an implementation-ready specification before build work begins.
 _Avoid_: Cloud financial advisor, autonomous investment manager

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,6 +70,10 @@ _Avoid_: Generic user ID, credential, authentication secret
 **Statement selection**:
 The set of statement types chosen for an enabled credential source to collect.
 
+**Collection scope version**:
+A sanitized version of the enabled product streams, Statement Selections, identity scope, query coverage, completeness semantics, and other non-secret Integration configuration that determines what one Source Capture means. A collection attempt records and revalidates this version before admission; authentication-secret rotation and purely presentational or scheduling changes do not create financial knowledge or change it.
+_Avoid_: Credential version, UI settings version, Capture contract version, secret fingerprint
+
 **Trusted financial overview**:
 A reviewable, traceable view that unifies a person's imported cash, deposits, liabilities, investments, foreign currency, crypto assets, income, spending, and statement activity across supported sources. Analysis must preserve the distinction between verified data, known gaps, and user-supplied assumptions.
 _Avoid_: Dashboard, portfolio view, financial summary
@@ -77,6 +81,14 @@ _Avoid_: Dashboard, portfolio view, financial summary
 **Financial account**:
 A persistent account identity established by one integration namespace, source connection, contract-defined stable account key, and identity epoch, used to organize that source scope's transactions, balances, liabilities, holdings, statements, and product terms. It persists across Captures and Import Runs within that scope but is never merged with an account from another integration or connection, even when both may represent the same real-world account.
 _Avoid_: Cross-source account, display group, individual card
+
+**Canonical local identifier**:
+An opaque durable reference assigned independently of account numbers, card keys, provider identifiers, content hashes, display values, and other business fields. It names an already admitted canonical object but does not prove uniqueness or identity continuity, which remain enforced by the object's contract-defined source scope and stable-key constraints.
+_Avoid_: Business-key identifier, deterministic content hash, identity evidence, display ID
+
+**Canonical identity invariant**:
+A contract-established source scope, stable key meaning, and identified subject property whose change means the prior identity contract was wrong or a new Identity Epoch has begun, rather than an ordinary field revision. Optional subtype, display metadata, lifecycle state, and financial measurements are not identity invariants merely because they appeared when the entity was first admitted.
+_Avoid_: Mutable entity field, optional classification, display label, current financial state
 
 **Institution**:
 The contract-established provider reference that maintains a Financial Account, such as a bank, broker, card issuer, fund platform, or crypto service. Its provider type is a technical taxonomy rather than a regulatory determination; an integration must map external provider identifiers uniquely before admission rather than creating provisional or conflicted Institution identity.
@@ -139,24 +151,56 @@ A persistent operational relationship through which a person authorizes or confi
 _Avoid_: Financial account, automation task run, credential secret
 
 **Source sync state**:
-Opaque continuation and health state scoped to a source connection, product stream, and optional financial account when required by the provider. A cursor is operational state rather than financial evidence and is advanced only according to the source protocol's complete-update rules.
+Opaque committed continuation and health state scoped to a source connection, product stream, and optional financial account when required by the provider. A cursor is operational state rather than financial evidence and advances in the same Canonical Financial Commit as the complete accepted Capture it covers; an integration whose source contract has no continuation state leaves it absent rather than inventing a collection-time watermark.
 _Avoid_: Financial transaction ID, source capture, global connection cursor
 
+**Sync attempt checkpoint**:
+Disposable transport progress for resuming an incomplete collection attempt, such as a downloaded page or temporary continuation token. It never advances committed Source Sync State, establishes a Source Capture, enters historical queries, or authorizes partial financial facts, and may be discarded when the attempt succeeds, fails, or expires.
+_Avoid_: Committed cursor, partial Capture, financial evidence, canonical checkpoint
+
 **Source capture**:
-An immutable metadata envelope produced only after one source-side collection event passes its integration contract and sync admission checks, recording declared scope, observation time, completeness, contract version, and zero or more compact Source Records. An unsupported or indeterminate required value cancels the entire attempted capture and emits an operational error; retries or reprocessing of an accepted capture are operational runs rather than new captures.
+An immutable metadata envelope produced only after one source-side collection event passes its integration contract and sync admission checks, recording observation time, contract version, one or more typed Capture Scopes, and zero or more compact Source Records. An unsupported or indeterminate required value cancels the entire attempted capture and emits an operational error; retries or reprocessing of an accepted capture are operational runs rather than new captures.
 _Avoid_: Import run, canonical financial account
 
+**Capture scope**:
+A typed, queryable declaration of the source subject, product stream, optional financial-time range, and contract-proven completeness covered by one Source Capture. Only the integration contract may establish complete-snapshot, complete-range, or incremental semantics; an empty result or absent next page does not establish completeness by itself. Absence may withdraw prior source support only within comparable scopes whose completeness is proven, while integration-specific supplementary metadata may remain in the compact Source Record payload but cannot authorize withdrawal.
+_Avoid_: Best-effort completeness, payload-only scope, empty-result withdrawal, transport page
+
 **Source record**:
-An immutable, compact evidence projection emitted by an integration within exactly one Source Capture, retaining the source identifiers, financial values, and provenance required for canonical mapping rather than a replayable file, response, or page. Repeated collection of an identical source claim may add provenance without duplicating its Canonical Assertion, while a newly discovered backfilled claim remains new knowledge even when its effective time is in the past.
+An immutable, compact evidence projection emitted by an integration within exactly one Source Capture, consisting of a common identity and provenance envelope plus a contract-versioned record-kind payload containing only the source identifiers and financial values required for canonical mapping. It is not a replayable file, response, or page; product calculations consume typed canonical facts rather than its integration-specific payload. Repeated collection of an identical source claim may add provenance without duplicating its Canonical Assertion, while a newly discovered backfilled claim remains new knowledge even when its effective time is in the past.
 _Avoid_: Canonical transaction, imported projection
 
 **Canonical assertion**:
-An append-only, provenance-bearing claim that a source, derivation, or person supports a value, identity, relationship, or lifecycle fact about a canonical subject. Assertions from different origin streams may coexist only after integration admission has produced a valid contract-defined value; current projections use declared precedence, and supersession occurs only within a continuous same-origin claim lineage.
+An append-only, provenance-bearing claim that a source, derivation, or person supports exactly one explicitly typed canonical revision, relation, observation, identity, or governed field. Assertions from different origin streams may coexist only after integration admission has produced a valid contract-defined value; current projections use declared precedence, and supersession occurs only within a continuous same-origin claim lineage.
 _Avoid_: Mutable canonical field, source record, cross-origin overwrite
+
+**Assertion lifecycle transition**:
+An append-only, knowledge-time event that observes, supersedes, withdraws, or restores support within one continuous, origin-specific Assertion lineage without mutating its prior Assertions or typed financial revisions. Repeated evidence for an unchanged claim adds provenance rather than another value revision; transitions never represent transaction cancellation, refund, reversal, deletion, or a cross-origin overwrite.
+_Avoid_: Mutable assertion status, financial event, duplicate unchanged assertion, conflict resolution
 
 **Canonical admission boundary**:
 The integration contract and sync preflight must resolve and validate every required candidate before it can become a Canonical Assertion; an indeterminate, unsupported, or mutually incompatible candidate cancels the attempted Source Capture, emits an operational error, and does not proceed into canonical storage or projection. Required canonical classifications never use `unknown`, while an unsupported optional fact is omitted rather than represented by an unknown assertion.
 _Avoid_: Persisted conflict candidate, last-write-wins, silent fallback
+
+**Canonical financial commit**:
+The indivisible visibility boundary that admits one complete Source Capture and makes its Source Records, canonical identities and facts, Assertion lineage, and affected current projections durable together. A failed admission, processing run, or Contract Purge exposes none of its partial financial effects; Sign-in Details, Integration configuration, and non-financial preferences are operational state outside this boundary.
+_Avoid_: Partial Capture commit, eventually consistent projection, cross-store financial write
+
+**Canonical knowledge point**:
+The single recorded knowledge position shared by every fact, Assertion transition, provenance link, and projection change in one Canonical Financial Commit. Knowledge points have a strict local order independent of wall-clock ties or reversal; backfilled financial facts retain the later knowledge point at which they were admitted rather than being backdated to their effective time.
+_Avoid_: Per-row import time, financial effective time, wall-clock-only ordering, backdated knowledge
+
+**Current financial projection**:
+The deterministic, disposable selection of the presently authoritative canonical revisions, Observations, Statements, and user-governed fields under declared Assertion precedence and Source Authority Routing. It becomes visible in the same Canonical Financial Commit as the facts that change it, contains no independent financial authority, and can be rebuilt completely from the immutable write model. A projection-rule change builds and validates one complete replacement while the prior projection remains readable, then switches atomically so consumers never observe a mixed generation.
+_Avoid_: Mutable source of truth, runtime consumer interpretation, eventually consistent read model
+
+**Historical financial projection**:
+A query-time reconstruction from immutable canonical facts and Assertion lifecycle using an explicit financial-time cutoff, knowledge-time cutoff, or both. Backfilled facts participate according to their effective time but remain absent from knowledge-time views before their `recorded_at`; precomputed daily snapshots never replace this dual-time history.
+_Avoid_: Current projection snapshot, import-time history, backdated knowledge
+
+**Canonical query boundary**:
+The exclusive read boundary through which product consumers request a Current Financial Projection, a cutoff-qualified Historical Financial Projection, or Lineage Inspection. Consumers never select Assertion precedence, Source Authority Routing, latest Observations, lifecycle effects, or integration-specific Source Record payloads independently, and missing canonical data never falls back to legacy or product-specific financial rows.
+_Avoid_: Direct write-model query, consumer-specific precedence, source-payload calculation, product fallback
 
 **Canonical reset cutover**:
 A version-triggered, one-time breaking replacement that automatically starts a new empty canonical financial store instead of migrating or reading any legacy financial, Source Capture, Source Record, assertion, projection, override, classification, import-run, or automation-run history. Startup completes the cutover only after it has atomically quarantined legacy data, copied Preserved Operational Configuration, and created and validated the empty store; failure leaves legacy files unchanged and refuses to open a partial store rather than falling back to the legacy model. The completed cutover creates new Source Connections, Identity Epochs, Captures, and canonical facts only through integration contracts that satisfy the current model. Legacy ledger and download files never participate in canonical reads, fallback, replay, or recollection; their physical retention or destruction follows Legacy Data Quarantine.
@@ -195,7 +239,7 @@ A Canonical Assertion recording a person's explicit correction or choice for a u
 _Avoid_: Source correction, destructive override, silent preference
 
 **User-governed field**:
-A descriptive or organizational field such as display name, category, tag, or note for which the first version permits a User Assertion to control the current projection. Source financial amounts, dates, lifecycle states, balances, holdings, and Statement totals are not user-governed; suspected errors may be annotated but do not enter financial calculations as corrected facts.
+A registered, typed descriptive or organizational field such as display name, category, tag, or note for which the first version permits a User Assertion to control the current projection. The field set is defined by the product contract rather than arbitrary user keys or JSON values. Source financial amounts, currencies, directions, dates, lifecycle states, balances, holdings, Statement totals, and membership are not user-governed; suspected errors may be annotated but do not enter financial calculations as corrected facts.
 _Avoid_: Source financial fact, statement selection, silent calculation override
 
 **Entity field assertion**:
@@ -211,11 +255,15 @@ A contract-declared fence within which stable source keys share one uniqueness s
 _Avoid_: Contract version, source revision, cross-epoch match
 
 **Contract purge**:
-The atomic hard deletion of all Captures and dependent Records, Assertions, revisions, relationships, and projections in an affected integration namespace, source connection, product stream, contract version, or identity epoch after an admitted contract is proven wrong. It is an exceptional replacement for correction lineage in the first version: only non-financial operational audit metadata remains, the old contract and epoch are disabled, and recovery requires recollection under a new version or epoch.
+The atomic hard deletion of a prevalidated ownership closure containing all Captures and dependent Records, identities, Assertions, revisions, relationships, sync state, and projections in an affected integration namespace, source connection, product stream, contract version, or identity epoch after an admitted contract is proven wrong. The closure must not cross into another source scope or shared operational configuration; any unexpected external reference aborts the purge. It is an exceptional replacement for correction lineage in the first version: only scope, reason, counts, fingerprint, and other non-financial operational audit metadata remain, the old contract and epoch are disabled, and recovery requires recollection under a new version or epoch.
 _Avoid_: Assertion withdrawal, partial row deletion, cross-source cascade
 
+**Canonical deletion completion**:
+The point at which a committed Contract Purge, Canonical Reset cleanup, or separately specified user deletion makes the removed financial data unreachable from every application query, projection, lineage, and recovery path. A resumable local storage scrub may follow to clear database and journal remnants, but the product does not claim forensic erasure from operating-system snapshots, external backups, or storage-device internals.
+_Avoid_: Assertion withdrawal, query-hidden archive, forensic erasure guarantee, backup deletion
+
 **Source authority routing**:
-A contract-defined assignment of one authoritative integration, connection, and product stream to each projection input, preventing duplicate financial facts without merging source-scoped identities. Another source may serve a different stream, but no fuzzy or user-selected reconciliation moves facts between identities.
+A versioned, immutable contract-defined assignment of exactly one authoritative integration, connection, product stream, and producer to each projection input scope at one Canonical Knowledge Point, preventing duplicate financial facts without merging source-scoped identities. Missing or overlapping routes fail admission or projection rebuild rather than invoking runtime priority; route changes create new knowledge and Historical Financial Projections retain the route valid at their cutoff. Another source may serve a different stream, but no fuzzy or user-selected reconciliation moves facts between identities.
 _Avoid_: Cross-source deduplication, identity merge, last-write-wins
 
 **Account display group**:
@@ -227,12 +275,20 @@ The append-only, provenance-bearing history `observed`, `revised`, `withdrawn`, 
 _Avoid_: Economic transaction status, incomplete-scope absence, user withdrawal, contract purge
 
 **Import run**:
-A processing execution that reads Source Records and atomically produces or reconciles canonical projections under identified parser and rule versions. Initial required mapping failure cancels its attempted Source Capture; reprocessing an accepted Capture creates another run whose failed or partial output leaves existing Assertions unchanged, while a successful complete output may supersede or withdraw Derived Assertions but never creates source evidence, Source Assertions, or Observations.
+A processing execution that reads Source Records and evaluates one declared complete subject, field, producer, and rule-lineage scope under identified parser and rule versions. It becomes visible only when the entire output succeeds and atomically updates its Derived Assertions and Current Financial Projection; failed or partial output leaves the prior complete result unchanged and produces only operational failure audit. Initial required mapping failure cancels its attempted Source Capture, while reprocessing an accepted Capture never creates source evidence, Source Assertions, or Observations.
 _Avoid_: Source capture, financial event
 
 **Evidence replay boundary**:
 The first version can re-evaluate derivation and normalization only from fields retained in compact Source Records; it does not preserve raw artifacts or promise to replay extraction from historical files, responses, or pages. An extraction-contract change that needs discarded source content requires a new source collection and cannot retroactively reinterpret the old capture.
 _Avoid_: Raw archive, artifact blob, full extraction reproducibility
+
+**Canonical retention**:
+Accepted Captures, compact Records, identities, revisions, Assertions, transitions, provenance, Statements, and Measurement History have no time-based expiration and remain available for Historical Financial Projection, Lineage Inspection, and deterministic rebuild until an explicit Contract Purge, Canonical Reset, or separately specified user data-deletion action removes them. Disconnection, configuration change, Assertion withdrawal, or loss of current authority never implies deletion; only operational checkpoints, staging data, logs, and retired projections may have bounded retention.
+_Avoid_: Rolling financial TTL, disconnect-as-delete, projection compaction, expired lineage
+
+**Canonical schema evolution**:
+A monotonic, forward-only versioning policy in which semantics-preserving structural changes migrate transactionally before the canonical writer and query boundary open, while projection-only rule changes rebuild and atomically switch a shadow projection generation without rewriting canonical history. A model change that requires identity, effective-time, or evidence facts the retained data cannot prove must purge and recollect the affected contract or identity epoch, or perform a Canonical Reset when the incompatibility is global; migrations never invent missing facts, downgrade schemas, or let an older application write a newer database.
+_Avoid_: Best-effort backfill, invented evidence, in-place projection rewrite, schema downgrade
 
 **Canonical entity lineage**:
 The required relationship from a canonical entity to the source records that support it. Direct source facts may inherit this relationship without duplicating provenance for every field.
@@ -247,7 +303,7 @@ The classification `source_fact`, `parser_inference`, `normalized_projection`, o
 _Avoid_: Verified boolean, importer name
 
 **Balance observation**:
-A balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It requires provenance plus contract-established effective, observation, and recording times so it can support historical valuation; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
+A balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It requires provenance plus contract-established effective, observation, and recording times so it can support historical valuation. A source-reported transaction `balance_after` may support a derived post-transaction ledger observation only when the contract establishes its effective ledger point or ordering; it is never presented as a real-time provider balance, and incomplete transaction history never synthesizes an account balance.
 _Avoid_: Current account field, transaction amount, assumed live balance
 
 **Measurement history**:
@@ -261,6 +317,10 @@ _Avoid_: Observation time, recording time, parser guess
 **Canonical temporal requirement**:
 Each fact type declares effective time as required or not applicable rather than exposing a universally nullable field: Transactions, Statements, Balance and Holding Observations, and Account lifecycle facts require their contract-defined financial date or time, while purely descriptive names, labels, and notes use mandatory recording time without financial effective time. Missing required temporal evidence cancels the attempted Source Capture, and recording or observation time never fills it.
 _Avoid_: Universal nullable effective-at, descriptive-field effective date, inferred timestamp
+
+**Canonical financial revision**:
+An immutable, internally complete version of a financial fact whose required values are admitted and superseded as one coherent unit, while its Assertion lineage records origin, producer, supporting evidence, and knowledge time without turning each required financial field into an independently drifting claim. Transactions, Statements, and corrected Observations retain their specialized revision rules; independently governed descriptive fields continue to use field-level Assertions.
+_Avoid_: Mutable financial row, generic field-value bag, partial financial revision, duplicated assertion payload
 
 **Observation revision**:
 An append-only correction lineage used only when an integration's verified source contract establishes that later evidence corrects the same source-side measurement. A new collection, a matching effective time, or reprocessing the same Source Capture is not by itself a revision; parser reinterpretation instead produces a versioned Derived Assertion.
@@ -291,7 +351,7 @@ The required denomination of the account-booked transaction amount, established 
 _Avoid_: Account default currency, display currency, unsupported currency guess
 
 **Exact monetary value**:
-A lossless decimal magnitude paired with an explicitly identified denomination; canonical amounts and rates never use binary floating point, while source formatting remains in the immutable Source Record and display rounding never changes the underlying value. Fiat denominations use ISO 4217, and any non-ISO denomination belongs to a distinct controlled scheme rather than masquerading as an ISO currency.
+A lossless, normalized decimal magnitude paired with an explicitly identified denomination; numerically equal values have one canonical equality representation regardless of source padding or display precision. Canonical amounts and rates never use binary floating point, while source formatting remains in the immutable Source Record and display rounding never changes the underlying value. Fiat denominations use ISO 4217, and any non-ISO denomination belongs to a distinct controlled scheme rather than masquerading as an ISO currency.
 _Avoid_: Floating-point money, universal cents integer, formatted source text as calculation input
 
 **Original transaction amount**:
@@ -323,7 +383,7 @@ An optional, non-independent extension of a financial transaction belonging to a
 _Avoid_: Credit card transaction entity, statement line, financial transaction
 
 **Transaction relation**:
-An optional, provenance-bearing relationship between two source-scoped Financial Transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`, created only from explicit source evidence or a validated uniquely deterministic integration contract. Users cannot establish financial relations; unsupported optional relations are absent, and admitted relations never merge or delete transactions, impose a global one-to-one constraint, or invent amount allocations.
+An optional, provenance-bearing, immutable typed relationship between two non-identical Financial Transactions within one contract-provable Source Connection and Identity Epoch, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`. Its endpoints and type are created only from explicit source evidence or a validated uniquely deterministic integration contract and never change in place; withdrawal and restoration affect its Assertion support. Users cannot establish financial relations; unsupported optional relations are absent, and admitted relations never merge or delete transactions, impose a global one-to-one constraint, or invent amount allocations.
 _Avoid_: Transaction identity merge, user financial assertion, ambiguous match
 
 **Pending-to-posted transaction relation**:
@@ -359,7 +419,7 @@ An evidence-gated, settled billing-cycle summary for a credit-card financial acc
 _Avoid_: Unbilled transaction list, transaction date, transaction export, source capture
 
 **Statement revision**:
-An append-only correction lineage created only when an integration's verified contract proves that the source reissued or corrected the same Statement through stable identity, revision, or replacement semantics. A different billing cycle creates a new Statement, and the first version does not allow a User Assertion to choose between ambiguous Statement candidates.
+An append-only correction lineage created only when an integration's verified contract proves that the source reissued or corrected the same Statement through stable identity, revision, or replacement semantics. Each revision immutably owns its source-reported totals, dates, and membership pinned to the specific Transaction Revisions used by that statement version, so later transaction changes cannot rewrite old billing history. A different billing cycle creates a new Statement, and the first version does not allow a User Assertion to choose between ambiguous Statement candidates.
 _Avoid_: New billing cycle, same-period guess, user-selected source revision
 
 **Statement document**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,8 +91,16 @@ The required top-level classification `depository`, `credit`, `loan`, `investmen
 _Avoid_: Product-specific table name, workflow label, unsupported inferred subtype
 
 **Account identifier**:
-A contract-defined stable source key used with integration namespace, source connection, and identity epoch to establish a Financial Account. Masks, labels, content hashes, and user input are not sufficient identity keys; an integration without a stable key fails admission rather than creating a provisional account.
+A contract-defined stable source key used with integration namespace, source connection, and identity epoch to establish a Financial Account. It may be a provider account identifier or a contract constant only when the integration proves that the connection scope contains exactly one account of that kind; masks, labels, content hashes, card keys, and user input are not sufficient identity keys, and an integration without a stable account scope fails admission rather than creating a provisional account.
 _Avoid_: Cross-source reconciliation key, display label, content hash
+
+**Credit-card financial account**:
+A `credit` Financial Account representing one issuer-managed primary-cardholder credit and billing portfolio within a source connection, under which multiple primary, supplementary, virtual, replacement, or renewed Card Instruments may generate transactions and statements. A card number, mask, product name, or billing cycle never establishes a separate account by itself; the integration must provide an account-level key or prove a single-primary-portfolio connection scope before it may use a fixed contract key.
+_Avoid_: Individual card, masked PAN account, issuer-wide merge across connections
+
+**Primary-cardholder portfolio scope**:
+A source contract guarantee that one source connection and credit-card product stream exposes exactly one primary cardholder's issuer-managed credit and billing portfolio, allowing a fixed account key within that connection while retaining all cards as subordinate instruments. A login, a list of cards, shared dates, or the authenticated person's identity does not establish this guarantee unless the provider page semantics and integration fixtures verify the primary-account scope; supplementary-only or mixed-primary scopes fail admission.
+_Avoid_: Logged-in-user assumption, all-cards-at-bank merge, card-list account inference
 
 **Account lifecycle fact**:
 A source-supported activation, suspension, closure, or comparable operational state of a Financial Account that requires a contract-established effective time because it changes synchronization and historical financial scope. Absence from a Capture or a state lacking its effective time cannot establish a lifecycle revision and instead fails admission when the contract requires that fact.
@@ -149,6 +157,26 @@ _Avoid_: Mutable canonical field, source record, cross-origin overwrite
 **Canonical admission boundary**:
 The integration contract and sync preflight must resolve and validate every required candidate before it can become a Canonical Assertion; an indeterminate, unsupported, or mutually incompatible candidate cancels the attempted Source Capture, emits an operational error, and does not proceed into canonical storage or projection. Required canonical classifications never use `unknown`, while an unsupported optional fact is omitted rather than represented by an unknown assertion.
 _Avoid_: Persisted conflict candidate, last-write-wins, silent fallback
+
+**Canonical reset cutover**:
+A version-triggered, one-time breaking replacement that automatically starts a new empty canonical financial store instead of migrating or reading any legacy financial, Source Capture, Source Record, assertion, projection, override, classification, import-run, or automation-run history. Startup completes the cutover only after it has atomically quarantined legacy data, copied Preserved Operational Configuration, and created and validated the empty store; failure leaves legacy files unchanged and refuses to open a partial store rather than falling back to the legacy model. The completed cutover creates new Source Connections, Identity Epochs, Captures, and canonical facts only through integration contracts that satisfy the current model. Legacy ledger and download files never participate in canonical reads, fallback, replay, or recollection; their physical retention or destruction follows Legacy Data Quarantine.
+_Avoid_: Legacy migration, compatibility backfill, dual read, legacy fallback, partial history carry-forward
+
+**Preserved operational configuration**:
+The non-financial local state carried across a Canonical Reset Cutover: Sign-in Details, enabled-integration configuration, Statement Selections, and user-interface preferences that neither assert a financial fact nor identify a canonical Financial Account. Preserving it authorizes future collection but never preserves Source Connection identity, Source Sync State, Captures, provenance, user financial classifications, or other financial history.
+_Avoid_: Migrated financial state, preserved canonical identity, retained sync cursor
+
+**Legacy data quarantine**:
+The temporary, read-disabled retention of the pre-cutover ledger and downloads outside every application lookup, import, replay, fallback, and recovery path. It provides no user-facing restore mode. The release after the Canonical Reset Cutover automatically destroys the quarantine only when a durable local marker proves that the cutover completed, the canonical store opened successfully, at least one contract-compliant recollection completed, and no canonical application path ever read the quarantined files; otherwise it leaves the quarantine unchanged for a later release. Quarantine never makes legacy data part of the supported model.
+_Avoid_: Legacy fallback, migration input, application-readable archive, indefinite compatibility storage
+
+**Canonical recollection readiness gate**:
+The release prerequisite that every enabled integration configuration preserved by a Canonical Reset Cutover, and every integration the release continues to advertise as supported, has a versioned, fixture-tested contract that resolves all required identity, classification, status, and effective-time semantics of the current canonical model. One unready supported integration blocks the breaking-change release; the gate evaluates new collection behavior only and never requires legacy data migration or parity.
+_Avoid_: Post-reset disabled surprise, partial integration rollout, legacy migration readiness, best-effort contract
+
+**Post-reset recollection**:
+The normal per-integration synchronization that repopulates an empty canonical store after a Canonical Reset Cutover. It begins only after the local cutover commits, follows the existing authorization, scheduling, OTP, retry, and error-notification behavior of each enabled integration, and never participates in cutover success or reads quarantined downloads. Until valid new Captures arrive, affected financial views show an explicit empty or awaiting-collection state rather than legacy values.
+_Avoid_: Cutover-time remote dependency, legacy replay, placeholder financial value, all-integrations transaction
 
 **Source assertion**:
 A Canonical Assertion for a fact explicitly supported by a Source Record, preserving the source evidence and its own lifecycle independently of parser interpretations or user corrections.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -178,6 +178,14 @@ _Avoid_: Amount sign, debit-or-credit column
 The required local calendar date selected deterministically for ordering, period queries, and reporting, paired with a required basis of `transaction`, `authorized`, `posted`, `accounting`, or `inferred`. Source-provided authorized, occurrence, posting, and accounting dates remain separate optional observations; absent times or time zones are never fabricated.
 _Avoid_: Import date, assumed midnight timestamp, only source date
 
+**Transaction posting status**:
+The required settlement classification `pending`, `posted`, or `unknown` for a financial transaction. Missing source status remains unknown; source removal is projection lifecycle, and billing, payment, refund, or reversal semantics are not posting statuses.
+_Avoid_: Billing status, transaction kind, source removal
+
+**Credit card transaction detail**:
+An optional, non-independent extension of a financial transaction belonging to a `credit` / `credit_card` financial account. It holds evidence-supported credit-card specifics such as Card Instrument, `unbilled | billed | unknown` billing status, Billing Statement membership, original-currency and FX data, installment detail, and source payment status without acquiring a separate identity or lifecycle.
+_Avoid_: Credit card transaction entity, statement line, financial transaction
+
 **Transaction removal**:
 A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
 _Avoid_: Refund, reversal, deleted source record

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,14 @@ _Avoid_: Source capture, financial event
 A time-bound balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It preserves effective and collection times plus provenance; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
 _Avoid_: Current account field, transaction amount, assumed live balance
 
+**Financial transaction**:
+A canonical projection of a monetary event associated with a financial account, identified by a stable internal identifier and traced to one or more source records. Provider identifiers and pending-to-posted linkage are optional; uncertain matches remain provisional and potentially duplicated rather than being merged as fact.
+_Avoid_: Source transaction row, import record, statement line
+
+**Transaction removal**:
+A source-sync assertion that a previously projected transaction is no longer present in that source's current result. It is not evidence by itself of a refund, reversal, or cancellation of the underlying monetary event.
+_Avoid_: Refund, reversal, deleted source record
+
 **Local-first AI financial assistant**:
 An assistant that lets a person use a locally available language model to explore their trusted financial overview, learn from it, and assess trends and risks with traceable external information. Product and technical boundaries—including privacy, model providers, advice, and external-information handling—are defined by an implementation-ready specification before build work begins.
 _Avoid_: Cloud financial advisor, autonomous investment manager

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,11 +75,11 @@ A reviewable, traceable view that unifies a person's imported cash, deposits, li
 _Avoid_: Dashboard, portfolio view, financial summary
 
 **Financial account**:
-A persistent, independently identifiable contractual, ledger, or asset-holding relationship between a person and an Institution, used to organize its transactions, balances, liabilities, holdings, statements, and product terms. It persists across source connections, captures, import runs, files, card instruments, and currencies; when source evidence cannot reliably distinguish or join accounts, its identity remains provisional.
-_Avoid_: Source account row, account-number hash, individual card
+A persistent account identity established by one integration namespace, source connection, contract-defined stable account key, and identity epoch, used to organize that source scope's transactions, balances, liabilities, holdings, statements, and product terms. It persists across Captures and Import Runs within that scope but is never merged with an account from another integration or connection, even when both may represent the same real-world account.
+_Avoid_: Cross-source account, display group, individual card
 
 **Institution**:
-The canonical identity of the real-world provider that maintains a financial account, such as a bank, broker, card issuer, fund platform, or crypto service. Its provider type is a technical taxonomy rather than a regulatory determination; portal IDs, Plaid institution IDs, workflow codes, brands, and other external identifiers may map many-to-one to a confirmed or provisional Institution.
+The contract-established provider reference that maintains a Financial Account, such as a bank, broker, card issuer, fund platform, or crypto service. Its provider type is a technical taxonomy rather than a regulatory determination; an integration must map external provider identifiers uniquely before admission rather than creating provisional or conflicted Institution identity.
 _Avoid_: Supported source, corporate-group brand, workflow provider code
 
 **Institution source coverage**:
@@ -87,23 +87,23 @@ The many-to-many mapping that records which Institutions and products a supporte
 _Avoid_: Source connection, Institution identity, account ownership
 
 **Financial account type**:
-The required top-level classification `depository`, `credit`, `loan`, `investment`, `other`, or `unknown`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. An optional subtype refines the product only when evidence supports it, such as `credit` with subtype `credit_card`.
+The required top-level classification `depository`, `credit`, `loan`, `investment`, or `other`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. Every integration contract must resolve one value or cancel the attempted Source Capture, while an optional subtype is simply absent unless evidence supports it, such as `credit` with subtype `credit_card`.
 _Avoid_: Product-specific table name, workflow label, unsupported inferred subtype
 
 **Account identifier**:
-A source-backed piece of evidence used to reconcile a financial account, currently limited to kinds such as `account_number_hash`, `account_mask`, and `source_account_label`, with its source record, observation time, and value origin. Ingestion IDs and hashes such as source-file, statement-row, and content hashes are not account identifiers; provider-specific account IDs are deferred until an actual provider integration requires them.
-_Avoid_: Financial account ID, source file ID, content hash
+A contract-defined stable source key used with integration namespace, source connection, and identity epoch to establish a Financial Account. Masks, labels, content hashes, and user input are not sufficient identity keys; an integration without a stable key fails admission rather than creating a provisional account.
+_Avoid_: Cross-source reconciliation key, display label, content hash
 
-**Account identity status**:
-The required reconciliation state `provisional`, `confirmed`, or `conflicted` for a financial account. A mask, label, or inferred account remains provisional; matching Institution-scoped account-number evidence or explicit user confirmation may confirm it, while mutually exclusive evidence makes it conflicted without rewriting the source records.
-_Avoid_: Data-quality score, account lifecycle status, verified fields
+**Account lifecycle fact**:
+A source-supported activation, suspension, closure, or comparable operational state of a Financial Account that requires a contract-established effective time because it changes synchronization and historical financial scope. Absence from a Capture or a state lacking its effective time cannot establish a lifecycle revision and instead fails admission when the contract requires that fact.
+_Avoid_: Account identity status, missing-account inference, collection-time closure
 
 **Crypto financial account**:
 An `investment` financial account with evidence-supported subtype `crypto_exchange` or `non_custodial_wallet`. Provider wallet labels create separate financial accounts only when the source establishes independent ledger, balance, transaction-scope, or wallet identity.
 _Avoid_: Crypto holding observation, token, UI wallet label
 
 **Holding observation**:
-A source-reported, point-in-time quantity, cost, or valuation of a Security held in an investment financial account. Holding observations are retained as evidence checkpoints, while the current holding is a projection from the latest valid observation and transaction history remains a separate event record.
+A source-reported quantity, cost, or valuation of a Security held in an investment financial account, recorded as a distinct evidence checkpoint only when its integration contract can establish when the measurement was financially effective. The current holding is a projection from the latest valid observation, while transaction history remains a separate event record.
 _Avoid_: Investment transaction, mutable current holding, liability balance
 
 **Crypto holding observation**:
@@ -127,7 +127,7 @@ A physical or virtual primary or supplementary card associated with a financial 
 _Avoid_: Credit-card account, financial account
 
 **Source connection**:
-An optional, persistent operational relationship through which a person authorizes or configures collection from a supported source; it may expose multiple financial accounts, and the same financial account may be observed through multiple connections. Connection failure, replacement, disconnection, or deletion does not close a financial account, manual captures require no connection, and authentication secrets remain outside the canonical model.
+A persistent operational relationship through which a person authorizes or configures collection from a supported source and which namespaces the Financial Accounts it exposes. Accounts from different connections never share canonical identity; connection failure, replacement, disconnection, or deletion does not itself establish an account lifecycle fact, and authentication secrets remain outside the canonical model.
 _Avoid_: Financial account, automation task run, credential secret
 
 **Source sync state**:
@@ -135,27 +135,83 @@ Opaque continuation and health state scoped to a source connection, product stre
 _Avoid_: Financial transaction ID, source capture, global connection cursor
 
 **Source capture**:
-An immutable evidence envelope produced by one source-side collection event for a declared scope and observation time. Its mapping and granularity in collection workflows remain revisable during the planned workflow refactor.
+An immutable metadata envelope produced only after one source-side collection event passes its integration contract and sync admission checks, recording declared scope, observation time, completeness, contract version, and zero or more compact Source Records. An unsupported or indeterminate required value cancels the entire attempted capture and emits an operational error; retries or reprocessing of an accepted capture are operational runs rather than new captures.
 _Avoid_: Import run, canonical financial account
 
 **Source record**:
-An immutable raw file, row, or object contained by a source capture and retained as evidence for canonical projections.
+An immutable, compact evidence projection emitted by an integration within exactly one Source Capture, retaining the source identifiers, financial values, and provenance required for canonical mapping rather than a replayable file, response, or page. Repeated collection of an identical source claim may add provenance without duplicating its Canonical Assertion, while a newly discovered backfilled claim remains new knowledge even when its effective time is in the past.
 _Avoid_: Canonical transaction, imported projection
 
+**Canonical assertion**:
+An append-only, provenance-bearing claim that a source, derivation, or person supports a value, identity, relationship, or lifecycle fact about a canonical subject. Assertions from different origin streams may coexist only after integration admission has produced a valid contract-defined value; current projections use declared precedence, and supersession occurs only within a continuous same-origin claim lineage.
+_Avoid_: Mutable canonical field, source record, cross-origin overwrite
+
+**Canonical admission boundary**:
+The integration contract and sync preflight must resolve and validate every required candidate before it can become a Canonical Assertion; an indeterminate, unsupported, or mutually incompatible candidate cancels the attempted Source Capture, emits an operational error, and does not proceed into canonical storage or projection. Required canonical classifications never use `unknown`, while an unsupported optional fact is omitted rather than represented by an unknown assertion.
+_Avoid_: Persisted conflict candidate, last-write-wins, silent fallback
+
+**Source assertion**:
+A Canonical Assertion for a fact explicitly supported by a Source Record, preserving the source evidence and its own lifecycle independently of parser interpretations or user corrections.
+_Avoid_: Derived assertion, user assertion, imported projection
+
+**Derived assertion**:
+A Canonical Assertion produced by a parser, normalization, enrichment, or reconciliation rule from retained evidence, with its producer and rule version. A newer derivation may supersede an older one in the same claim lineage without claiming that the source evidence changed.
+_Avoid_: Source fact, user correction, unversioned inference
+
+**Derived assertion lifecycle**:
+The append-only result of an atomic, successful, complete-scope Import Run for one producer, subject, field, and rule lineage: a changed supported value supersedes the prior Derived Assertion, an explicitly unsupported optional fact withdraws it, and an unchanged value only gains run provenance. Failed or partial runs change no assertions or projections, and one producer never supersedes another producer's lineage.
+_Avoid_: Missing-output withdrawal, partial commit, cross-producer overwrite
+
+**User assertion**:
+A Canonical Assertion recording a person's explicit correction or choice for a user-governed field, including actor, decision time, and optional rationale. It may take precedence in the current projection or be withdrawn so projection falls back to the next valid assertion, but never rewrites or supersedes Source or Derived Assertions.
+_Avoid_: Source correction, destructive override, silent preference
+
+**User-governed field**:
+A descriptive or organizational field such as display name, category, tag, or note for which the first version permits a User Assertion to control the current projection. Source financial amounts, dates, lifecycle states, balances, holdings, and Statement totals are not user-governed; suspected errors may be annotated but do not enter financial calculations as corrected facts.
+_Avoid_: Source financial fact, statement selection, silent calculation override
+
+**Entity field assertion**:
+A Canonical Assertion about one descriptive or lifecycle field of a durable entity such as a Financial Account, Institution, or Security, allowing the current entity projection to combine independently sourced claims without whole-entity revision. A field change does not change canonical identity or relocate historical relationships.
+_Avoid_: Whole-entity snapshot, identity remapping, mutable entity row
+
+**Identity admission**:
+The integration contract must establish one immutable source-scoped identity from integration namespace, source connection, stable source key, and identity epoch for every admitted source occurrence before a Source Capture is accepted. The first version provides no cross-source merge, split, relink, or Identity Correction capability; a contract later found wrong purges and recollects the affected scope rather than remapping it.
+_Avoid_: Provisional identity, manual merge, silent account-id rewrite
+
+**Identity epoch**:
+A contract-declared fence within which stable source keys share one uniqueness scope, normalization, and subject meaning and may therefore continue a source-scoped identity across Captures. A new connection or any change to key scope, normalization, reuse rules, or identified subject starts a new epoch that never reconciles with the old one; non-identity parser, mapping, or enrichment changes only advance contract or rule version.
+_Avoid_: Contract version, source revision, cross-epoch match
+
+**Contract purge**:
+The atomic hard deletion of all Captures and dependent Records, Assertions, revisions, relationships, and projections in an affected integration namespace, source connection, product stream, contract version, or identity epoch after an admitted contract is proven wrong. It is an exceptional replacement for correction lineage in the first version: only non-financial operational audit metadata remains, the old contract and epoch are disabled, and recovery requires recollection under a new version or epoch.
+_Avoid_: Assertion withdrawal, partial row deletion, cross-source cascade
+
+**Source authority routing**:
+A contract-defined assignment of one authoritative integration, connection, and product stream to each projection input, preventing duplicate financial facts without merging source-scoped identities. Another source may serve a different stream, but no fuzzy or user-selected reconciliation moves facts between identities.
+_Avoid_: Cross-source deduplication, identity merge, last-write-wins
+
+**Account display group**:
+A user-governed presentation grouping that may place multiple source-scoped Financial Accounts together without changing identity, relocating facts, deduplicating transactions, or authorizing their values for aggregation. It may be renamed or removed independently of all source evidence.
+_Avoid_: Canonical account, reconciliation group, calculation authority
+
 **Source assertion lifecycle**:
-The append-only, provenance-bearing history `observed`, `revised`, `withdrawn`, and `restored` describing what a source asserts about a canonical projection. Absence from a later capture is not withdrawal; only an explicit source tombstone or a comparable capture with a declared complete scope may withdraw the assertion, and withdrawal preserves the evidence and does not imply refund, reversal, cancellation, or deletion of the underlying financial transaction.
-_Avoid_: Economic transaction status, missing-row deletion, source record mutation
+The append-only, provenance-bearing history `observed`, `revised`, `withdrawn`, and `restored` describing what a source asserts about a canonical projection. Only an explicit source tombstone or absence from a comparable contract-declared complete scope may withdraw a claim, and later reassertion of the same stable key may restore it; users cannot initiate either action, and neither action implies refund, reversal, cancellation, deletion, or Contract Purge.
+_Avoid_: Economic transaction status, incomplete-scope absence, user withdrawal, contract purge
 
 **Import run**:
-A processing execution that reads source records and produces or reconciles canonical projections. Reprocessing the same source records creates another import run, not another source capture.
+A processing execution that reads Source Records and atomically produces or reconciles canonical projections under identified parser and rule versions. Initial required mapping failure cancels its attempted Source Capture; reprocessing an accepted Capture creates another run whose failed or partial output leaves existing Assertions unchanged, while a successful complete output may supersede or withdraw Derived Assertions but never creates source evidence, Source Assertions, or Observations.
 _Avoid_: Source capture, financial event
+
+**Evidence replay boundary**:
+The first version can re-evaluate derivation and normalization only from fields retained in compact Source Records; it does not preserve raw artifacts or promise to replay extraction from historical files, responses, or pages. An extraction-contract change that needs discarded source content requires a new source collection and cannot retroactively reinterpret the old capture.
+_Avoid_: Raw archive, artifact blob, full extraction reproducibility
 
 **Canonical entity lineage**:
 The required relationship from a canonical entity to the source records that support it. Direct source facts may inherit this relationship without duplicating provenance for every field.
 _Avoid_: Import timestamp, source filename only
 
 **Field provenance**:
-The evidence and transformation metadata required for an inferred, normalized, conflicting, or user-asserted canonical field, including its field path, value origin, supporting evidence, and applicable rule version. Confidence is recorded only when the derivation can support it.
+The evidence and transformation metadata required for an inferred, normalized, or user-asserted canonical field, including its field path, value origin, supporting evidence, and applicable rule version. Confidence is recorded only when the derivation can support it.
 _Avoid_: Entity lineage only, fabricated probability
 
 **Canonical value origin**:
@@ -163,28 +219,40 @@ The classification `source_fact`, `parser_inference`, `normalized_projection`, o
 _Avoid_: Verified boolean, importer name
 
 **Balance observation**:
-A time-bound balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It preserves effective and collection times plus provenance; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
+A balance measurement associated with a financial account and typed according to its actual meaning, such as ledger balance, available balance, credit limit, or amount due. It requires provenance plus contract-established effective, observation, and recording times so it can support historical valuation; a value derived from a transaction's balance-after field remains marked as derived and is not presented as a real-time provider balance.
 _Avoid_: Current account field, transaction amount, assumed live balance
 
+**Measurement history**:
+The append-only sequence of Balance or Holding Observations created for distinct source-side measurement evidence with a contract-established effective time. Reprocessing the same Source Capture does not create another observation, while a measurement whose effective time cannot be established fails integration admission rather than entering history.
+_Avoid_: Mutable current measurement, inferred effective date, transaction history
+
+**Measurement effective time**:
+The required financial time at which an integration's verified source contract says a Balance or Holding Observation applies, preserving the precision and time-zone semantics the contract can support. If the contract cannot determine it, the attempted Source Capture is cancelled; collection, recording, file, and import times never substitute for it.
+_Avoid_: Observation time, recording time, parser guess
+
+**Canonical temporal requirement**:
+Each fact type declares effective time as required or not applicable rather than exposing a universally nullable field: Transactions, Statements, Balance and Holding Observations, and Account lifecycle facts require their contract-defined financial date or time, while purely descriptive names, labels, and notes use mandatory recording time without financial effective time. Missing required temporal evidence cancels the attempted Source Capture, and recording or observation time never fills it.
+_Avoid_: Universal nullable effective-at, descriptive-field effective date, inferred timestamp
+
+**Observation revision**:
+An append-only correction lineage used only when an integration's verified source contract establishes that later evidence corrects the same source-side measurement. A new collection, a matching effective time, or reprocessing the same Source Capture is not by itself a revision; parser reinterpretation instead produces a versioned Derived Assertion.
+_Avoid_: New observation, duplicate import, parser reinterpretation
+
 **Financial transaction**:
-A canonical projection of a monetary event associated with a financial account, identified by an opaque stable local identifier and traced to one or more source records. Matching source records may share that identity only when explicit source evidence or a deterministic versioned rule establishes equivalence; weak or ambiguous matches remain separate and potentially duplicated because avoiding a false merge takes precedence over suppressing a possible duplicate.
-_Avoid_: Source transaction row, import record, statement line
+A source-scoped canonical projection of a monetary event associated with a Financial Account, identified within one integration namespace, connection, product stream, stable source key, and identity epoch and traced to its Source Records. Occurrences from another integration or connection never share its identity; an integration unable to determine the key uniquely fails admission rather than creating a candidate or duplicate merge.
+_Avoid_: Cross-source transaction, import record, statement line
 
 **Transaction occurrence matching**:
-The provenance-bearing reconciliation of repeated source-record occurrences to stable financial-transaction identities within comparable source-capture scopes. It treats matching signatures as multisets, preserves every identical occurrence, and continues an identity only when a versioned rule can pair it uniquely; a content hash or occurrence ordinal is matching evidence rather than a permanent transaction identifier.
-_Avoid_: Set deduplication, content-hash identity, silent ambiguous merge
+The contract-defined reconciliation of repeated Source Record occurrences to one stable Financial Transaction identity within the same integration namespace, connection, product stream, and identity epoch. The mapping must be unique and versioned; a content hash or occurrence ordinal is evidence rather than a permanent key, and ambiguity cancels the attempted Capture.
+_Avoid_: Cross-source match, content-hash identity, ambiguous merge
 
-**Cross-source transaction reconciliation**:
-The evidence-backed assignment of transaction occurrences from different supported sources or source connections to one financial-transaction identity after they have been reconciled to the same financial account. Shared provider identifiers, validated versioned rules, or explicit user assertions may establish equivalence; amount, nearby dates, or description similarity alone create only a match candidate and never an automatic merge.
-_Avoid_: Cross-account merge, fuzzy auto-merge, transfer deduplication
+**Cross-source transaction separation**:
+Financial Transactions from different integrations or source connections always retain separate identities, even when they appear to describe the same real-world event. Source authority routing prevents double use in projections; the first version performs no cross-source reconciliation, fuzzy deduplication, or user merge.
+_Avoid_: Shared transaction identity, fuzzy auto-merge, user merge
 
 **Transaction revision**:
 An append-only canonical version created when strong source linkage establishes that changed evidence describes the same financial transaction. It preserves the stable financial-transaction identity, the prior revisions, supporting source records, and rule provenance; without strong linkage the changed record creates a separate transaction, while pending-to-posted remains a relation between two transactions rather than an ordinary revision.
 _Avoid_: In-place transaction overwrite, guessed correction, pending-to-posted mutation
-
-**Transaction identity correction**:
-An append-only, provenance-bearing merge, split, or supersede decision that corrects which source occurrences represent the same financial event without silently changing an existing transaction identifier's meaning. Historical identities and revisions remain resolvable; current identities change only through the recorded correction, and ambiguous evidence remains conflicted rather than being reassigned.
-_Avoid_: ID rewrite, destructive deduplication, silent rule-upgrade remapping
 
 **Transaction amount**:
 The required non-negative monetary magnitude actually booked to the financial account, paired with its required currency and an account-relative transaction direction. A currency inferred from an account or collection workflow remains explicitly marked with its provenance; a source record without a usable booked amount or currency is not promoted to a financial transaction.
@@ -203,11 +271,11 @@ An optional non-negative amount and currency in which a merchant, counterparty, 
 _Avoid_: Canonical transaction amount, display-currency conversion
 
 **Transaction conversion**:
-Optional provenance-bearing conversion evidence connecting an original transaction amount to its account-booked transaction amount, with explicit base and quote currencies and a separate conversion date when known. A source-reported rate and a rate implied by the two amounts remain distinct; their consistency follows a versioned rounding rule, conflicts do not change the booked amount, and neither a discrepancy nor a missing fact is silently explained as a fee or filled from a later market rate.
+Optional provenance-bearing conversion evidence connecting an original transaction amount to its account-booked transaction amount, with explicit base and quote currencies and a separate conversion date when known. A source-reported rate and a rate implied by the two amounts remain distinct and must pass a versioned rounding contract; inconsistent required evidence fails Capture admission, while an unsupported optional conversion is omitted rather than silently explained as a fee or filled from a later market rate.
 _Avoid_: Bare exchange rate, current market conversion, inferred foreign fee
 
 **Transaction direction**:
-The required classification `inflow` or `outflow` describing money crossing the boundary of the financial account: deposits, refunds, and liability payments enter an account, while withdrawals, card purchases, and loan disbursements leave it. Every Supported Source Integration defines and tests one unambiguous versioned mapping from its signs and debit/credit fields; a conflicting or indeterminate Source Record is retained as a projection data issue rather than promoted to a financial transaction.
+The required classification `inflow` or `outflow` describing money crossing the boundary of the financial account: deposits, refunds, and liability payments enter an account, while withdrawals, card purchases, and loan disbursements leave it. Every Supported Source Integration defines and tests one total, versioned mapping from its signs and debit/credit fields; a conflicting, indeterminate, or unsupported value cancels the attempted Source Capture.
 _Avoid_: Amount sign, debit-or-credit column, unknown canonical direction, balance effect, net-worth effect
 
 **Transaction effective date**:
@@ -219,31 +287,27 @@ A provenance-bearing occurrence, authorization, posting, or accounting date/time
 _Avoid_: Exact timestamp for every date, system-timezone conversion, billing-statement date
 
 **Transaction posting status**:
-The required account-ledger booking classification `pending`, `posted`, or `unknown`: pending evidence describes authorization, an expected entry, or a reserved amount not yet booked; posted evidence establishes that the Institution recorded the entry in its account ledger; and unknown is an exceptional fail-safe for indeterminate source semantics. Each Supported Source Integration defines and tests a versioned mapping per Source Record kind; billing, payment-network settlement, payment, refund, reversal, and source-removal semantics stay separate, and Taiwan `unbilled` card activity may already be posted.
+The required account-ledger booking classification `pending` or `posted`: pending evidence describes authorization, an expected entry, or a reserved amount not yet booked, while posted evidence establishes that the Institution recorded the entry in its account ledger. Each Supported Source Integration defines and tests a total, versioned mapping per Source Record kind; a missing, indeterminate, or unsupported source status is an integration contract error that cancels the attempted Source Capture rather than producing `unknown`, while billing, payment-network settlement, payment, refund, reversal, and source-removal semantics stay separate.
 _Avoid_: Billing status, unbilled-as-pending, payment-network settlement, transaction kind, source removal
 
 **Credit card transaction detail**:
-An optional, non-independent extension of a financial transaction belonging to a `credit` / `credit_card` financial account. It holds evidence-supported credit-card specifics such as Card Instrument, `unbilled | billed | unknown` billing status, Billing Statement membership, original-currency and FX data, installment detail, and source payment status without acquiring a separate identity or lifecycle.
+An optional, non-independent extension of a financial transaction belonging to a `credit` / `credit_card` financial account. It holds evidence-supported credit-card specifics such as Card Instrument, optional `unbilled | billed` billing status, Billing Statement membership, original-currency and FX data, installment detail, and source payment status without acquiring a separate identity or lifecycle; unsupported optional facts are absent rather than `unknown`.
 _Avoid_: Credit card transaction entity, statement line, financial transaction
 
 **Transaction relation**:
-An optional, provenance-bearing relationship between two Financial Transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`, created only from explicit source evidence, an explicit user assertion, or a validated uniquely deterministic rule. Relations never merge or delete transactions, have no global one-to-one constraint, and do not invent amount allocations or unsupported aggregate events.
-_Avoid_: Transaction identity merge, source removal, ambiguous match
-
-**Transaction match candidate**:
-A provenance-bearing, non-canonical proposal that Financial Transactions may be related, retaining its proposed kind, participants, supporting and contradicting evidence, and producing rule version. Similar amount, direction, date, or description may create a candidate, but it never affects identity or financial computation; confirmation creates a separate Transaction Relation while preserving the candidate and decision history.
-_Avoid_: Transaction relation, fuzzy automatic relation, implicit transfer exclusion, candidate-driven financial calculation
+An optional, provenance-bearing relationship between two source-scoped Financial Transactions, initially typed as `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, or `installment_of`, created only from explicit source evidence or a validated uniquely deterministic integration contract. Users cannot establish financial relations; unsupported optional relations are absent, and admitted relations never merge or delete transactions, impose a global one-to-one constraint, or invent amount allocations.
+_Avoid_: Transaction identity merge, user financial assertion, ambiguous match
 
 **Pending-to-posted transaction relation**:
-A directed `pending_to_posted` Transaction Relation from a separate pending Financial Transaction to its posted Financial Transaction when explicit source linkage or a validated, versioned source-specific rule establishes the pairing. Each transaction retains its identity and evidence, an unmatched pending transaction remains independent, and similarity alone creates only a match candidate rather than a revision, merge, or reason to delete the pending transaction.
+A directed `pending_to_posted` Transaction Relation from a separate pending Financial Transaction to its posted Financial Transaction when explicit source linkage or a validated, versioned source-specific contract establishes the pairing. Each transaction retains its identity and evidence, an unmatched pending transaction remains independent, and similarity alone establishes no relation, revision, merge, or reason to delete the pending transaction.
 _Avoid_: Pending-to-posted mutation, transaction revision, fuzzy confirmed relation, pending deletion
 
 **Transaction refund relation**:
-A `refund_of` Transaction Relation from a separately booked return of value to an earlier Financial Transaction that remains an economic event. A refund may be partial, and multiple refunds may refer to the same original transaction; similar descriptions, opposite directions, equal amounts, or nearby dates alone create only a match candidate.
+A `refund_of` Transaction Relation from a separately booked return of value to an earlier Financial Transaction that remains an economic event. A refund may be partial, and multiple refunds may refer to the same original transaction; similar descriptions, opposite directions, equal amounts, or nearby dates alone establish no relation.
 _Avoid_: Reversal, cancellation, original-transaction deletion, fuzzy confirmed relation
 
 **Transaction reversal relation**:
-A `reversal_of` Transaction Relation from a separately booked compensating transaction to the Financial Transaction whose economic effect it corrects or voids. It is distinct from a refund because the original event is being undone rather than followed by a later return of value; source wording or amount-and-date similarity alone creates only a match candidate.
+A `reversal_of` Transaction Relation from a separately booked compensating transaction to the Financial Transaction whose economic effect it corrects or voids. It is distinct from a refund because the original event is being undone rather than followed by a later return of value; source wording or amount-and-date similarity alone establishes no relation.
 _Avoid_: Refund, cancellation, source withdrawal, fuzzy confirmed relation
 
 **Transfer-counterpart transaction relation**:
@@ -263,8 +327,12 @@ An explicitly source-reported outcome that a pending authorization or other unpo
 _Avoid_: Source withdrawal, cancelled posting status, inferred cancellation, refund, reversal
 
 **Credit card billing statement**:
-An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when the source explicitly identifies a settled statement or supplies enough billing-cycle facts to establish one. Its period, issue and due dates, totals, minimum payment, and transaction membership belong to the Statement rather than becoming transaction date observations; a billed status may exist without Statement membership, and an unbilled list never establishes a Statement.
+An evidence-gated, settled billing-cycle summary for a credit-card financial account, created only when an integration's verified contract can establish its source identity and settled billing-cycle semantics. Its period, issue and due dates, totals, minimum payment, and transaction membership belong to the Statement rather than becoming transaction date observations; ambiguous same-period candidates are excluded by the integration rather than admitted for canonical conflict resolution.
 _Avoid_: Unbilled transaction list, transaction date, transaction export, source capture
+
+**Statement revision**:
+An append-only correction lineage created only when an integration's verified contract proves that the source reissued or corrected the same Statement through stable identity, revision, or replacement semantics. A different billing cycle creates a new Statement, and the first version does not allow a User Assertion to choose between ambiguous Statement candidates.
+_Avoid_: New billing cycle, same-period guess, user-selected source revision
 
 **Statement document**:
 A provider-issued statement file, such as an official PDF, retained as a source record rather than treated as a canonical billing statement by its file form alone.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -142,6 +142,10 @@ _Avoid_: Import run, canonical financial account
 An immutable raw file, row, or object contained by a source capture and retained as evidence for canonical projections.
 _Avoid_: Canonical transaction, imported projection
 
+**Source assertion lifecycle**:
+The append-only, provenance-bearing history `observed`, `revised`, `withdrawn`, and `restored` describing what a source asserts about a canonical projection. Absence from a later capture is not withdrawal; only an explicit source tombstone or a comparable capture with a declared complete scope may withdraw the assertion, and withdrawal preserves the evidence and does not imply refund, reversal, cancellation, or deletion of the underlying financial transaction.
+_Avoid_: Economic transaction status, missing-row deletion, source record mutation
+
 **Import run**:
 A processing execution that reads source records and produces or reconciles canonical projections. Reprocessing the same source records creates another import run, not another source capture.
 _Avoid_: Source capture, financial event
@@ -163,8 +167,24 @@ A time-bound balance measurement associated with a financial account and typed a
 _Avoid_: Current account field, transaction amount, assumed live balance
 
 **Financial transaction**:
-A canonical projection of a monetary event associated with a financial account, identified by a stable internal identifier and traced to one or more source records. Provider identifiers and pending-to-posted linkage are optional; uncertain matches remain provisional and potentially duplicated rather than being merged as fact.
+A canonical projection of a monetary event associated with a financial account, identified by an opaque stable local identifier and traced to one or more source records. Matching source records may share that identity only when explicit source evidence or a deterministic versioned rule establishes equivalence; weak or ambiguous matches remain separate and potentially duplicated because avoiding a false merge takes precedence over suppressing a possible duplicate.
 _Avoid_: Source transaction row, import record, statement line
+
+**Transaction occurrence matching**:
+The provenance-bearing reconciliation of repeated source-record occurrences to stable financial-transaction identities within comparable source-capture scopes. It treats matching signatures as multisets, preserves every identical occurrence, and continues an identity only when a versioned rule can pair it uniquely; a content hash or occurrence ordinal is matching evidence rather than a permanent transaction identifier.
+_Avoid_: Set deduplication, content-hash identity, silent ambiguous merge
+
+**Cross-source transaction reconciliation**:
+The evidence-backed assignment of transaction occurrences from different supported sources or source connections to one financial-transaction identity after they have been reconciled to the same financial account. Shared provider identifiers, validated versioned rules, or explicit user assertions may establish equivalence; amount, nearby dates, or description similarity alone create only a match candidate and never an automatic merge.
+_Avoid_: Cross-account merge, fuzzy auto-merge, transfer deduplication
+
+**Transaction revision**:
+An append-only canonical version created when strong source linkage establishes that changed evidence describes the same financial transaction. It preserves the stable financial-transaction identity, the prior revisions, supporting source records, and rule provenance; without strong linkage the changed record creates a separate transaction, while pending-to-posted remains a relation between two transactions rather than an ordinary revision.
+_Avoid_: In-place transaction overwrite, guessed correction, pending-to-posted mutation
+
+**Transaction identity correction**:
+An append-only, provenance-bearing merge, split, or supersede decision that corrects which source occurrences represent the same financial event without silently changing an existing transaction identifier's meaning. Historical identities and revisions remain resolvable; current identities change only through the recorded correction, and ambiguous evidence remains conflicted rather than being reassigned.
+_Avoid_: ID rewrite, destructive deduplication, silent rule-upgrade remapping
 
 **Transaction amount**:
 The required non-negative monetary magnitude of a financial transaction paired with a required currency. A currency inferred from an account or collection workflow remains explicitly marked with its provenance; a source record without a usable amount or currency is not promoted to a financial transaction.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,14 @@ _Avoid_: Source connection, Institution identity, account ownership
 The required top-level classification `depository`, `credit`, `loan`, `investment`, `other`, or `unknown`; `depository`, `credit`, `loan`, and `investment` are all supported by current product paths. An optional subtype refines the product only when evidence supports it, such as `credit` with subtype `credit_card`.
 _Avoid_: Product-specific table name, workflow label, unsupported inferred subtype
 
+**Account identifier**:
+A source-backed piece of evidence used to reconcile a financial account, currently limited to kinds such as `account_number_hash`, `account_mask`, and `source_account_label`, with its source record, observation time, and value origin. Ingestion IDs and hashes such as source-file, statement-row, and content hashes are not account identifiers; provider-specific account IDs are deferred until an actual provider integration requires them.
+_Avoid_: Financial account ID, source file ID, content hash
+
+**Account identity status**:
+The required reconciliation state `provisional`, `confirmed`, or `conflicted` for a financial account. A mask, label, or inferred account remains provisional; matching Institution-scoped account-number evidence or explicit user confirmation may confirm it, while mutually exclusive evidence makes it conflicted without rewriting the source records.
+_Avoid_: Data-quality score, account lifecycle status, verified fields
+
 **Crypto financial account**:
 An `investment` financial account with evidence-supported subtype `crypto_exchange` or `non_custodial_wallet`. Provider wallet labels create separate financial accounts only when the source establishes independent ledger, balance, transaction-scope, or wallet identity.
 _Avoid_: Crypto holding observation, token, UI wallet label

--- a/docs/adr/0004-plaid-inspired-canonical-financial-model.md
+++ b/docs/adr/0004-plaid-inspired-canonical-financial-model.md
@@ -1,0 +1,232 @@
+# Plaid-inspired canonical financial model
+
+Status: accepted
+
+## Context
+
+OctopusBeak currently preserves source-specific rows for bank deposits, foreign-currency deposits, credit cards, loans, funds, brokerage, and crypto data. Those rows have useful ingestion lineage but do not form one stable domain model. In particular, current sources do not consistently provide provider account, transaction, or statement identifiers; query periods do not establish statement coverage; a transaction-row running balance is not an independent live balance; and workflow, filename, parser, and product labels include inference that must not be presented as source fact.
+
+The decision uses two research baselines:
+
+- [Plaid account, transaction, and synchronization semantics](../research/plaid-accounts-transactions-semantics.md)
+- [OctopusBeak bank source and storage capabilities](../research/octopusbeak-bank-source-capabilities.md)
+
+Plaid is a model reference only. This decision does not plan or require a Plaid integration and does not assume that Plaid identifiers, cursors, webhooks, pending matching, merchant enrichment, or category enrichment exist in Taiwan sources.
+
+## Decision
+
+OctopusBeak adopts a logical canonical model centered on stable local Financial Accounts and immutable source evidence. Canonical projections remain traceable to Source Records, distinguish source facts from inference, and preserve uncertainty instead of forcing identity matches or provider semantics that the source cannot support.
+
+This ADR fixes domain entities, relations, field requirements, and terminology. It does not prescribe physical tables, workflow boundaries, migration sequencing, or whether a relation is stored as a table, structured column, or graph edge. The planned workflow refactor may revise those implementation choices without changing the semantic boundaries below.
+
+```mermaid
+flowchart TD
+    I["Institution"]
+    SS["Supported Source"]
+    SC["Source Connection"]
+    CAP["Source Capture"]
+    SR["Source Record"]
+    IR["Import Run"]
+    FA["Financial Account"]
+    AI["Account Identifier"]
+    BO["Balance Observation"]
+    FT["Financial Transaction"]
+    CCD["Credit Card Transaction Detail"]
+    TR["Transaction Relation"]
+    CI["Card Instrument"]
+    CBS["Credit Card Billing Statement"]
+    HO["Holding Observation"]
+    SEC["Security"]
+
+    I <-->|"coverage"| SS
+    SS --> SC
+    SC -. "observes" .-> FA
+    SC --> CAP
+    SS --> CAP
+    CAP --> SR
+    IR -->|"reads"| SR
+    FA --> AI
+    FA --> BO
+    FA --> FT
+    FA --> CI
+    FA --> CBS
+    FA --> HO
+    SR -. "supports" .-> FA
+    SR -. "supports" .-> BO
+    SR -. "supports" .-> FT
+    SR -. "supports" .-> CBS
+    SR -. "supports" .-> HO
+    FT --> CCD
+    FT --> TR
+    TR --> FT
+    HO --> SEC
+```
+
+### Institution, Supported Source, and Source Connection
+
+An Institution is the canonical identity of the real-world provider that maintains a Financial Account. A Supported Source is a verified collection and import integration. Their coverage mapping is many-to-many: one Institution may have separate deposit, credit-card, loan, fund, or brokerage sources, while a future aggregator source may cover multiple Institutions.
+
+A Source Connection is an optional, user-specific operational relationship with a Supported Source. It may expose multiple Financial Accounts, and the same Financial Account may later be observed through another connection. Connection failure, replacement, or deletion does not close the account. Manual captures do not require a Source Connection.
+
+Plaid institution IDs, portal IDs, workflow codes, bank codes, and brands are external identifiers rather than canonical Institution identity. The Institution taxonomy is technical and does not declare that every fund or crypto provider has a particular Taiwan regulatory status.
+
+| Entity | Required | Optional or conditional |
+| --- | --- | --- |
+| Institution | local ID, canonical name, provider type, identity status | jurisdiction, parent group, external identifiers, display metadata |
+| Supported Source | local ID, name, verified coverage and support state | collector/parser versions, capability metadata |
+| Institution source coverage | Institution, Supported Source, covered product | evidence and verification time |
+| Source Connection | local ID, Supported Source, connection status | Institution hints, connected/last-successful time, consent metadata, configuration reference |
+| Source sync state | Source Connection, product stream, opaque state | Financial Account scope, cursor, last-successful time, health detail |
+
+Authentication secrets never enter this model. A sync cursor is operational state, not financial evidence; its scope and advancement follow the source protocol rather than a global connection cursor convention.
+
+### Source evidence and processing
+
+A Source Capture is the immutable evidence envelope for one source-side collection event at a declared observation time and scope. Its exact workflow mapping and granularity remain revisable. A Source Record is an immutable file, row, or object inside that capture. An Import Run is a processing execution that reads Source Records and creates or reconciles projections; reprocessing evidence creates another Import Run, not another Source Capture.
+
+| Entity | Required | Optional or conditional |
+| --- | --- | --- |
+| Source Capture | local ID, Supported Source, collection time, declared scope | Source Connection, source-effective time, completeness/finality assertions |
+| Source Record | local ID, Source Capture, record kind, immutable payload or content reference, content integrity value, source coordinates | provider metadata |
+| Import Run | local ID, processing status, start time, parser/rule version | completion time, error summary |
+
+Every canonical entity has entity-level lineage to its supporting Source Records. Direct `source_fact` fields may inherit that lineage. A field that is inferred, normalized, conflicting, or user asserted has field-level provenance with field path, value origin, evidence, and applicable rule version. The allowed value origins are `source_fact`, `parser_inference`, `normalized_projection`, and `user_assertion`. User assertions coexist with immutable evidence and never rewrite it.
+
+### Financial Account and identity
+
+A Financial Account is the stable local representation of an independently identifiable contractual, ledger, or asset-holding relationship with an Institution. It persists across connections, captures, imports, files, card instruments, and currencies.
+
+The required account types are:
+
+- `depository`
+- `credit`
+- `loan`
+- `investment`
+- `other`
+- `unknown`
+
+Current product paths support `depository`, `credit`, `loan`, and `investment`. Subtype is optional and evidence-gated. A credit-card account is `credit / credit_card`; a crypto exchange or self-custody wallet is `investment / crypto_exchange` or `investment / non_custodial_wallet` when its account boundary is supported by source evidence.
+
+| Field | Requirement | Rule |
+| --- | --- | --- |
+| `financial_account_id` | required | Stable local ID; never a source row ID or account-number hash |
+| Institution | required | May be provisional when provider identity is unresolved |
+| `account_type` | required | One of the canonical top-level types |
+| `identity_status` | required | `provisional`, `confirmed`, or `conflicted` |
+| canonical entity lineage | required | Links account identity to supporting Source Records |
+| `account_subtype` | optional | Never inferred solely from workflow name |
+| display name | optional | Source-backed or user asserted |
+| default currency | optional | Never overrides transaction or balance currency |
+
+A Financial Account may contain multiple currencies. Currency-specific files do not prove separate currency subaccounts. A separate currency subaccount is created only when the source establishes independent identity.
+
+Account identity evidence is represented by multiple Account Identifiers rather than one global `account_number` field. Initial kinds are `account_number_hash`, `account_mask`, and `source_account_label`. Each identifier records its Financial Account, kind, value, supporting Source Record, observation time, and value origin. Source-file IDs, statement-row IDs, content hashes, and filename-derived ingestion keys are not Account Identifiers. Provider account IDs are deferred until an actual provider integration requires them.
+
+An account stays `provisional` when only masks, labels, or inferred identifiers exist; Institution-scoped account-number evidence or explicit user confirmation may make it `confirmed`; mutually exclusive evidence makes it `conflicted`. Conflict stops silent reconciliation but does not rewrite or delete either source record.
+
+### Card Instrument
+
+A Card Instrument is a physical or virtual primary or supplementary card associated with a `credit / credit_card` Financial Account. Different card numbers or masks do not by themselves establish separate Financial Accounts. Card-number masks belong to Card Instruments unless the source explicitly identifies them as account-level identifiers.
+
+| Required | Optional |
+| --- | --- |
+| local ID, Financial Account, lineage | instrument kind, primary/supplementary role, mask, source label, holder label, active dates |
+
+### Balance Observation
+
+A Balance Observation is a typed, time-bound measurement associated with a Financial Account. Balances are not mutable account fields. Balance kinds include ledger/current, available, credit limit, amount due, and margin loan, with additional kinds introduced only when their source meaning is defined.
+
+| Field | Requirement |
+| --- | --- |
+| local ID, Financial Account | required |
+| balance kind | required |
+| non-negative or signed amount according to the defined balance kind, plus currency | required |
+| collection time | required |
+| source-effective time | optional when the source does not provide it |
+| canonical entity lineage | required |
+| derivation metadata | required when derived |
+
+A transaction row's `balance_after` may support a derived Balance Observation but remains marked as derived and is never advertised as a real-time provider balance. Credit-card capture totals are likewise local projections, not provider balance objects. An investment account's undifferentiated margin debt is a `margin_loan` Balance Observation; an independently identifiable borrowing is a separate `credit` or `loan` Financial Account rather than a liability holding.
+
+### Financial Transaction
+
+All account types share one Financial Transaction entity. Credit-card transactions do not have a separate identity or lifecycle.
+
+| Field | Requirement | Rule |
+| --- | --- | --- |
+| `financial_transaction_id` | required | Stable local ID |
+| Financial Account | required | Establishes account-relative meaning |
+| amount | required | Non-negative magnitude |
+| currency | required | Inference is allowed only with field provenance |
+| direction | required | `inflow`, `outflow`, or `unknown` from the account perspective |
+| `effective_on` | required | Local calendar date selected deterministically |
+| `effective_on_basis` | required | `transaction`, `authorized`, `posted`, `accounting`, or `inferred` |
+| `posting_status` | required | `pending`, `posted`, or `unknown` |
+| canonical entity lineage | required | One or more supporting Source Records |
+| description and raw description | optional | Raw source text is distinct from enrichment |
+| occurred, authorized, posted, and accounting date/time observations | optional | Kept separately; absent time or zone is not fabricated |
+| provider transaction ID | deferred | Not required by current Taiwan sources |
+| merchant, counterparty, and category enrichment | optional | Never treated as source fact without evidence |
+
+Signed report values are derived from amount and direction; the canonical model does not copy Plaid's provider-specific positive-outflow sign convention.
+
+`posting_status` is independent of billing, payment, refund, reversal, and projection state. Missing source status is `unknown`; downloading a row does not prove it is posted.
+
+A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, `unbilled | billed | unknown` billing status, Credit Card Billing Statement membership, original amount and currency, FX date, installment detail, and source payment status. Filename-derived billed/unbilled values are `parser_inference`.
+
+An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`. A relation requires explicit source evidence or a deterministic versioned rule with provenance. Ambiguous matching creates no relation.
+
+Source removal is projection lifecycle, not economic evidence of refund, reversal, or cancellation. When a provider protocol supplies added, modified, or removed patches, its cursor and mutation semantics remain in Source Sync State and projection processing rather than being copied into transaction status.
+
+### Credit Card Billing Statement and Statement Document
+
+A Credit Card Billing Statement is an evidence-gated, settled billing-cycle summary for a `credit / credit_card` Financial Account. It exists only when the source identifies a settled statement or provides enough billing-cycle facts to establish one.
+
+| Required | Optional |
+| --- | --- |
+| local ID, Financial Account, lineage, evidence sufficient to establish a settled cycle | source statement ID, period start/end, issue date, due date, statement currency, statement balance, minimum payment, totals, transaction membership |
+
+A deposit transaction query, CSV export, filename, Source Capture, and unbilled credit-card list are not Statements. A provider-issued PDF or equivalent file is a Statement Document retained as a Source Record; file form alone does not create a canonical Credit Card Billing Statement.
+
+### Security and Holding Observation
+
+OctopusBeak keeps Plaid's technical Security umbrella. Security types include equity, ETF, mutual fund, fixed income, derivative, cash, cryptocurrency, loan, and other. `Security / cryptocurrency` is a data-taxonomy choice and does not assert that the asset is legally a security in Taiwan.
+
+A Holding Observation is a source-reported evidence checkpoint for a Security held in an `investment` Financial Account. It does not replace Investment Transaction history, and Investment Transactions cannot be assumed to reconstruct holdings without a complete opening position, transaction history, corporate actions, transfers, and prices.
+
+| Entity | Required | Optional or conditional |
+| --- | --- | --- |
+| Security | local ID, security type, identity status, lineage | provider identifiers, name, ticker, currency, display metadata |
+| Holding Observation | local ID, Financial Account, Security, observation time, lineage | quantity, cost basis, price, valuation, valuation time and currency |
+
+A Holding Observation requires at least one usable quantity or valuation. The current holding is a projection from the latest valid observation; OctopusBeak does not synthesize daily snapshots when the source provides no observation.
+
+BTC, ETH, and similar assets are Securities referenced by crypto Holding Observations rather than Financial Accounts. Provider wallet labels create separate Financial Accounts only when independent ledger, balance, transaction-scope, or wallet identity is established.
+
+## Plaid alignment classification
+
+| Classification | Concepts |
+| --- | --- |
+| Plaid-aligned | Institution as a provider reference; Account type/subtype hierarchy; Account-linked Transactions; Security; Holding; `depository`, `credit`, `loan`, and `investment`; `credit / credit_card`; `investment / crypto_exchange` and `non_custodial_wallet` |
+| Taiwan-adjusted | Stable local Financial Account identity; multiple evidence-backed Account Identifiers; multi-currency account boundary; non-negative Transaction amount plus explicit direction; multiple transaction dates plus effective-date basis; typed Balance Observations; Holding observations retained as checkpoints |
+| OctopusBeak-added | Supported Source coverage; Source Connection separated from Account; Source Capture, Source Record, and Import Run; entity- and field-level provenance; account identity status; Card Instrument; Credit Card Transaction Detail; generic Transaction Relation |
+| Excluded from canonical model | Workflow and filename labels as identities; source-row and content hashes as account IDs; mutable current balances; account-per-currency inference; card-per-account inference; generic Statement inferred from an export; separate CreditCardTransaction entity; liability Holding; authentication secrets |
+| Deferred until evidence requires it | Provider account/transaction IDs; provider cursor/webhook storage beyond generic Source Sync State; exact Taiwan account-subtype vocabulary; universal transaction-kind taxonomy; automatic merchant/category enrichment; physical schema and migration plan |
+
+## Consequences
+
+- Canonical projections require more explicit relations and provenance than the current typed source tables.
+- Account reconciliation is deliberately conservative; provisional duplicates are preferable to silently combining unrelated accounts.
+- Product queries derive current account, balance, and holding views from evidence-backed observations rather than assuming the latest imported row is authoritative.
+- Credit-card, investment, loan, and deposit sources share core account and transaction vocabulary while retaining type-specific components.
+- Workflow and schema refactors must preserve immutable evidence, value origin, and the separation between collection, processing, and financial facts.
+- Future provider integrations can add external identifiers and protocol-specific sync state without changing canonical local identity.
+
+## Rejected alternatives
+
+- Copy Plaid objects and identifiers directly: current Taiwan sources do not provide the necessary IDs, mutation stream, webhook, or enrichment guarantees.
+- Keep only source-specific tables: this prevents stable cross-source accounts and a common trusted overview.
+- Collapse captures, import runs, and task runs: this confuses evidence with processing and cannot represent safe reprocessing.
+- Treat each currency, card mask, or workflow output as an account: the current sources do not establish those identity boundaries.
+- Rebuild holdings from transactions alone: current sources do not prove complete transaction and valuation history.
+- Infer Statements from query periods or filenames: those values do not establish coverage or finality.

--- a/docs/adr/0004-plaid-inspired-canonical-financial-model.md
+++ b/docs/adr/0004-plaid-inspired-canonical-financial-model.md
@@ -2,6 +2,8 @@
 
 Status: accepted
 
+[ADR 0008](./0008-source-scoped-lineage-and-strict-canonical-admission.md) amends this model's identity, source-evidence retention, admission, temporal requirements, `unknown`, candidate, and user-correction semantics. Where this ADR describes provisional or cross-source identity, raw replayable records, optional Balance/Holding effective time, canonical conflicts, or financial match candidates, ADR 0008 governs.
+
 ## Context
 
 OctopusBeak currently preserves source-specific rows for bank deposits, foreign-currency deposits, credit cards, loans, funds, brokerage, and crypto data. Those rows have useful ingestion lineage but do not form one stable domain model. In particular, current sources do not consistently provide provider account, transaction, or statement identifiers; query periods do not establish statement coverage; a transaction-row running balance is not an independent live balance; and workflow, filename, parser, and product labels include inference that must not be presented as source fact.
@@ -15,7 +17,7 @@ Plaid is a model reference only. This decision does not plan or require a Plaid 
 
 ## Decision
 
-OctopusBeak adopts a logical canonical model centered on stable local Financial Accounts and immutable source evidence. Canonical projections remain traceable to Source Records, distinguish source facts from inference, and preserve uncertainty instead of forcing identity matches or provider semantics that the source cannot support.
+OctopusBeak adopts a logical canonical model centered on source-scoped Financial Accounts and immutable compact source evidence. Canonical projections remain traceable to Source Records and distinguish source facts from inference; unresolved required semantics fail strict admission instead of becoming canonical uncertainty.
 
 This ADR fixes domain entities, relations, field requirements, and terminology. It does not prescribe physical tables, workflow boundaries, migration sequencing, or whether a relation is stored as a table, structured column, or graph edge. The planned workflow refactor may revise those implementation choices without changing the semantic boundaries below.
 
@@ -66,13 +68,13 @@ flowchart TD
 
 An Institution is the canonical identity of the real-world provider that maintains a Financial Account. A Supported Source is a verified collection and import integration. Their coverage mapping is many-to-many: one Institution may have separate deposit, credit-card, loan, fund, or brokerage sources, while a future aggregator source may cover multiple Institutions.
 
-A Source Connection is an optional, user-specific operational relationship with a Supported Source. It may expose multiple Financial Accounts, and the same Financial Account may later be observed through another connection. Connection failure, replacement, or deletion does not close the account. Manual captures do not require a Source Connection.
+A Source Connection is a user-specific operational relationship with a Supported Source and namespaces the source-scoped Financial Accounts it exposes. Accounts from another connection never share canonical identity; connection failure, replacement, or deletion does not by itself establish account closure.
 
 Plaid institution IDs, portal IDs, workflow codes, bank codes, and brands are external identifiers rather than canonical Institution identity. The Institution taxonomy is technical and does not declare that every fund or crypto provider has a particular Taiwan regulatory status.
 
 | Entity | Required | Optional or conditional |
 | --- | --- | --- |
-| Institution | local ID, canonical name, provider type, identity status | jurisdiction, parent group, external identifiers, display metadata |
+| Institution | contract-established local ID, canonical name, provider type | jurisdiction, parent group, external identifiers, display metadata |
 | Supported Source | local ID, name, verified coverage and support state | collector/parser versions, capability metadata |
 | Institution source coverage | Institution, Supported Source, covered product | evidence and verification time |
 | Source Connection | local ID, Supported Source, connection status | Institution hints, connected/last-successful time, consent metadata, configuration reference |
@@ -82,19 +84,19 @@ Authentication secrets never enter this model. A sync cursor is operational stat
 
 ### Source evidence and processing
 
-A Source Capture is the immutable evidence envelope for one source-side collection event at a declared observation time and scope. Its exact workflow mapping and granularity remain revisable. A Source Record is an immutable file, row, or object inside that capture. An Import Run is a processing execution that reads Source Records and creates or reconciles projections; reprocessing evidence creates another Import Run, not another Source Capture.
+A Source Capture is the immutable metadata envelope for one independently observed source event that passed its versioned contract and sync admission checks. A Source Record is an immutable compact evidence projection inside exactly one Capture; the first version retains no raw replayable file, response, or page. An Import Run atomically reads Source Records and creates projections; reprocessing creates another run, not another Capture.
 
 | Entity | Required | Optional or conditional |
 | --- | --- | --- |
-| Source Capture | local ID, Supported Source, collection time, declared scope | Source Connection, source-effective time, completeness/finality assertions |
-| Source Record | local ID, Source Capture, record kind, immutable payload or content reference, content integrity value, source coordinates | provider metadata |
+| Source Capture | local ID, Supported Source, Source Connection, observation time, declared scope, completeness, contract version | operational request metadata |
+| Source Record | local ID, Source Capture, record kind, compact contract-defined values and source identity, provenance | optional provider metadata retained by the compact contract |
 | Import Run | local ID, processing status, start time, parser/rule version | completion time, error summary |
 
-Every canonical entity has entity-level lineage to its supporting Source Records. Direct `source_fact` fields may inherit that lineage. A field that is inferred, normalized, conflicting, or user asserted has field-level provenance with field path, value origin, evidence, and applicable rule version. The allowed value origins are `source_fact`, `parser_inference`, `normalized_projection`, and `user_assertion`. User assertions coexist with immutable evidence and never rewrite it.
+Every canonical entity has entity-level lineage to its supporting Source Records. Direct `source_fact` fields may inherit that lineage. An inferred, normalized, or user-governed field has field-level provenance with field path, value origin, evidence, and applicable rule version. User assertions coexist with immutable evidence, never rewrite it, and are limited by ADR 0008 to display names, categories, tags, and notes.
 
 ### Financial Account and identity
 
-A Financial Account is the stable local representation of an independently identifiable contractual, ledger, or asset-holding relationship with an Institution. It persists across connections, captures, imports, files, card instruments, and currencies.
+A Financial Account is the stable source-scoped representation established within one integration namespace, Source Connection, contract-defined stable key, and Identity Epoch. It persists across Captures and Import Runs in that scope but is never merged with an Account from another integration or connection.
 
 The required account types are:
 
@@ -103,16 +105,14 @@ The required account types are:
 - `loan`
 - `investment`
 - `other`
-- `unknown`
 
 Current product paths support `depository`, `credit`, `loan`, and `investment`. Subtype is optional and evidence-gated. A credit-card account is `credit / credit_card`; a crypto exchange or self-custody wallet is `investment / crypto_exchange` or `investment / non_custodial_wallet` when its account boundary is supported by source evidence.
 
 | Field | Requirement | Rule |
 | --- | --- | --- |
 | `financial_account_id` | required | Stable local ID; never a source row ID or account-number hash |
-| Institution | required | May be provisional when provider identity is unresolved |
+| Institution | required | Integration contract must resolve it uniquely before admission |
 | `account_type` | required | One of the canonical top-level types |
-| `identity_status` | required | `provisional`, `confirmed`, or `conflicted` |
 | canonical entity lineage | required | Links account identity to supporting Source Records |
 | `account_subtype` | optional | Never inferred solely from workflow name |
 | display name | optional | Source-backed or user asserted |
@@ -120,9 +120,7 @@ Current product paths support `depository`, `credit`, `loan`, and `investment`. 
 
 A Financial Account may contain multiple currencies. Currency-specific files do not prove separate currency subaccounts. A separate currency subaccount is created only when the source establishes independent identity.
 
-Account identity evidence is represented by multiple Account Identifiers rather than one global `account_number` field. Initial kinds are `account_number_hash`, `account_mask`, and `source_account_label`. Each identifier records its Financial Account, kind, value, supporting Source Record, observation time, and value origin. Source-file IDs, statement-row IDs, content hashes, and filename-derived ingestion keys are not Account Identifiers. Provider account IDs are deferred until an actual provider integration requires them.
-
-An account stays `provisional` when only masks, labels, or inferred identifiers exist; Institution-scoped account-number evidence or explicit user confirmation may make it `confirmed`; mutually exclusive evidence makes it `conflicted`. Conflict stops silent reconciliation but does not rewrite or delete either source record.
+An Account Identifier is the stable source key that the Integration contract scopes by namespace, Source Connection, and Identity Epoch. Masks, labels, source-file IDs, row IDs, content hashes, filename-derived keys, and user input cannot establish identity; an Integration without a unique stable key cancels the attempted Capture.
 
 ### Card Instrument
 
@@ -142,7 +140,7 @@ A Balance Observation is a typed, time-bound measurement associated with a Finan
 | balance kind | required |
 | non-negative or signed amount according to the defined balance kind, plus currency | required |
 | collection time | required |
-| source-effective time | optional when the source does not provide it |
+| contract-defined effective time | required |
 | canonical entity lineage | required |
 | derivation metadata | required when derived |
 
@@ -161,7 +159,7 @@ All account types share one Financial Transaction entity. Credit-card transactio
 | direction | required | `inflow` or `outflow` across the Financial Account boundary; ambiguous source rows are not promoted |
 | `effective_on` | required | Local calendar date selected deterministically |
 | `effective_on_basis` | required | `occurred`, `authorized`, `posted`, `accounting`, or `inferred` |
-| `posting_status` | required | `pending`, `posted`, or `unknown` |
+| `posting_status` | required | `pending` or `posted`; unresolved source semantics cancel the attempted Capture |
 | canonical entity lineage | required | One or more supporting Source Records |
 | description and raw description | optional | Raw source text is distinct from enrichment |
 | occurred, authorized, posted, and accounting date/time observations | optional | Kept separately with precision, time origin, source timezone, and UTC normalization semantics |
@@ -170,11 +168,11 @@ All account types share one Financial Transaction entity. Credit-card transactio
 
 Signed report values are derived from amount and direction; the canonical model does not copy Plaid's provider-specific positive-outflow sign convention.
 
-`posting_status` is independent of billing, payment, refund, reversal, and projection state. [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md) defines it by account-ledger booking, requires a verified Integration mapping, and keeps `unknown` as the exceptional fail-safe; downloading a row does not prove it is posted.
+`posting_status` is independent of billing, payment, refund, reversal, and projection state. [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md) defines it by account-ledger booking, while ADR 0008 requires a total verified Integration mapping and cancels an attempted Capture whose required status cannot be resolved.
 
-A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, `unbilled | billed | unknown` billing status, Credit Card Billing Statement membership, original amount and currency, provenance-bearing conversion evidence, installment detail, and source payment status. Filename-derived billed/unbilled values are `parser_inference`.
+A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, optional `unbilled | billed` billing status, Credit Card Billing Statement membership, original amount and currency, provenance-bearing conversion evidence, installment detail, and source payment status. An unsupported optional fact is absent rather than `unknown`.
 
-An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`; [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md) fixes their direction, cardinality, confirmation evidence, and separation from inert Transaction Match Candidates.
+An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`; ADR 0007 fixes their direction and cardinality, while ADR 0008 requires contract-established source-scoped evidence and stores no match candidates.
 
 Source removal is projection lifecycle, not economic evidence of refund, reversal, or cancellation. When a provider protocol supplies added, modified, or removed patches, its cursor and mutation semantics remain in Source Sync State and projection processing rather than being copied into transaction status.
 
@@ -186,7 +184,7 @@ A Credit Card Billing Statement is an evidence-gated, settled billing-cycle summ
 | --- | --- |
 | local ID, Financial Account, lineage, evidence sufficient to establish a settled cycle | source statement ID, period start/end, issue date, due date, statement currency, statement balance, minimum payment, totals, transaction membership |
 
-A deposit transaction query, CSV export, filename, Source Capture, and unbilled credit-card list are not Statements. Statement period, issue, and due dates belong to the Credit Card Billing Statement rather than becoming transaction date observations; a billed status may exist without Statement membership. A provider-issued PDF or equivalent file is a Statement Document retained as a Source Record; file form alone does not create a canonical Credit Card Billing Statement.
+A deposit transaction query, CSV export, filename, Source Capture, and unbilled credit-card list are not Statements. Statement period, issue, and due dates belong to the Credit Card Billing Statement rather than becoming transaction date observations; a billed status may exist without Statement membership. The first version retains only the Integration's compact Statement evidence rather than a replayable provider-issued document, and file form alone never establishes a canonical Statement.
 
 ### Security and Holding Observation
 
@@ -196,8 +194,8 @@ A Holding Observation is a source-reported evidence checkpoint for a Security he
 
 | Entity | Required | Optional or conditional |
 | --- | --- | --- |
-| Security | local ID, security type, identity status, lineage | provider identifiers, name, ticker, currency, display metadata |
-| Holding Observation | local ID, Financial Account, Security, observation time, lineage | quantity, cost basis, price, valuation, valuation time and currency |
+| Security | contract-established source-scoped identity, security type, lineage | provider identifiers, name, ticker, currency, display metadata |
+| Holding Observation | local ID, Financial Account, Security, contract-defined effective time, observation time, lineage, and at least one usable quantity or valuation | cost basis, price, valuation currency |
 
 A Holding Observation requires at least one usable quantity or valuation. The current holding is a projection from the latest valid observation; OctopusBeak does not synthesize daily snapshots when the source provides no observation.
 
@@ -208,15 +206,15 @@ BTC, ETH, and similar assets are Securities referenced by crypto Holding Observa
 | Classification | Concepts |
 | --- | --- |
 | Plaid-aligned | Institution as a provider reference; Account type/subtype hierarchy; Account-linked Transactions; Security; Holding; `depository`, `credit`, `loan`, and `investment`; `credit / credit_card`; `investment / crypto_exchange` and `non_custodial_wallet` |
-| Taiwan-adjusted | Stable local Financial Account identity; multiple evidence-backed Account Identifiers; multi-currency account boundary; non-negative Transaction amount plus explicit direction; multiple transaction dates plus effective-date basis; typed Balance Observations; Holding observations retained as checkpoints |
-| OctopusBeak-added | Supported Source coverage; Source Connection separated from Account; Source Capture, Source Record, and Import Run; entity- and field-level provenance; account identity status; Card Instrument; Credit Card Transaction Detail; generic Transaction Relation |
+| Taiwan-adjusted | Source-scoped Financial Account identity; contract-defined stable Account Identifier; multi-currency account boundary; non-negative Transaction amount plus explicit direction; multiple transaction dates plus effective-date basis; typed Balance Observations; Holding observations retained as checkpoints |
+| OctopusBeak-added | Supported Source coverage; Source Connection as identity namespace; Source Capture, compact Source Record, and atomic Import Run; origin-specific assertion lineage; Identity Epoch; Source Authority Routing; Contract Purge; Card Instrument; Credit Card Transaction Detail; generic Transaction Relation |
 | Excluded from canonical model | Workflow and filename labels as identities; source-row and content hashes as account IDs; mutable current balances; account-per-currency inference; card-per-account inference; generic Statement inferred from an export; separate CreditCardTransaction entity; liability Holding; authentication secrets |
 | Deferred until evidence requires it | Provider account/transaction IDs; provider cursor/webhook storage beyond generic Source Sync State; exact Taiwan account-subtype vocabulary; universal transaction-kind taxonomy; automatic merchant/category enrichment; physical schema and migration plan |
 
 ## Consequences
 
 - Canonical projections require more explicit relations and provenance than the current typed source tables.
-- Account reconciliation is deliberately conservative; provisional duplicates are preferable to silently combining unrelated accounts.
+- Accounts and Transactions remain source-scoped; Source Authority Routing prevents duplicate projection inputs without cross-source identity reconciliation.
 - Product queries derive current account, balance, and holding views from evidence-backed observations rather than assuming the latest imported row is authoritative.
 - Credit-card, investment, loan, and deposit sources share core account and transaction vocabulary while retaining type-specific components.
 - Workflow and schema refactors must preserve immutable evidence, value origin, and the separation between collection, processing, and financial facts.

--- a/docs/adr/0004-plaid-inspired-canonical-financial-model.md
+++ b/docs/adr/0004-plaid-inspired-canonical-financial-model.md
@@ -156,15 +156,15 @@ All account types share one Financial Transaction entity. Credit-card transactio
 | --- | --- | --- |
 | `financial_transaction_id` | required | Stable local ID |
 | Financial Account | required | Establishes account-relative meaning |
-| amount | required | Non-negative magnitude |
-| currency | required | Inference is allowed only with field provenance |
-| direction | required | `inflow`, `outflow`, or `unknown` from the account perspective |
+| amount | required | Exact non-negative magnitude booked to the Financial Account |
+| currency | required | Explicit denomination; inference is allowed only from traceable source or Integration evidence |
+| direction | required | `inflow` or `outflow` across the Financial Account boundary; ambiguous source rows are not promoted |
 | `effective_on` | required | Local calendar date selected deterministically |
-| `effective_on_basis` | required | `transaction`, `authorized`, `posted`, `accounting`, or `inferred` |
+| `effective_on_basis` | required | `occurred`, `authorized`, `posted`, `accounting`, or `inferred` |
 | `posting_status` | required | `pending`, `posted`, or `unknown` |
 | canonical entity lineage | required | One or more supporting Source Records |
 | description and raw description | optional | Raw source text is distinct from enrichment |
-| occurred, authorized, posted, and accounting date/time observations | optional | Kept separately; absent time or zone is not fabricated |
+| occurred, authorized, posted, and accounting date/time observations | optional | Kept separately with precision, time origin, source timezone, and UTC normalization semantics |
 | provider transaction ID | deferred | Not required by current Taiwan sources |
 | merchant, counterparty, and category enrichment | optional | Never treated as source fact without evidence |
 
@@ -172,7 +172,7 @@ Signed report values are derived from amount and direction; the canonical model 
 
 `posting_status` is independent of billing, payment, refund, reversal, and projection state. Missing source status is `unknown`; downloading a row does not prove it is posted.
 
-A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, `unbilled | billed | unknown` billing status, Credit Card Billing Statement membership, original amount and currency, FX date, installment detail, and source payment status. Filename-derived billed/unbilled values are `parser_inference`.
+A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, `unbilled | billed | unknown` billing status, Credit Card Billing Statement membership, original amount and currency, provenance-bearing conversion evidence, installment detail, and source payment status. Filename-derived billed/unbilled values are `parser_inference`.
 
 An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`. A relation requires explicit source evidence or a deterministic versioned rule with provenance. Ambiguous matching creates no relation.
 
@@ -186,7 +186,7 @@ A Credit Card Billing Statement is an evidence-gated, settled billing-cycle summ
 | --- | --- |
 | local ID, Financial Account, lineage, evidence sufficient to establish a settled cycle | source statement ID, period start/end, issue date, due date, statement currency, statement balance, minimum payment, totals, transaction membership |
 
-A deposit transaction query, CSV export, filename, Source Capture, and unbilled credit-card list are not Statements. A provider-issued PDF or equivalent file is a Statement Document retained as a Source Record; file form alone does not create a canonical Credit Card Billing Statement.
+A deposit transaction query, CSV export, filename, Source Capture, and unbilled credit-card list are not Statements. Statement period, issue, and due dates belong to the Credit Card Billing Statement rather than becoming transaction date observations; a billed status may exist without Statement membership. A provider-issued PDF or equivalent file is a Statement Document retained as a Source Record; file form alone does not create a canonical Credit Card Billing Statement.
 
 ### Security and Holding Observation
 

--- a/docs/adr/0004-plaid-inspired-canonical-financial-model.md
+++ b/docs/adr/0004-plaid-inspired-canonical-financial-model.md
@@ -170,11 +170,11 @@ All account types share one Financial Transaction entity. Credit-card transactio
 
 Signed report values are derived from amount and direction; the canonical model does not copy Plaid's provider-specific positive-outflow sign convention.
 
-`posting_status` is independent of billing, payment, refund, reversal, and projection state. Missing source status is `unknown`; downloading a row does not prove it is posted.
+`posting_status` is independent of billing, payment, refund, reversal, and projection state. [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md) defines it by account-ledger booking, requires a verified Integration mapping, and keeps `unknown` as the exceptional fail-safe; downloading a row does not prove it is posted.
 
 A Financial Transaction belonging to a `credit / credit_card` account may have one Credit Card Transaction Detail component. The component has no independent ID or lifecycle. Its optional fields include Card Instrument, `unbilled | billed | unknown` billing status, Credit Card Billing Statement membership, original amount and currency, provenance-bearing conversion evidence, installment detail, and source payment status. Filename-derived billed/unbilled values are `parser_inference`.
 
-An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`. A relation requires explicit source evidence or a deterministic versioned rule with provenance. Ambiguous matching creates no relation.
+An optional Transaction Relation links two transactions without merging or deleting them. Initial types are `pending_to_posted`, `refund_of`, `reversal_of`, `transfer_counterpart`, and `installment_of`; [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md) fixes their direction, cardinality, confirmation evidence, and separation from inert Transaction Match Candidates.
 
 Source removal is projection lifecycle, not economic evidence of refund, reversal, or cancellation. When a provider protocol supplies added, modified, or removed patches, its cursor and mutation semantics remain in Source Sync State and projection processing rather than being copied into transaction status.
 

--- a/docs/adr/0005-conservative-transaction-identity-and-revision-semantics.md
+++ b/docs/adr/0005-conservative-transaction-identity-and-revision-semantics.md
@@ -1,0 +1,97 @@
+# Conservative transaction identity and revision semantics
+
+Status: accepted
+
+## Context
+
+OctopusBeak must reconcile overlapping bank and credit-card downloads whose rows usually have no provider transaction ID, pending linkage, tombstone, stable source sequence, or complete-snapshot guarantee. Content-based set deduplication can collapse two real transactions with the same date, amount, and description, while append-only import can count the same source occurrence repeatedly. In-place updates or deletes would also make historical financial computations impossible to reproduce.
+
+This decision refines the Financial Transaction boundary in [ADR 0004](./0004-plaid-inspired-canonical-financial-model.md). Plaid's transaction IDs and `added` / `modified` / `removed` patch stream remain provider capabilities described in [the Plaid semantics research](../research/plaid-accounts-transactions-semantics.md); current Taiwan sources described in [the source-capability inventory](../research/octopusbeak-bank-source-capabilities.md) do not inherit those guarantees.
+
+## Decision
+
+OctopusBeak gives every Financial Transaction an opaque stable local ID and reconciles immutable source-record occurrences to that identity conservatively. False merges are more harmful than provisional duplicates: explicit source evidence or a deterministic versioned rule must establish equivalence, and weak or ambiguous similarity never silently merges transactions.
+
+This ADR defines logical identity, matching, source-assertion lifecycle, revision, and correction semantics. It does not prescribe physical tables, indexes, importer sequencing, matching thresholds, or user-interface flows.
+
+### Identity evidence
+
+A content hash, normalized matching signature, capture row coordinate, or occurrence ordinal is evidence for matching, not a Financial Transaction identifier. Source records that share content remain separate immutable occurrences.
+
+Identity continuity may be established by, in descending order of directness:
+
+1. a provider transaction ID or stable source sequence with a documented scope and lifecycle;
+2. another explicit source linkage that uniquely identifies the occurrence;
+3. a validated source-specific deterministic rule, with its rule version and supporting records retained; or
+4. an explicit user assertion.
+
+Amount, nearby dates, description similarity, or a shared content hash alone creates at most a match candidate. When evidence is ambiguous, the candidate transactions remain separate. `financial_transaction_id` is never computed from mutable business fields.
+
+### Overlapping downloads and multiplicity
+
+Comparable captures are reconciled as multisets within the same Financial Account, Supported Source, and declared capture scope. A source-specific matching signature groups candidate occurrences, while a stable source order or group occurrence ordinal may pair repeated identical rows one-to-one. Three identical rows therefore remain three transaction occurrences rather than collapsing into one.
+
+The ordinal is local matching evidence rather than durable identity. If count, order, or content changes make one-to-one pairing ambiguous, reconciliation does not guess which occurrence changed or disappeared. It records unmatched observations or withdrawal candidates according to the capture's completeness evidence.
+
+### Source assertion lifecycle
+
+Each source's support for a canonical projection has an append-only lifecycle:
+
+- `observed`: a capture first supports the occurrence;
+- `revised`: strong linkage shows that new evidence revises the same occurrence;
+- `withdrawn`: an explicit tombstone or a comparable capture with a declared complete scope withdraws the source assertion; and
+- `restored`: strong identity evidence shows that a withdrawn occurrence has reappeared.
+
+Absence from a later file, a different query window, or an incomplete capture is not withdrawal. Lifecycle changes retain Source Capture, Source Record, Import Run, matching-rule version, actor where applicable, and decision time. They describe projection evidence rather than the transaction's economic status: withdrawal never means refund, reversal, cancellation, or deletion.
+
+The current canonical projection is derived from effective source assertions and revisions. A transaction with no effective supporting assertion may be excluded from the default current view, but its identity, revisions, evidence, and historical visibility remain intact. One source's withdrawal does not deactivate a transaction still supported by another effective assertion.
+
+### Transaction revisions
+
+When provider linkage, a stable source sequence, or another unique deterministic match proves that changed evidence describes the same occurrence, OctopusBeak preserves `financial_transaction_id` and appends a Transaction Revision. Each revision retains the canonical values effective for that version, supporting Source Records, value origins, and applicable parser and matching-rule versions. Product queries may select the latest effective revision, while historical computations can remain pinned to the revision used at the time.
+
+Without strong linkage, a changed record creates a separate Financial Transaction. Pending-to-posted is not an ordinary revision: it remains two Financial Transactions connected by a provenance-bearing `pending_to_posted` Transaction Relation, as decided in ADR 0004.
+
+### Cross-source reconciliation
+
+Occurrences from different Supported Sources or Source Connections may share a Financial Transaction identity only after they have been reconciled to the same Financial Account and equivalence is established by a shared provider identifier, a validated cross-source rule, or a user assertion. Fuzzy similarity alone never auto-merges them.
+
+Transactions in different Financial Accounts remain distinct even when they describe opposite sides of one transfer or credit-card payment. Sufficient evidence may connect them with `transfer_counterpart`; it does not deduplicate them.
+
+### Identity corrections
+
+Discovering that previous occurrences were wrongly merged or split creates an append-only Transaction Identity Correction rather than rewriting an ID's meaning. Corrections record supporting evidence, actor, rule version, processing context, and decision time.
+
+- A merge preserves the historical identities and records which current identity survives.
+- A split supersedes an ambiguous combined identity and identifies the resulting current identities. An old ID is not silently reused for one child unless the evidence uniquely preserves that continuity.
+- A supersede decision preserves the prior identity and revisions while directing current queries to the corrected identity set.
+- Conflicting evidence stops automatic reconciliation until stronger evidence or a user assertion resolves it.
+
+Parser or matching-rule upgrades may propose or create provenance-bearing corrections when their evidence standard permits; they never directly rewrite existing IDs, revisions, or Source Records.
+
+## Plaid alignment classification
+
+| Classification | Semantics |
+| --- | --- |
+| Plaid-aligned | Provider transaction IDs may establish identity; provider patch protocols may explicitly add, modify, or remove source assertions. |
+| Taiwan-adjusted | Opaque stable local transaction identity; multiset occurrence matching for overlapping downloads; absence is not removal; source-specific deterministic rules preserve uncertainty and multiplicity. |
+| OctopusBeak-added | Append-only source-assertion lifecycle, Transaction Revisions, cross-source reconciliation provenance, and merge / split / supersede identity corrections. |
+| Excluded | Content-hash transaction IDs, set deduplication, fuzzy automatic merges, destructive row replacement, removal-as-refund, and silent ID remapping after rule upgrades. |
+| Deferred | Physical schema and indexes, source-specific signatures, candidate scoring, review UX, migration, and retention policy. |
+
+## Consequences
+
+- Current views require projection over effective assertions and revisions rather than selecting the latest imported row alone.
+- Identical real transactions survive deduplication, while repeated observations can support one stable identity when evidence is sufficient.
+- Provisional duplicates remain visible until stronger evidence resolves them; this is an intentional safety trade-off.
+- Reprocessing and rule upgrades remain auditable and cannot silently change historical calculations.
+- Source integrations that later provide stable IDs, tombstones, or patch streams can supply stronger identity evidence without changing the local canonical identity model.
+
+## Rejected alternatives
+
+- Use a date / amount / description hash as identity: mutable fields and genuine identical purchases make it unstable and lossy.
+- Treat matching signatures as sets: this collapses repeated same-content transactions.
+- Infer removal from absence in any later capture: query scope and completeness are not reliable enough.
+- Update or delete a canonical transaction in place: this destroys the evidence needed to reproduce historical views.
+- Automatically merge cross-source fuzzy matches: false merges are harder to detect and reverse than provisional duplicates.
+- Reuse an old ID silently after a merge or split correction: downstream references could retain the same identifier while its economic meaning changes.

--- a/docs/adr/0005-conservative-transaction-identity-and-revision-semantics.md
+++ b/docs/adr/0005-conservative-transaction-identity-and-revision-semantics.md
@@ -1,6 +1,8 @@
 # Conservative transaction identity and revision semantics
 
-Status: accepted
+Status: superseded by ADR 0008
+
+[ADR 0008](./0008-source-scoped-lineage-and-strict-canonical-admission.md) replaces this ADR's provisional, cross-source, user-confirmed, candidate, and Identity Correction model with strict source-scoped identity and purge-and-recollect. Its source revision and withdrawal concepts survive only under ADR 0008's total integration-contract admission rules.
 
 ## Context
 

--- a/docs/adr/0006-canonical-transaction-money-currency-and-time.md
+++ b/docs/adr/0006-canonical-transaction-money-currency-and-time.md
@@ -1,0 +1,99 @@
+# Canonical transaction money, currency, and time
+
+Status: accepted
+
+## Context
+
+Current Taiwan bank, foreign-currency, credit-card, and loan sources expose different sign conventions, debit/credit columns, original and booked amounts, exchange-rate fields, and combinations of transaction, authorization, posting, accounting, FX, and billing dates. They usually provide local Taiwan civil dates or times without an explicit zone. Copying a provider-specific signed amount or coercing every date to an apparently exact timestamp would make cross-source calculations ambiguous and could manufacture precision the source did not provide.
+
+This decision refines the Financial Transaction and Credit Card Billing Statement boundaries in [ADR 0004](./0004-plaid-inspired-canonical-financial-model.md). Plaid remains a comparison reference only; OctopusBeak does not adopt Plaid field names, positive-outflow convention, or overloaded pending/posted `date` semantics.
+
+## Decision
+
+### Booked money and direction
+
+Every Financial Transaction records the exact non-negative magnitude actually booked to its Financial Account, its explicit denomination, and one required direction: `inflow` or `outflow`. Direction describes money crossing the account boundary rather than asset, liability, balance, or net-worth change.
+
+- Deposits and refunds enter an account.
+- Withdrawals and card purchases leave an account.
+- Credit-card and loan payments enter the liability account.
+- Loan disbursements leave the loan account; a corresponding deposit-account transaction remains a separate inflow and may be linked by `transfer_counterpart`.
+
+Reports may derive positive inflows and negative outflows, but canonical amounts never carry a provider-specific sign convention. Transfers retain both account-side transactions and are not deduplicated into one signed event.
+
+Every Supported Source Integration must define and test a versioned, unambiguous mapping from its amount signs, withdrawal/deposit columns, and debit/credit codes to canonical direction. If the fields are missing, contradictory, or cannot be interpreted uniquely, the immutable Source Record remains available with a projection data issue but is not promoted to a Financial Transaction. Canonical direction therefore has no `unknown` value.
+
+### Exact values and denomination evidence
+
+Canonical amounts and rates use an exact decimal domain type and never IEEE-754 binary floating point. Source formatting remains in the immutable Source Record; the canonical value is a lossless parsed decimal, and presentation rounding never changes it. The later physical schema may use decimal text or coefficient plus scale, but not a lossy `REAL` representation or one universal cents convention.
+
+Fiat denominations use ISO 4217. A non-ISO denomination belongs to a distinct controlled scheme rather than masquerading as an ISO currency code.
+
+Transaction currency is established in this evidence order:
+
+1. an explicit transaction-row denomination, recorded as `source_fact`;
+2. a currency-specific Source Capture or query scope, recorded with its provenance; or
+3. a versioned fixed-currency Integration contract.
+
+A Financial Account default currency is not transaction evidence and never overrides the booked amount denomination. A Source Record without a usable booked amount, direction, or traceable denomination does not enter the complete Financial Transaction projection.
+
+### Original amount and conversion evidence
+
+An optional Original Transaction Amount preserves the merchant, counterparty, or source denomination before conversion. It never replaces the amount booked to the Financial Account.
+
+Optional Transaction Conversion evidence may record:
+
+- original and booked exact amounts;
+- explicit base and quote denominations;
+- a source-reported rate;
+- a separately derived implied rate;
+- a source-reported conversion date;
+- the origin and applicable parser or rule version; and
+- a `consistent` or `conflicted` comparison under a versioned rounding tolerance.
+
+A rate derived from the two amounts is not presented as a bank rate. When the reported and implied rates disagree, the booked amount remains authoritative for account reconciliation and both rates remain visible. OctopusBeak does not fill missing conversion facts from a later market rate or infer a fee from the discrepancy. A fee becomes another Financial Transaction only when the source explicitly itemizes it.
+
+### Transaction date observations
+
+Occurrence, authorization, posting, and accounting dates are separate provenance-bearing Transaction Date Observations. Each observation retains:
+
+- role: `occurred`, `authorized`, `posted`, or `accounting`;
+- source-local calendar date;
+- optional source-local time;
+- source timezone;
+- UTC-normalized timestamp;
+- precision, including `date` for a date-only value; and
+- time origin, including `source_reported` or `defaulted_local_midnight`.
+
+All current Supported Source Integrations declare `Asia/Taipei` for otherwise unzoned transaction dates and times. A complete local date/time is normalized to UTC. A date-only value may use `00:00:00 Asia/Taipei` as its UTC storage anchor, but it must keep `precision = date` and `time_origin = defaulted_local_midnight`. Product display and ordering must not claim that this anchor is a source-reported event time. Future Integrations must declare their own versioned source-timezone rule rather than inheriting the current Taiwan default from the user's device or system timezone.
+
+Every Financial Transaction also has one required local `effective_on` date for default ordering, period queries, and reporting. After source fields are mapped to semantic roles, the common priority is:
+
+1. `occurred`;
+2. `authorized`;
+3. `posted`;
+4. `accounting`; then
+5. `inferred` only when no reliable transaction observation exists.
+
+The selected basis and rule provenance remain explicit. `effective_on` is a query projection and does not replace the underlying observations. Import time does not become a transaction date merely because source dates are absent.
+
+### Billing dates
+
+Statement period, issue date, and payment due date belong to the Credit Card Billing Statement, not to Transaction Date Observations. Transactions relate to an evidence-gated settled Statement through membership. A source-derived `billed` status may exist without enough evidence to establish a Statement; an unbilled list, filename, query month, export, or Source Capture never establishes one by itself.
+
+## Consequences
+
+- Financial calculations can reproduce exact booked values without provider sign or floating-point ambiguity.
+- Integration acceptance must include fixtures for signs, debit/credit meanings, denomination evidence, timezone normalization, date-only anchoring, and rejection cases.
+- Date-only rows remain efficiently sortable by UTC anchor while retaining their lower precision and source-local calendar meaning.
+- Spending chronology, account reconciliation, and statement liability can use occurred/effective, posted/accounting, and Statement dates respectively without conflating them.
+- Conflicting conversion evidence remains inspectable without inventing fees or rewriting the booked amount.
+
+## Rejected alternatives
+
+- Copy a signed provider amount: sign conventions differ and liability accounts make balance-effect interpretations ambiguous.
+- Allow `direction = unknown` in canonical transactions: Integration ambiguity would leak into every financial computation instead of being rejected at projection time.
+- Infer currency from the account default: a Financial Account may contain multiple denominations.
+- Use binary floating point or universal cents: neither preserves all source amount, rate, investment, or non-ISO denomination precision.
+- Keep only one transaction date or use billing date as a transaction date: occurrence, settlement, accounting, and statement lifecycles answer different questions.
+- Treat a date-only UTC midnight anchor as exact time: the anchor is storage normalization, not source-reported precision.

--- a/docs/adr/0007-canonical-transaction-status-and-relation-semantics.md
+++ b/docs/adr/0007-canonical-transaction-status-and-relation-semantics.md
@@ -2,7 +2,7 @@
 
 Status: accepted
 
-OctopusBeak classifies transaction posting by account-ledger booking, keeps economic relations separate from source and projection lifecycle, and records uncertain pairings as inert candidates. This avoids importing Plaid-only identity guarantees while preserving Taiwan authorization, presentment, billing, refund, reversal, and transfer evidence without false merges.
+OctopusBeak classifies transaction posting by account-ledger booking and keeps economic relations separate from source and projection lifecycle. [ADR 0008](./0008-source-scoped-lineage-and-strict-canonical-admission.md) amends this decision by requiring total `pending | posted` mappings, rejecting unresolved required semantics, forbidding user-confirmed financial relations, and removing canonical match candidates.
 
 ## Context
 
@@ -14,13 +14,12 @@ The semantic comparison is documented in [Transaction posting semantics across P
 
 ### Posting status follows account-ledger booking
 
-Every Financial Transaction has `posting_status = pending | posted | unknown`:
+Every Financial Transaction has `posting_status = pending | posted`:
 
 - `pending`: source evidence describes an authorization, immediate-card record, expected entry, or reserved amount that the Institution has not yet booked to the account ledger;
-- `posted`: source evidence or a verified, versioned Supported Source Integration contract establishes that the Institution recorded the entry in the account ledger; and
-- `unknown`: an exceptional fail-safe when the source semantics remain indeterminate.
+- `posted`: source evidence or a verified, versioned Supported Source Integration contract establishes that the Institution recorded the entry in the account ledger.
 
-Each Integration defines and tests its status mapping per Source Record kind. A Taiwan credit-card transaction may be posted after merchant presentment while remaining unbilled until the statement cut-off, so `unbilled | billed | unknown` remains independent Credit Card Transaction Detail. Payment-network settlement, cancellation, refund, reversal, payment kind, and source-assertion lifecycle are also separate from posting status.
+Each Integration defines and tests a total status mapping per Source Record kind. A missing, indeterminate, or unsupported source status cancels the attempted Source Capture rather than producing `unknown`. A Taiwan credit-card transaction may be posted after merchant presentment while remaining unbilled until the statement cut-off, so optional `unbilled | billed` remains independent Credit Card Transaction Detail. Payment-network settlement, cancellation, refund, reversal, payment kind, and source-assertion lifecycle are also separate from posting status.
 
 Pending and posted records retain separate Financial Transaction identities. Confirmed continuity is a directed `pending_to_posted` Transaction Relation from pending to posted, never a Transaction Revision, merge, or deletion. An unmatched pending transaction remains independent.
 
@@ -38,24 +37,22 @@ Initial Transaction Relation semantics are:
 
 Cross-account transfers retain both transactions. A counterpart involving a `credit / credit_card` account is interpreted as a credit-card payment from account types and transaction directions rather than a separate relation type; a source-reported payment with no observed other side remains source fact without a counterpart relation.
 
-A confirmed Transaction Relation requires explicit source linkage, an explicit user assertion, or a validated, versioned rule that determines the pairing uniquely. Source wording, opposite direction, equal or summing amounts, nearby dates, and description similarity alone never confirm a relation.
+A Transaction Relation requires explicit source linkage or a validated, versioned integration contract that determines the pairing uniquely within one source-scoped identity. Source wording, opposite direction, equal or summing amounts, nearby dates, description similarity, and user input never confirm a relation.
 
 Every relation connects two transactions, but there is no global one-to-one cardinality constraint. Evidence may establish split postings, partial or repeated refunds, compound corrections, or multi-entry transfers through multiple pairwise relations; relations do not invent amount allocations or an aggregate financial event absent from the source.
 
 `transfer_counterpart` is semantically symmetric even if physical storage orders endpoint IDs to prevent duplicate edges. All other initial relation types have the direction stated above.
 
-### Candidates have no financial effect
+### Unconfirmed relations are absent
 
-A Transaction Match Candidate retains a proposed relation kind, participating transactions, supporting and contradicting evidence, and producing rule version. It never changes identity, deduplicates transactions, excludes transfers from spending, or affects any other financial computation.
-
-Confirmation creates a separate Transaction Relation and preserves the candidate and decision history. Candidate scoring and review UI remain deferred.
+An optional relation that cannot be established uniquely is omitted rather than represented by an `unknown`, conflict, or Transaction Match Candidate. If an Integration attempts to emit mutually incompatible required mappings, sync admission cancels the attempted Source Capture; users cannot confirm financial relations in the first version.
 
 ## Consequences
 
-- Taiwan Integrations need acceptance fixtures for each Source Record kind's posting-status mapping and for indeterminate cases.
+- Taiwan Integrations need acceptance fixtures proving a total posting-status mapping for every admitted Source Record kind; an unhandled case cancels the attempted Capture.
 - Credit-card authorization, merchant presentment, and statement billing remain separately queryable.
-- Financial calculations may trust confirmed relations while displaying candidates as uncertainty without silently changing totals.
-- The physical schema, candidate ranking, review interaction, and migration sequence remain implementation-handoff decisions rather than part of this ADR.
+- Financial calculations may trust admitted relations without interpreting candidates or user financial corrections.
+- The physical schema and migration sequence remain implementation-handoff decisions rather than part of this ADR.
 
 ## Rejected alternatives
 
@@ -63,4 +60,4 @@ Confirmation creates a separate Transaction Relation and preserves the candidate
 - Treat `unbilled` as pending: Taiwan banks use unbilled for merchant-presented activity awaiting the statement boundary.
 - Add cancelled, refunded, reversed, or paid to posting status: these are source facts, economic relations, or payment semantics rather than ledger-booking states.
 - Merge pending and posted records or opposite transfer sides: this destroys distinct source evidence and assumes provider identity guarantees current sources do not have.
-- Promote fuzzy matches directly to relations: false relationships would silently alter identity and financial computation.
+- Store fuzzy or uncertain matches as candidates: ADR 0008 requires integrations to omit unsupported optional relations and reject unresolved required mappings before canonical persistence.

--- a/docs/adr/0007-canonical-transaction-status-and-relation-semantics.md
+++ b/docs/adr/0007-canonical-transaction-status-and-relation-semantics.md
@@ -1,0 +1,66 @@
+# Canonical transaction status and relation semantics
+
+Status: accepted
+
+OctopusBeak classifies transaction posting by account-ledger booking, keeps economic relations separate from source and projection lifecycle, and records uncertain pairings as inert candidates. This avoids importing Plaid-only identity guarantees while preserving Taiwan authorization, presentment, billing, refund, reversal, and transfer evidence without false merges.
+
+## Context
+
+[ADR 0004](./0004-plaid-inspired-canonical-financial-model.md) introduced Financial Transaction, posting status, and Transaction Relation; [ADR 0005](./0005-conservative-transaction-identity-and-revision-semantics.md) made transaction identity and revisions append-only and conservative. The remaining ambiguity was how to distinguish pending from posted in Taiwan sources, represent cancellation and compensating movements, and retain useful but unconfirmed relation hypotheses.
+
+The semantic comparison is documented in [Transaction posting semantics across Plaid, UK Open Banking, and Taiwan banks](../research/transaction-posting-semantics.md). Plaid is a comparison model only, and OctopusBeak does not assume Plaid transaction IDs, pending linkage, cursor patches, or enrichment.
+
+## Decision
+
+### Posting status follows account-ledger booking
+
+Every Financial Transaction has `posting_status = pending | posted | unknown`:
+
+- `pending`: source evidence describes an authorization, immediate-card record, expected entry, or reserved amount that the Institution has not yet booked to the account ledger;
+- `posted`: source evidence or a verified, versioned Supported Source Integration contract establishes that the Institution recorded the entry in the account ledger; and
+- `unknown`: an exceptional fail-safe when the source semantics remain indeterminate.
+
+Each Integration defines and tests its status mapping per Source Record kind. A Taiwan credit-card transaction may be posted after merchant presentment while remaining unbilled until the statement cut-off, so `unbilled | billed | unknown` remains independent Credit Card Transaction Detail. Payment-network settlement, cancellation, refund, reversal, payment kind, and source-assertion lifecycle are also separate from posting status.
+
+Pending and posted records retain separate Financial Transaction identities. Confirmed continuity is a directed `pending_to_posted` Transaction Relation from pending to posted, never a Transaction Revision, merge, or deletion. An unmatched pending transaction remains independent.
+
+Explicitly source-reported cancellation of an unposted transaction remains provenance-bearing source fact in the first canonical model. Disappearance, Source Assertion withdrawal, or failure to find a posted counterpart never establishes cancellation; a separately booked compensating movement is evaluated as refund or reversal.
+
+### Confirmed relations remain evidence-gated
+
+Initial Transaction Relation semantics are:
+
+- `pending_to_posted`: pending transaction to posted transaction;
+- `refund_of`: separately booked partial or full return of value to the original transaction, which remains an economic event;
+- `reversal_of`: separately booked correcting or voiding transaction to the original transaction;
+- `transfer_counterpart`: a semantically symmetric connection between separate account-side transactions of one movement; and
+- `installment_of`: installment transaction to an observed, evidence-backed original transaction.
+
+Cross-account transfers retain both transactions. A counterpart involving a `credit / credit_card` account is interpreted as a credit-card payment from account types and transaction directions rather than a separate relation type; a source-reported payment with no observed other side remains source fact without a counterpart relation.
+
+A confirmed Transaction Relation requires explicit source linkage, an explicit user assertion, or a validated, versioned rule that determines the pairing uniquely. Source wording, opposite direction, equal or summing amounts, nearby dates, and description similarity alone never confirm a relation.
+
+Every relation connects two transactions, but there is no global one-to-one cardinality constraint. Evidence may establish split postings, partial or repeated refunds, compound corrections, or multi-entry transfers through multiple pairwise relations; relations do not invent amount allocations or an aggregate financial event absent from the source.
+
+`transfer_counterpart` is semantically symmetric even if physical storage orders endpoint IDs to prevent duplicate edges. All other initial relation types have the direction stated above.
+
+### Candidates have no financial effect
+
+A Transaction Match Candidate retains a proposed relation kind, participating transactions, supporting and contradicting evidence, and producing rule version. It never changes identity, deduplicates transactions, excludes transfers from spending, or affects any other financial computation.
+
+Confirmation creates a separate Transaction Relation and preserves the candidate and decision history. Candidate scoring and review UI remain deferred.
+
+## Consequences
+
+- Taiwan Integrations need acceptance fixtures for each Source Record kind's posting-status mapping and for indeterminate cases.
+- Credit-card authorization, merchant presentment, and statement billing remain separately queryable.
+- Financial calculations may trust confirmed relations while displaying candidates as uncertainty without silently changing totals.
+- The physical schema, candidate ranking, review interaction, and migration sequence remain implementation-handoff decisions rather than part of this ADR.
+
+## Rejected alternatives
+
+- Treat every downloaded row as posted: collection does not prove account-ledger booking.
+- Treat `unbilled` as pending: Taiwan banks use unbilled for merchant-presented activity awaiting the statement boundary.
+- Add cancelled, refunded, reversed, or paid to posting status: these are source facts, economic relations, or payment semantics rather than ledger-booking states.
+- Merge pending and posted records or opposite transfer sides: this destroys distinct source evidence and assumes provider identity guarantees current sources do not have.
+- Promote fuzzy matches directly to relations: false relationships would silently alter identity and financial computation.

--- a/docs/adr/0008-source-scoped-lineage-and-strict-canonical-admission.md
+++ b/docs/adr/0008-source-scoped-lineage-and-strict-canonical-admission.md
@@ -1,0 +1,79 @@
+# Source-scoped lineage and strict canonical admission
+
+Status: accepted
+
+OctopusBeak admits canonical financial data only through total, versioned integration contracts; keeps identity source-scoped and immutable; and preserves append-only Source, Derived, and User Assertion lineage without conflict states or manual financial correction. This sacrifices cross-source reconciliation, permissive ingestion, raw replay, and repair-in-place so current and historical projections never depend on guessed identity, time, status, or precedence.
+
+This ADR supersedes [ADR 0005](./0005-conservative-transaction-identity-and-revision-semantics.md) and amends the identity, evidence-retention, admission, `unknown`, candidate, effective-time, and user-correction portions of [ADR 0004](./0004-plaid-inspired-canonical-financial-model.md) and [ADR 0007](./0007-canonical-transaction-status-and-relation-semantics.md).
+
+## Decision
+
+### Collection and processing are separate lineage
+
+A Source Capture exists only after one independent source-side observation passes its integration contract and sync admission checks. It records integration and contract version, Source Connection, product and account scope, observation time, completeness, and zero or more compact Source Records. A retry, pagination step, or processing rerun is not a new Capture; a later independent live observation is, even if its compact values are identical.
+
+Each Source Record belongs to exactly one Capture and is an immutable, compact evidence projection containing only identifiers, financial values, and provenance needed for canonical mapping. The first version stores no replayable PDF, CSV, response, page, or Source Artifact. It can rerun rules over retained compact fields but cannot recover an extraction field that was discarded.
+
+An Import Run atomically processes retained Source Records under identified parser and rule versions. Initial required mapping failure cancels the attempted Capture. A failed or partial rerun of an accepted Capture changes nothing; a successful complete-scope rerun may change only Derived Assertion lineage.
+
+### Identity is source-scoped and has no correction workflow
+
+Financial Account and Financial Transaction identity is established from integration namespace, Source Connection, product stream where applicable, a contract-defined stable source key, and an Identity Epoch. Accounts or transactions from different integrations or connections never share canonical identity, even when they appear to represent the same real-world subject or event.
+
+An Identity Epoch is a fence around one key uniqueness scope, normalization, reuse policy, and subject meaning. A new connection or a change to any of those identity semantics starts a new epoch that is never reconciled with the old one; non-identity parser and enrichment changes advance only their contract or rule version.
+
+The first version has no provisional or conflicted identity, cross-source merge, split, relink, user merge, fuzzy deduplication, or Identity Correction. Source Authority Routing assigns one authoritative integration, connection, and stream to each projection input. User-facing Account Display Groups may organize accounts visually but cannot change identity, move facts, deduplicate, or authorize aggregation.
+
+If an admitted contract is later proven wrong, a source-scoped Contract Purge atomically hard-deletes all affected Captures and dependent Records, Assertions, revisions, relationships, and projections for the integration, connection, product stream, contract version, or identity epoch. Only non-financial operational audit metadata remains; the old version or epoch is disabled, and recovery requires recollection. Unavailable historical source data is intentionally lost rather than repaired through identity lineage.
+
+### Assertions have origin-specific lifecycle
+
+Every accepted claim belongs to one origin stream:
+
+- Source Assertion: a fact explicitly supported by compact Source Records;
+- Derived Assertion: a versioned parser, normalization, enrichment, or reconciliation result; or
+- User Assertion: a person's explicit value for a user-governed field.
+
+Only a continuous same-origin, same-producer claim lineage may supersede itself. Cross-origin overwrite is forbidden. Current projections apply contract-declared Source Authority Routing and producer authority rather than last-write-wins or runtime conflict selection.
+
+Source Assertions may be revised only through contract-established stable claim identity. An explicit tombstone or absence from a comparable contract-declared complete scope may withdraw a Source Assertion; later reassertion of the same stable key may restore it. Withdrawal and restoration describe source support, not refund, reversal, cancellation, deletion, or Contract Purge, and users cannot initiate them.
+
+A successful, atomic, complete-scope Import Run handles one Derived lineage in three ways: a changed supported value supersedes the old assertion; an explicitly unsupported optional fact withdraws it; and an unchanged value retains its assertion while gaining run provenance. Failed or partial output has no effect, and one producer never supersedes another producer's lineage. Enrichment may provide descriptive and organizational facts but cannot rewrite financial amounts, dates, status, balances, holdings, or Statement totals.
+
+User Assertions are limited in the first version to display names, categories, tags, and notes. They may take projection precedence for those fields and may be withdrawn so projection falls back to the next valid assertion. Users cannot override financial facts, choose a Statement candidate, establish identity, or withdraw and restore Source Assertions.
+
+### Admission is total and conflict-free
+
+Every required canonical classification and identity must have one contract-defined value before persistence. Required enums never use `unknown`; unsupported optional facts are absent. Transaction posting status is exactly `pending | posted`. An indeterminate, unsupported, or mutually incompatible required candidate is an integration contract or sync preflight error that cancels the entire attempted Capture; canonical storage contains no conflict status, candidate assertions, partial Capture, or financial conflict selector.
+
+A new billing cycle creates a new Statement. A Statement Revision exists only when stable source identity, revision, or replacement semantics prove that the source corrected the same Statement. Ambiguous same-period documents are rejected by the integration rather than stored for canonical or user selection.
+
+A new Balance or Holding measurement creates a new Observation. An Observation Revision exists only when the integration contract proves that the source corrected the same measurement; matching dates, recollection, and rerunning a Capture are insufficient. Repeated independent observations are retained even when values match, while repeated claims may share canonical claim lineage and add Capture provenance.
+
+### Time requirements follow fact type
+
+All admitted lineage records mandatory `recorded_at`. Fact types declare financial effective time as required or not applicable rather than exposing a universal nullable field:
+
+- Transactions require their contract-defined effective date and precision.
+- Statements require their settled cycle and applicable dates.
+- Balance and Holding Observations require contract-defined `effective_at` so they can support historical valuation.
+- Account lifecycle facts require contract-defined `effective_at` because they affect synchronization and historical financial scope.
+- Pure names, labels, categories, tags, and notes have no financial effective time and use `recorded_at` only.
+
+Observation, collection, file, import, and recording times never substitute for required effective time. Backfilled source data keeps its historical financial effective time and the current admission time, so financial-time and knowledge-time queries do not pretend the system knew the fact earlier.
+
+## Consequences
+
+- Integrations must provide fixtures for every accepted record kind, required classification, identity key, completeness rule, temporal requirement, revision link, and authority route. Runtime surprises fail the whole Capture.
+- Current projections are simpler because they never interpret `unknown`, identity conflict, match candidates, user financial overrides, or partial imports.
+- Cross-source duplicates and identity discontinuities remain visible by design. Presentation grouping does not make them safe to aggregate.
+- Historical reproducibility covers compact admitted evidence, assertion lineage, financial effective time, and system recording time; it does not cover discarded raw inputs or purged contract data.
+- Plaid remains a comparison model only. OctopusBeak is intentionally stricter than Plaid's nullable balance and holding time metadata because historical valuation requires effective time; the comparison is recorded in [Plaid reference semantics for missing or imprecise effective time](../research/plaid-effective-time-semantics.md).
+
+## Rejected alternatives
+
+- Preserve raw Source Artifacts for parser replay: the first version stores only compact integration output.
+- Store `unknown`, conflicts, or candidates for later resolution: unresolved required semantics fail admission.
+- Repair identity through merge, split, relink, or user action: identity stays source-scoped; contract bugs purge and recollect.
+- Reconcile cross-source duplicates: authority routing prevents duplicate use without shared identity.
+- Allow users to correct financial facts: the first version limits user assertions to descriptive and organizational fields.

--- a/docs/adr/0009-reset-legacy-financial-data-before-canonical-collection.md
+++ b/docs/adr/0009-reset-legacy-financial-data-before-canonical-collection.md
@@ -1,0 +1,36 @@
+# Reset legacy financial data before canonical collection
+
+Status: accepted
+
+OctopusBeak will not migrate its product-specific legacy ledger into the strict canonical financial model. The breaking-change release instead performs a version-triggered Canonical Reset Cutover, preserving only operational configuration and rebuilding all financial state from newly collected, contract-compliant Captures. This deliberately loses legacy history because the inspected data cannot uniformly establish the identity and effective-time semantics required by the current model, while a compatibility migration would reintroduce exceptions the canonical admission boundary was designed to exclude.
+
+## Decision
+
+Before release, every enabled integration configuration that may survive the reset, and every integration the release continues to advertise as supported, must pass the Canonical Recollection Readiness Gate. Its versioned fixtures must resolve every identity, classification, status, effective-time, completeness, and authority requirement needed by the current canonical model. An unready supported integration blocks the release; old data compatibility is not part of this gate.
+
+On first startup of the breaking-change version, the application automatically and atomically:
+
+- moves the legacy ledger and downloads into Legacy Data Quarantine, outside all application read, import, replay, fallback, and recovery paths;
+- carries forward only Sign-in Details, enabled-integration configuration, Statement Selections, and non-financial preferences; and
+- creates and validates a new empty canonical store with new Source Connections and Identity Epochs.
+
+Financial records, Source Captures, Source Records, assertions, projections, user financial overrides and classifications, Source Sync State, import history, and automation-run history are not copied. Failure before commit leaves the legacy files unchanged and refuses to open a partial canonical store; it never falls back to the legacy model.
+
+Remote collection is not part of the cutover transaction. After local cutover commits, enabled integrations repopulate the store through ordinary Post-reset Recollection, including their normal scheduling, authentication, OTP, retry, and error-notification behavior. Until new Captures arrive, financial views show an explicit empty or awaiting-collection state and never display legacy values.
+
+Legacy Data Quarantine is a temporary safety buffer, not a supported restore path. The following application release automatically destroys it only when a durable local marker proves that cutover completed, the canonical store opened successfully, at least one contract-compliant recollection completed, and no canonical application path read the quarantined files. Otherwise the quarantine remains untouched for a later release. Physical deletion is never part of this ADR's planning work and must be implemented and verified separately.
+
+## Consequences
+
+- Legacy financial history, classifications, overrides, lineage, and run history are intentionally unavailable after reset and eventually deleted.
+- No migration mapper, dual read, dual write, compatibility projection, legacy fallback, Identity Correction, or raw-download replay mechanism is built.
+- The canonical model remains total and conflict-free: missing required semantics cause integration admission failure rather than a legacy exception.
+- New collection may not immediately recover history that a provider no longer exposes; the product must describe the affected view as awaiting collection or unavailable rather than imply continuity.
+- The inspected local ledger and downloads informed feasibility only, as recorded in [Current local ledger feasibility for canonical reset](../research/current-ledger-canonical-reset-feasibility.md). They are not migration fixtures and are not modified by this decision record.
+
+## Rejected alternatives
+
+- Migrate only legacy rows that appear compatible: rejected because it creates partial, product-dependent history and still requires migration-specific identity and time rules.
+- Keep the legacy database as a read-only compatibility view: rejected because it creates mixed authority and lets unqualified values bypass canonical admission.
+- Recollect during the cutover transaction: rejected because bank availability, OTP, and integration-specific retries would turn a local atomic replacement into a distributed transaction.
+- Delete legacy files immediately: rejected in favor of one release of read-disabled quarantine guarded by durable success markers.

--- a/docs/adr/0010-canonical-financial-store-and-projection-boundary.md
+++ b/docs/adr/0010-canonical-financial-store-and-projection-boundary.md
@@ -1,0 +1,23 @@
+# Canonical financial store and projection boundary
+
+Status: accepted
+
+OctopusBeak stores admitted source evidence, source-scoped identities, immutable typed financial revisions, assertion lineage, committed sync state, authority routes, and disposable current projections in one canonical SQLite database so each accepted financial change and its visible projection commit atomically. Operational configuration, secrets, failed attempts, temporary transport state, and scrub jobs remain outside that database; products read only the Current, Historical, and Lineage query contracts and never interpret compact payloads, assertion precedence, or legacy tables themselves.
+
+The write model is hybrid relational rather than EAV or a generic event store: typed domain tables own financial values and real foreign keys, while a shared append-only assertion spine records producer, lifecycle, knowledge time, and provenance. Current projections are transactionally materialized and generation-switched when rebuilt; historical projections are calculated from immutable facts using explicit financial-time and knowledge-time cutoffs. The complete physical specification and transaction boundaries are defined in [Canonical financial storage specification](../specs/canonical-financial-storage.md).
+
+## Consequences
+
+- Canonical commits, accepted Captures, committed Source Sync State, successful complete-scope Import Runs, assertion transitions, and affected current projections share one SQLite transaction.
+- Integration contracts must produce total typed values, identity, effective time, Capture Scope completeness, and authority routing before admission. Canonical storage contains no required-value `unknown`, conflict state, correction queue, or partial Capture.
+- Financial identity and values are never sourced from JSON, mutable entity rows, current projections, UUID timestamps, SQLite `REAL`, or JavaScript `Number`.
+- Contract bugs are handled by scoped Contract Purge and recollection, not Identity Correction or invented migration values. Globally incompatible schema changes use Canonical Reset.
+- WAL and application-level serialization provide one canonical writer; readers use snapshot connections through query contracts.
+
+## Rejected alternatives
+
+- Product-specific canonical tables or direct product reads: rejected because they duplicate precedence and historical semantics.
+- Generic entities, EAV values, JSON facts, or polymorphic target IDs: rejected because they weaken type, foreign-key, and admission guarantees.
+- Mutable assertion status or in-place financial updates: rejected because they erase knowledge-time lineage.
+- Materialized historical snapshots: rejected because the immutable write model can answer explicit dual-cutoff history without daily duplication.
+- A shared content-addressed payload store: rejected for the first version because compact Source Records are intentionally small and independent Capture occurrences must remain visible.

--- a/docs/adr/0011-orthogonal-transaction-taxonomy-and-enrichment.md
+++ b/docs/adr/0011-orthogonal-transaction-taxonomy-and-enrichment.md
@@ -1,0 +1,30 @@
+# Orthogonal transaction taxonomy and enrichment
+
+Status: accepted
+
+OctopusBeak models transaction enrichment as independent, typed dimensions rather than one provider-shaped category field: Transaction Kind describes the financial operation, Personal Category describes personal-finance purpose, Counterparty Participation describes who took part and in what role, and user-owned Transaction Tags provide many-valued organization. Transaction Relations, account-relative direction, posting status, Statement membership, and financial report inclusion remain separate financial semantics.
+
+The first version publishes immutable, versioned product taxonomies for Transaction Kind, Personal Category, Counterparty Role, and Kind/Category applicability. Published code meaning and parentage never change; corrections deprecate an old code and add a new one. Taxonomy packages live in the repository, pass fixture and immutability checks, seed the canonical database transactionally, and ship only inside immutable desktop releases. Installing a package does not reclassify existing Assertions.
+
+Source, Derived, and User enrichment continues through the canonical Assertion spine, provenance, complete-scope Import Runs, Canonical Financial Commits, and knowledge-time query rules established by ADRs 0008 and 0010. Current enrichment is a rebuildable typed projection, not a second event system. Unsupported optional enrichment is absent; an unresolved contract-required Kind or incompatible Kind/Category cancels the attempted Capture. Canonical storage contains no `other`, `uncategorized`, confidence contest, conflict status, or guessed fallback.
+
+The complete registries, permissions, physical responsibilities, projection precedence, report boundaries, and verification requirements are defined in [Transaction taxonomy and enrichment specification](../specs/transaction-taxonomy-and-enrichment.md).
+
+## Consequences
+
+- A merchant name, merchant activity code, Personal Category, and Transaction Kind cannot silently substitute for one another.
+- A transaction has either one current Personal Category, one exact complete Category Allocation, or no categorization. Partial allocations never participate in reports.
+- Financial report inclusion is decided before categorization. Included uncategorized amounts remain visible in a query-time Unclassified bucket; missing semantics required by a report produce an explicit eligibility-coverage gap.
+- Counterparty identity is reusable only through a stable producer-scoped key. Similar names never merge identities; user aliases change display only.
+- Confidence may support one producer's admission threshold but never becomes canonical uncertainty or runtime authority ranking.
+- User Assertions may select a registered category, provide a complete allocation, override display, or manage Tags; they cannot change Kind, Counterparty role/identity, or financial facts.
+- Historical enrichment uses the Transaction's financial date for period membership and Canonical Knowledge Point for what was known. It has no separately backdated financial `effective_at`.
+
+## Rejected alternatives
+
+- Copy Plaid Personal Finance Categories or Investments type/subtype directly: rejected because provider conventions combine concerns that OctopusBeak keeps separate.
+- One universal merchant/category field: rejected because non-merchant transactions, financial operation, merchant activity, and personal purpose have different identity and authority.
+- User-defined category trees in the first version: rejected in favor of a stable product taxonomy plus reusable Tags.
+- Fuzzy Counterparty merging or global merchant identity: rejected because names do not prove identity across producers.
+- Persist `unclassified`, eligibility, low-confidence, or conflict statuses: rejected because they are query results or admission failures, not canonical facts.
+- Let Category admit or exclude financial amounts: rejected because descriptive organization cannot rewrite financial semantics.

--- a/docs/research/current-ledger-canonical-reset-feasibility.md
+++ b/docs/research/current-ledger-canonical-reset-feasibility.md
@@ -1,0 +1,37 @@
+# 現有本機 ledger 對 canonical reset 的可行性
+
+## 範圍與方法
+
+本紀錄彙整 2026-08-16 對 OctopusBeak application-support `data` 與 `downloads` 目錄所做的唯讀盤點，用來判斷 legacy migration 是否值得實作。SQLite 以 immutable read-only 模式查詢；下載檔只統計數量、格式與 integration 分布。本文不保存帳號、交易內容、登入資料、原始 payload 或檔名。
+
+這是單一實際執行環境的可行性證據，不是 integration contract fixture，也不能證明某個 legacy row 符合 canonical admission。
+
+## 資料規模
+
+- `ledger.sqlite` 約 1.28 GB。
+- `downloads` 約 4,239 個檔案，以各 integration 的 CSV／JSON 輸出為主。
+- ledger 記錄 595 個 imported source versions。
+- 產品 overview、spending 與 liabilities 查詢直接依賴多組 product-specific tables；64 筆 spending overrides 仍引用 legacy statement row identity，盤點時沒有 orphan。
+
+## Canonical model gaps
+
+| Legacy product data | 盤點數量 | 可見資訊 | 對 strict canonical admission 的限制 |
+| --- | ---: | --- | --- |
+| Domestic account transactions | 427 | legacy account欄位與交易時間皆存在；3 筆 movement 為零 | 欄位存在不等於 integration contract 已證明 stable account identity、direction 與 status |
+| Foreign-currency transactions | 71 | legacy identity 與時間皆存在 | 仍需 contract 證明 account scope、money direction 與 typed date semantics |
+| Credit-card statement lines | 514 | 多數有 legacy card identity；1 筆 billed row 缺少 card identity | card key 不能自行提升為 Credit-card Financial Account identity |
+| Active loan transactions | 132 | 另有 6 筆透過 disabled lineage 不再 active | legacy visibility lifecycle 不能直接等同 canonical source assertion lifecycle |
+| Fund holding rows | 106 | overview projection 缺少 provider effective time，亦缺 fund ID／query period | 無法滿足 Holding Observation 的 effective-time 與 stable Security evidence |
+| Brokerage holding rows | 297 | 具有 legacy identity 與 `as_of` | 仍需由 integration contract 驗證語義，不能僅靠欄位名稱遷移 |
+| Brokerage trades | 91 | 具有 legacy identity 與日期 | 仍缺 strict admission 所需的完整 contract guarantee |
+| MaiCoin account snapshots | 347 | 只有 collection／capture time | 不可把 collection time 代替 Balance Observation `effective_at` |
+| MaiCoin statement rows | 890 | 多數具有 provider-created time；conversion row 另有 from／to values | event data可能可重新建模，但不能修補 snapshot effective time |
+| Credit-card snapshots | 294 | `as_of_date` 由 `capturedAt` 截取日期產生 | parser-derived collection date 不是 provider-established financial effective time |
+
+## 可行性結論
+
+Legacy data不是完全無用，但不同產品缺少的 canonical semantics 不一致。要保留其中一部分，仍需建立 product-specific migration contracts、信用卡 account／card 重建規則、legacy effective-time 例外、override identity 轉換及 mixed projection compatibility；即使完成，也無法讓 fund、crypto balance 與 credit-card snapshot history符合目前要求的 Measurement Effective Time。
+
+因此，最小且完整符合現有 model 的方案是 Canonical Reset Cutover：不讀取或轉換任何 legacy financial state，只保存 Operational Configuration，從新的 contract-compliant Captures 重建資料。舊 ledger 與 downloads 只進入 read-disabled Legacy Data Quarantine，並依 [ADR 0009](../adr/0009-reset-legacy-financial-data-before-canonical-collection.md) 的 marker 條件在後續 release 銷毀。
+
+此結論不保證 provider 仍能重新提供全部歷史。無法重新取得的歷史會永久缺少；產品必須顯示 awaiting collection 或 unavailable，而不能回退到 legacy projection。

--- a/docs/research/octopusbeak-bank-source-capabilities.md
+++ b/docs/research/octopusbeak-bank-source-capabilities.md
@@ -1,0 +1,128 @@
+# OctopusBeak 現有銀行資料儲存與來源能力盤點
+
+## 研究問題與範圍
+
+本文件回答：現有 collector、CSV importer、SQLite ledger 與產品 query，對台灣銀行存款、外幣存款、信用卡、餘額、交易、帳單／抓取批次及來源 lineage **實際能表達什麼**。證據基線為 commit [`93bfbd24`](https://github.com/WangWilly/OctopusBeak/tree/93bfbd24b3353b19b5cdf85b592e6731bc23ba90)。證券、基金、加密資產排除；貸款只標示既有邊界。
+
+證據強度分三層：
+
+- **Source fact**：collector 從銀行頁面/API 讀到並寫入 CSV/sidecar 的欄位。
+- **Parser inference**：importer 由目錄、檔名、sidecar 或欄位推導的值；不等同銀行明示。
+- **Normalized projection**：ledger 或產品層再計算的 account、balance、transaction、snapshot；不等同 source fact。
+
+`BANK_STATEMENT_CAPABILITIES` 與 automation task registry 只證明產品可選／可執行哪些 workflow，不單獨證明銀行端現在仍可成功抓取。registry 宣告 Fubon、ESun、Yuanta、Cathay、HNCB、CTBC、Post、SinoPac、LINE Bank 的 statement types，且 importer gate 依賴相應 crawler tasks；本文只有在 collector output 與 parser mapping 也吻合時，才列為「collector→import 已接通」。([statement-selection.ts L68-L79](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/automation/statement-selection.ts#L68-L79), [tasks.ts L29-L41](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/automation/server/tasks.ts#L29-L41))
+
+## 1. 現有儲存模型
+
+### 共通 provenance
+
+三種本票核心 row tables 共用：`statement_row_id`、`source_file_id`、`import_run_id`、`source_relative_path`、`source_row_index`、`source_hash`、`content_hash`、`bank`、`product`、`raw_payload_json`、`imported_at`、`created_at`。因此 normalized row 可回到某次 import、某個檔案路徑及 CSV row，但這不是外部銀行物件 ID。([schema.ts L4-L17](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L4-L17))
+
+### `account_transactions`
+
+來源專屬 normalized fields：`account_name`、`account_number`、固定必填的 `currency`、`accounting_date`、`transaction_date`、`transaction_time`、`transaction_at_utc`、`description`、`withdrawal_amount`、`deposit_amount`、`balance_after`、`note`、`fx_rate`。沒有 account master、account type（活存／支存／定存）、available/current balance 區分、transaction status 或 source transaction ID。([schema.ts L148-L163](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L148-L163))
+
+### `foreign_currency_transactions`
+
+欄位與 domestic 相同，另有 `query_currency`；每 row 的 `currency` 必填。沒有外幣 account master、存款種類或 balance type。([schema.ts L165-L181](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L165-L181))
+
+### 信用卡 tables
+
+`credit_card_statement_lines` 保存 `statement_type`、`statement_period`、card number/label、consume/posting dates、description、country/foreign currency、FX date/amount、TWD amount、installment action、payment status，以及 canonicalization 用的 `content_key`、`occurrence_index`、first/last seen。([schema.ts L183-L208](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L183-L208))
+
+`credit_card_captures` 與 `credit_card_capture_entries` 表示一次完整 billed+unbilled capture 及其 row membership；`credit_card_snapshots` 則按 card key、statement type、日期保存 transaction count 與 total amount。這些是 importer 建立的 normalized capture/snapshot，不是銀行提供的 balance object。([schema.ts L210-L267](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L210-L267))
+
+### 貸款邊界
+
+現有 `loan_transactions` 有 account number、trade/posting dates、item、計息期間、amount/rate、`balance_after`、overpayment、note；本票不延伸其 canonical model。([schema.ts L269-L282](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L269-L282))
+
+## 2. Collector → importer → projection
+
+### Collector 輸出
+
+銀行存款 workflows 的共同 contract 是每 account/currency 寫一對 `.csv` + `.json` sidecar。CSV 是 transaction rows；sidecar 通常保存 `帳號`、查詢期間、分行，外幣來源另存幣別。例：Fubon 寫帳務日、交易時間、摘要、支出、存入、即時餘額、附註及 account/query metadata；Cathay foreign 另寫 currency；SinoPac 與 LINE Bank 依 currency 分流到 domestic/foreign 目錄。([fubon-statements.ts L654-L705](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/fubon-statements.ts#L654-L705), [cathay-foreign-statements.ts L438-L490](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/cathay-foreign-statements.ts#L438-L490), [sinopac-statements.ts L600-L634](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/sinopac-statements.ts#L600-L634), [linebank-statements.ts L457-L491](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/linebank-statements.ts#L457-L491))
+
+信用卡 workflows 也寫 billed/unbilled CSV + sidecars。Fubon source columns 包含 last-card identifiers、consume/posting dates、foreign/TWD amounts、installment/payment status；ESun 有 statement period、payment currency/status；Yuanta 有 consume/posting dates、country/currency、FX date/amount、TWD amount，billed 才多 payment status。([fubon-credit-card-statements.ts L112-L135](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/fubon-credit-card-statements.ts#L112-L135), [esun-credit-card-statements.ts L82-L93](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/esun-credit-card-statements.ts#L82-L93), [yuanta-credit-card-statements.ts L627-L639](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/yuanta-credit-card-statements.ts#L627-L639))
+
+### Parser 與 persistence
+
+Importer recursively 掃描 `downloads/**/*.csv`，以第一層目錄 `<bank>-<product>` 推導 bank/product，讀同 basename JSON sidecar；這兩者都是 **parser inference**。([import-downloads-csv.ts L169-L177](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L169-L177), [import-downloads-csv.ts L207-L220](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L207-L220))
+
+第一 CSV row 被視為 header；空 row 被略過；duplicate headers 會加 `__2` 等 suffix。每 row 保留 raw payload，再交由 `(bank, product, filename)` mapping 寫入 typed table；未知組合進 `unsupported_statement_rows`。([import-downloads-csv.ts L1090-L1140](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L1090-L1140), [source-csv-parsers.ts L60-L149](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-csv-parsers.ts#L60-L149))
+
+Domestic parser 將「交易日期」缺值 fallback 為「帳務日期」，currency 強制 TWD；account identity 依序取 row、sidecar、filename；foreign parser 再由 row、sidecar 或 filename 推 currency。信用卡 `statement_type` 是由 filename 是否含 `unbilled` 推得。這些值均須視為 **parser inference**。([source-csv-parsers.ts L385-L425](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-csv-parsers.ts#L385-L425), [source-csv-parsers.ts L428-L459](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-csv-parsers.ts#L428-L459), [source-csv-parsers.ts L462-L498](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-csv-parsers.ts#L462-L498))
+
+Importer 在單一 SQLite transaction 內接受 source versions、寫 source files/rows/captures、寫 completed run；失敗 rollback，另記 failed event。([import-downloads-csv.ts L1306-L1413](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L1306-L1413))
+
+## 3. Identity、dedup 與 idempotency
+
+- `source_version_key = SHA256([bank, product, source_file_hash])`；相同 bytes 在同 bank/product 下再次觀察時不重投影，只增加 observation count/last seen。路徑不是 version identity。([source-version.ts L1-L7](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-version.ts#L1-L7), [import-downloads-csv.ts L1206-L1227](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L1206-L1227))
+- `source_file_id = hash(source relative path)`；`statement_row_id = hash(path, row index, raw-row hash)`。它們是本地 ingestion IDs，不是 provider IDs。([import-downloads-csv.ts L382-L394](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L382-L394))
+- 一般 typed rows 的 `content_hash = hash(bank, product, raw payload)`，但忽略 query period/currency keys；unique `content_hash` 或 `statement_row_id` 衝突視為 duplicate。因此 corrected source row 可能成為新 logical row，而非更新舊 row；也沒有 source transaction ID 可用來表達 mutation。([content-hash.ts L3-L8](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/content-hash.ts#L3-L8), [content-hash.ts L30-L41](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/content-hash.ts#L30-L41), [import-downloads-csv.ts L280-L301](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L280-L301))
+- Credit-card content identity 是 bank + card last4 + billed/unbilled + consume date + description + currency/amount + installment/payment status；相同 content 的真正重複 row 用 capture 內 occurrence index 保留。程式註解亦承認 source 沒有 transaction sequence 時可能 collision。([credit-card-identity.ts L21-L35](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/credit-card-identity.ts#L21-L35), [credit-card-capture.ts L26-L37](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/credit-card-capture.ts#L26-L37))
+- 只有 billed 與 unbilled 兩檔、capture metadata/card row counts 彼此一致時，capture 才被 verified；這是 importer completeness 驗證，不是銀行 statement finality。([import-downloads-csv.ts L829-L889](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L829-L889))
+
+## 4. Lineage：已有與缺少
+
+已有：
+
+- `import_runs`/events 記 importer 起訖、filters、file/row counts；`source_file_imports` 記 immutable version、first/last seen、observation count；`source_row_lineage` 記 source version row → projection table/row 與 inserted/duplicate/upserted outcome。([schema.ts L25-L94](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/db/schema.ts#L25-L94))
+- `source_files` 是「同一路徑最新觀察」的 mutable record；`source_file_imports` 才是多版本 history。([import-downloads-csv.ts L396-L461](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L396-L461))
+- 每 normalized row 仍存完整 raw CSV payload。([import-downloads-csv.ts L464-L509](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L464-L509))
+
+缺少：
+
+- Automation crawler run 有獨立 `task_run_id`、task/script/status/log/attempt/timestamps，但 schema 與 importer input 都沒有 `task_run_id` ↔ generated file/source version/import run 的 FK 或 correlation ID。只能用 path/timestamp/log 人工關聯。([store.ts L15-L32](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/automation/server/store.ts#L15-L32), [store.ts L246-L273](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/automation/server/store.ts#L246-L273), [import-downloads-csv.ts L33-L38](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/import-downloads-csv.ts#L33-L38))
+- 沒有 institution connection/login identity、provider account ID、provider transaction ID、statement ID、bank-side generated/export timestamp、coverage start/end 的結構化欄位；sidecar 的 query periods 是 free-form metadata。
+- 沒有「同一銀行 transaction 被後續 source 修正／刪除／pending→posted」的 explicit lineage。一般 dedup 是內容相等；credit card 是 local content key + occurrence。
+
+## 5. 產品使用的 normalized projections
+
+- Overview 讀取 source lineage、domestic/foreign transactions、credit-card captures/entries/snapshots/lines，建立 account overview、net assets、daily history 與 Sankey。([load-overview.ts L21-L76](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/overview/server/load-overview.ts#L21-L76))
+- Bank/foreign account identity 是 hash(kind, bank, product, account number, currency)；balance 是每 account/currency 最新一筆 transaction 的 `balance_after`，不是獨立 balance snapshot。([accounts.ts L319-L360](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/shared-ledger/server/accounts.ts#L319-L360), [accounts.ts L1153-L1159](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/shared-ledger/server/accounts.ts#L1153-L1159))
+- Transaction DTO 的 signed amount 是 deposit − withdrawal；date 依 transaction → accounting → import date fallback。信用卡 account 以 bank/product/card last4 聚合，amount 優先 TWD。這些是 **normalized projections**。([accounts.ts L847-L891](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/shared-ledger/server/accounts.ts#L847-L891))
+- Spending 直接 query domestic `account_transactions` 的提款/存款，並用負額 credit-card lines 識別 card payment；foreign transactions 不在此 spending query。([spending store.ts L107-L128](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/spending/server/store.ts#L107-L128))
+- Daily history 的日期主要取 source file modified/imported day；它不是 source-reported balance as-of timeline。([daily-history.ts L52-L79](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/overview/server/daily-history.ts#L52-L79), [daily-history.ts L106-L108](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/lib/overview/server/daily-history.ts#L106-L108))
+
+## 6. Supported-source capability matrix
+
+`✓` = collector output 與 parser mapping 都有 source-code 證據；`P` = parser/projected/inferred；`—` = 未見證據。所有列均缺 source transaction ID、statement ID 與 bank-side mutation semantics。
+
+| 實際接通來源 | Account identifier | Balance | Transaction/date | Statement/status | Currency/FX | Source identifiers |
+|---|---|---|---|---|---|---|
+| Fubon domestic | sidecar account；P account number extraction | ✓ running `即時餘額` | ✓ accounting date/time, debit/credit | query periods；無 row status | TWD(P) | — |
+| Cathay domestic | sidecar/API account no+label | ✓ running balance | ✓ accounting + transaction datetime | query period；無 row status | TWD(P) | — |
+| HNCB domestic | sidecar account/id | ✓ running balance | ✓ transaction/accounting date+time；另有存款人代號、票據欄 | query period；無 row status | row currency | — |
+| CTBC / Post domestic | sidecar account/id | ✓ running balance | ✓ accounting/transaction date+time | query periods；無 row status | TWD(P) | — |
+| Yuanta domestic | row account name/no | ✓ 帳面餘額 | ✓ accounting/transaction date+time | chosen range；無 row status | TWD(P) | — |
+| SinoPac / LINE Bank domestic | endpoint account id/label；sidecar | ✓ running balance | ✓ accounting/transaction date+time | query periods；無 row status | TWD(P), row FX optional | — |
+| Cathay / SinoPac / LINE Bank foreign | account id+currency；sidecar | ✓ running balance | ✓ dates/time, debit/credit | query periods；無 row status | ✓ currency；FX only when source row has it | — |
+| Yuanta foreign demand deposit | row account name/no/query currency | ✓ 帳面餘額 | ✓ accounting/transaction date+time | chosen range；無 row status | ✓ row/query currency + FX | — |
+| Fubon / ESun / Yuanta credit card | card number/label（projection 常退化 last4） | —；P capture total only | ✓ consume date；posting date 視來源；foreign/TWD amount | billed/unbilled 是 filename P；payment status 視來源 | foreign amount/currency；TWD amount；部分 FX date | — |
+
+Domestic/foreign table mappings 的完整名單由 parser 明確列出。([source-csv-parsers.ts L72-L109](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/ledger/source-csv-parsers.ts#L72-L109)) HNCB headers 證明額外欄位；Yuanta foreign headers 證明 query currency/FX；SinoPac/LINE Bank headers 都含 running balance 與 FX。([hncb-statements.ts L85-L97](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/hncb-statements.ts#L85-L97), [yuanta-foreign-currency-statements.ts L119-L133](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/yuanta-foreign-currency-statements.ts#L119-L133), [sinopac-statements.ts L19-L29](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/sinopac-statements.ts#L19-L29), [linebank-statements.ts L12-L22](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/linebank-statements.ts#L12-L22))
+
+### 無法證明或僅為邊界
+
+- **活存／支存／定存**：現行 domestic table 沒有 account type。Yuanta foreign workflow 明確導向「活期明細」，但這不足以推出其他 workflow 或定存能力；定存 balance/term/maturity/rate 沒有本票範圍內的 normalized fields。([yuanta-foreign-currency-statements.ts L630-L636](https://github.com/WangWilly/OctopusBeak/blob/93bfbd24b3353b19b5cdf85b592e6731bc23ba90/src/workflows/yuanta-foreign-currency-statements.ts#L630-L636))
+- Workflow 檔與 tests 證明 parser/DOM/API contract 的意圖，不證明 2026-08 銀行 production endpoint 可用、所有 account types 可列舉或歷史區間完整。
+- `payment_status` 是自由文字且各 card source 不一致；不能當成跨來源 posted/pending enum。
+- Running `balance_after` 只在有 transaction row 且 source 有該欄時存在；零交易 account 可能完全不出現在 normalized account overview。
+
+## 7. 給後續 canonical model 的事實護欄（非 schema 決策）
+
+1. 必須能保留 source fact、parser inference、normalized projection 的界線；目前若只看 typed row，三者容易混在一起。
+2. 不可預設 provider account/transaction/statement IDs 存在；現有 bank sources 幾乎只有 account label/number、card last4 與本地 hashes。
+3. 不可預設 transaction 有 stable mutation identity、pending→posted linkage、delete/update stream 或 webhook；repo 無此 source capability。
+4. `balance_after` 是 transaction-row running balance；credit-card liability 是 verified capture 的 locally computed total。兩者皆不可自動等同獨立 provider balance snapshot。
+5. `transaction_date`、`currency=TWD`、credit-card billed/unbilled 與 account identity 可能是 fallback/inference；canonical discussion 應明示 provenance/confidence。
+6. Source-file/import-run/row lineage 已足以做 ingestion audit，但 automation run 到 source file 的鏈缺失。
+7. Account type、term-deposit terms、statement coverage/finality、source timestamps、balance type 與 cross-source institution/account identity，都是現有模型無法可靠回答的 gaps；後續決策不可從 workflow 名稱臆測。
+
+## Unresolved gaps
+
+- Repo 中沒有 production fixture/recording 可證明各 bank 實際回傳的 account-type universe、空帳戶或零交易帳戶行為。
+- 查詢期間 sidecar 多為 workflow request，不一定等於 source 保證的完整 coverage；未見 truncation/page completeness 的統一持久化欄位。
+- 未見 institution-level canonical registry；`bank`/`product` 來自目錄命名，可能隨 workflow rename 改變。
+- 未見跨檔案辨識同一 account 的 provider ID；account number masking/label fallback 可能造成 collision 或分裂。
+- Tests 可驗證 importer idempotency 與部分 workflow parser，但不能提升為 bank production capability；本文件因此沒有把 test-only case 列成 supported source。

--- a/docs/research/plaid-accounts-transactions-semantics.md
+++ b/docs/research/plaid-accounts-transactions-semantics.md
@@ -1,0 +1,166 @@
+# Plaid account、transaction 與同步語義研究
+
+研究日期：2026-08-15
+
+範圍：為後續 canonical model 與領域詞彙決策建立事實護欄；本文不決定 OctopusBeak schema。
+
+來源政策：只引用 Plaid 官方文件。欄位語義以目前官方 API reference 為準；Plaid 文件或 API version 日後可能改變。
+
+## 結論摘要
+
+- Plaid 的 `Item` 是一次金融機構登入／連線，不是帳戶本身；同一組帳戶再次連線會產生不同 `item_id`。`account_id` 也不是永久跨連線識別碼：Plaid 無法 reconciliation、刪除 access token 後重連等情況都可能換 ID。[Items API](https://plaid.com/docs/api/items/)；[Accounts API](https://plaid.com/docs/api/accounts/)；[Preventing duplicate Items](https://plaid.com/docs/link/duplicate-items/)
+- Plaid account、balance 與 transaction response 同時包含必定為非 `null` 的核心欄位，以及大量 nullable、機構限定、產品限定或 Plaid enrichment 欄位。`available`、精確時間、merchant、分類、counterparty、location、MCC、pending linkage 都不能視為普遍存在。[Accounts API](https://plaid.com/docs/api/accounts/)；[Transactions API](https://plaid.com/docs/api/products/transactions/)
+- `/transactions/sync` 是「自某 cursor 後的有序 patch stream」，不是指定日期範圍的 snapshot。呼叫端必須拉完所有頁，累積 `added`、`modified`、`removed`，並保存最後 cursor；若 pagination 期間資料 mutation，整輪必須從該輪第一頁的原 cursor 重跑。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)；[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+- Pending 轉 posted 不是同一 record 的狀態翻轉：通常是 pending ID 出現在 `removed`，posted transaction 以新 ID 出現在 `added`，並可能用 `pending_transaction_id` 連回舊 ID；但機構不一定提供 pending，Plaid 也不保證成功 matching。[Transaction states](https://plaid.com/docs/transactions/transactions-data/)
+- Plaid 提供的穩定 IDs、cursor/delta、webhook 與 enrichment 是 provider capabilities。沒有明示相同 contract 的台灣網銀爬取資料，不可假設具備這些能力。
+
+## 1. Plaid 物件邊界與識別碼
+
+### Item 與 Account
+
+Plaid 定義一個 `Item` 為一次金融機構登入；一個 Item 通常包含該登入下的一個或多個 accounts。`access_token` 對應 Item，`item_id` 用於唯一識別該 Item 與 webhook routing。同一帳戶、同一機構再次經 Link 建立連線，仍會形成另一個 `item_id`，因此 Item identity 不等於外部世界中的銀行帳戶 identity。[Items API](https://plaid.com/docs/api/items/)；[Preventing duplicate Items](https://plaid.com/docs/link/duplicate-items/)
+
+`account_id` 是 Plaid 在該連線脈絡中的 account identifier，且大小寫敏感。官方保證它通常不變，但列出兩種明確例外：Plaid 無法把金融機構新回傳資料 reconciliation 到既有帳戶（例如名稱改變），或 access token 被刪除後以相同 credentials 重新連線。帳戶若從 response 消失，Plaid 說「likely closed」；closed accounts 本身不再回傳。[Accounts API](https://plaid.com/docs/api/accounts/)
+
+Plaid 另有 `persistent_account_id`，但它只支援採 Tokenized Account Numbers 的特定美國機構／帳戶，不能推廣成一般 account key。[Accounts API](https://plaid.com/docs/api/accounts/)；[Preventing duplicate Items](https://plaid.com/docs/link/duplicate-items/)
+
+### Account 核心欄位與可空性
+
+下表的「非 nullable」是 Plaid API reference 對 response object 的型別承諾，不代表其他資料來源也必須能供應。
+
+| 欄位 | Plaid response 語義 | Presence／nullability 限制 |
+| --- | --- | --- |
+| `account_id` | Plaid account identifier | 非 nullable；case-sensitive；可能因 reconciliation 或重連而改變 |
+| `balances` | balance fields 的容器 | 非 nullable object；其子欄位多為 nullable |
+| `name` | 使用者或金融機構指定的帳戶名稱 | 非 nullable string |
+| `type` | `investment`、`credit`、`depository`、`loan`、`other` 等粗分類 | 非 nullable enum string |
+| `mask` | 顯示 mask 或 official account number 的末 2–4 碼 | nullable；同一 Item 內也可能不唯一，且不保證等於帳號末四碼 |
+| `official_name` | 金融機構提供的官方帳戶名稱 | nullable |
+| `subtype` | checking、savings、credit card 等細分類 | nullable；有效值受 `type` 與 API taxonomy 約束 |
+
+來源：[Accounts API](https://plaid.com/docs/api/accounts/)；mask／duplicate 限制另見 [Preventing duplicate Items](https://plaid.com/docs/link/duplicate-items/)。
+
+### Balance 欄位與 freshness
+
+| 欄位 | Plaid response 語義 | Presence／nullability 限制 |
+| --- | --- | --- |
+| `available` | 金融機構判定目前可提領的金額 | nullable；並非所有機構計算。通常 `current` 為 null 時它非 null，但 limited-purpose checking 可兩者皆 null |
+| `current` | 帳戶持有或所欠總額 | nullable；正負號意義依 account type 不同。credit／loan 正值通常表示欠款；investment 表示機構呈現的資產總值 |
+| `limit` | credit limit；某些 depository 市場則是 overdraft limit | nullable；強烈依 account type／地區而定 |
+| `iso_currency_code` | ISO-4217 幣別 | nullable；與 `unofficial_currency_code` 互斥 |
+| `unofficial_currency_code` | 非 ISO 幣別 | nullable；與 `iso_currency_code` 互斥 |
+| `last_updated_datetime` | balance 最後更新時間 | nullable 且目前只對官方指定的單一機構回傳，不可作通用 freshness timestamp |
+
+除 `/accounts/balance/get` 或特定即時 balance endpoint 外，balance 可能是 cached，或由 Plaid 按最近取得的 transaction activity 調整；若 Item 啟用 Transactions，balance 至少與最近 transaction update 一樣新，但仍不是即時保證。[Accounts API](https://plaid.com/docs/api/accounts/)
+
+## 2. Transaction 欄位、required／nullable／conditional 語義
+
+以下聚焦 `/transactions/sync`／`/transactions/get` 的一般 Transaction object。Plaid API reference 將未標 `nullable` 的 response 欄位描述為非 nullable；部分非 nullable 容器仍可能是空陣列或其子欄位全為 null。
+
+### 核心與金額／日期
+
+| 欄位 | Plaid 語義 | Presence／nullability 限制 |
+| --- | --- | --- |
+| `transaction_id` | Plaid transaction identifier | 非 nullable、case-sensitive；pending 與 posted 通常是不同 ID |
+| `account_id` | 此 transaction 所屬 Plaid account | 非 nullable；繼承 account ID 的 provider scope 與變更限制 |
+| `amount` | transaction currency 下的 settled value | 非 nullable number；除 Income products 外，流出為正、流入為負 |
+| `date` | pending 時為發生日；posted 時為入帳日 | 非 nullable `YYYY-MM-DD` |
+| `pending` | 是否未入帳／未結算 | 非 nullable boolean；細節可能在結算前改變 |
+| `payment_channel` | `online`、`in store`、`other` | 非 nullable；取代 deprecated `transaction_type` |
+| `iso_currency_code` | ISO-4217 幣別 | nullable；與 `unofficial_currency_code` 互斥 |
+| `unofficial_currency_code` | 非 ISO 幣別 | nullable；與 `iso_currency_code` 互斥 |
+| `authorized_date` | 金融機構授權日 | nullable；posted UI 時官方通常偏好它而非 posted `date` |
+| `authorized_datetime` | 授權時間 | nullable；只由部分機構提供，可能帶預設 `00:00:00` |
+| `datetime` | 入帳時間 | nullable；只由部分機構提供，可能帶預設時間 |
+
+來源：[Transactions API](https://plaid.com/docs/api/products/transactions/)。
+
+### 描述、分類與 enrichment
+
+| 欄位 | Plaid 語義 | Presence／nullability／conditional 限制 |
+| --- | --- | --- |
+| `name` | merchant name 或 transaction description 的 legacy 欄位 | Transactions endpoints 會出現，但已 deprecated／不主動維護 |
+| `merchant_name` | Plaid 從 `name` enrichment 的較可讀 merchant | nullable；checks、account transfers 等可能沒有有意義的 merchant |
+| `original_description` | 金融機構原始描述 | nullable；在 sync/get 只有 request 設 `include_original_description=true` 才包含 |
+| `personal_finance_category` | Plaid 判定的 transaction intent taxonomy | nullable；若有則含非 null `primary`／`detailed` 及 nullable confidence；taxonomy 有版本 |
+| `counterparties` | Plaid 從 raw description 擷取的 merchant／institution／payment app 等 parties | array 可為空；party 的 `entity_id`、網站、logo、confidence 等可空；`entity_id` 是 Plaid-generated stable ID |
+| `merchant_entity_id` | 映射到跨門市 merchant 的 Plaid-generated stable ID | nullable |
+| `merchant_category_code` | 機構回報的 MCC | nullable；通常僅機構有傳送的 card purchase 才有 |
+| `location` | physical transaction 地點 | object 會出現但所有細節可空；online 不提供，且 availability 依 merchant |
+| `payment_meta` | inter-bank transfer metadata | Transactions endpoints 會出現，但沒有任何子欄位有資料保證；非 transfer 時全為 null |
+| `check_number` | 支票號碼 | nullable；只在 check transaction 填入 |
+| `account_owner` | sub-account owner 描述 | nullable、不常填、格式不標準且依機構 |
+
+來源：[Transactions API](https://plaid.com/docs/api/products/transactions/)。Plaid 明確描述 `merchant_name`、counterparties、PFC 與 entity IDs 為 Plaid enrichment／Plaid-generated data，而非原始銀行 statement 的普遍欄位。
+
+## 3. `/transactions/sync` 的 patch 與 cursor contract
+
+### Cursor 與 response
+
+- Request `cursor` 表示「上一次已看過的 update」。省略／空 cursor 會從 Item 最初 added transactions 開始回傳完整 update history；`"now"` 是既有 `/transactions/get` migration 的 fast-forward 特例，不建議新 Item 使用。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)；[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+- `added`：cursor 後加入 Item 的完整 Transaction objects；`modified`：cursor 後被修改的完整 Transaction objects；`removed`：被移除 transaction 的 `transaction_id` 與 `account_id`。三組各自按 ascending last-modified time 排序。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)
+- `next_cursor` 用於取得後續頁或未來 updates。只有 `has_more=false` 時，該 cursor 才代表這輪已拉完；官方保證拉完所有頁後的 cursor 至少有效一年，應持久保存。資料尚未 ready 時可能是空字串。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)
+- `has_more=true` 時必須用該頁 `next_cursor` 繼續，直到 false。Plaid sample 先累積所有頁的三種 patches，最後才把 updates 與 final cursor 一起 persist，這反映 cursor checkpoint 與 patch application 需要同一完整批次處理。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)
+- `/transactions/sync` 不接受 date range；若 consumer 只要日期範圍，必須在取得 sync updates 後自行 filter。[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+
+### Pagination mutation retry
+
+Plaid 可能在多頁 update 尚未拉完時又收到 underlying mutation，並回傳 `TRANSACTIONS_SYNC_MUTATION_DURING_PAGINATION`。官方要求：**整個 pagination loop 從本輪第一頁使用的原 cursor 重新開始**，不可只重試失敗的單頁。因此實作者需要同時保留「目前頁的 `next_cursor`」和「本輪起始 cursor」，且在完成全輪前不能把中途 cursor 當作 durable checkpoint。[Transactions API — `/transactions/sync`](https://plaid.com/docs/api/products/transactions/#transactionssync)；[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)；[Transactions errors](https://plaid.com/docs/errors/transactions/)
+
+## 4. Pending → posted
+
+Plaid 將 pending 與 posted 視為兩筆不同 transaction records，而非同一 record 的 boolean transition：
+
+1. pending transaction 先以自己的 `transaction_id` 存在，`pending=true`。
+2. 入帳時，pending ID 出現在 `/transactions/sync.removed`；posted transaction 以另一個 `transaction_id` 出現在 `added`，`pending=false`。
+3. 若 Plaid 能 matching，posted record 的 `pending_transaction_id` 指向舊 pending ID。removed 與 added 不保證在同一頁，但應在同一個 overall update。
+
+這不是完整保證：某些機構完全不提供 pending；Plaid 也可能無法 matching，讓 `pending_transaction_id=null`。Pending 的名稱、金額等可在 posted 時改變，authorization hold 甚至可能只消失而不產生 posted counterpart；posted transaction 也不絕對 immutable，仍可能因退款或重新分類被 modified／removed。[Transaction states](https://plaid.com/docs/transactions/transactions-data/)；[Transactions API](https://plaid.com/docs/api/products/transactions/)
+
+## 5. Webhook 與同步初始化
+
+- `SYNC_UPDATES_AVAILABLE` 是「有變更可取」通知，不攜帶 transaction patches；收到後仍要用最後 cursor 呼叫 `/transactions/sync`。[Transactions webhooks](https://plaid.com/docs/transactions/webhooks/)
+- Webhook 要先配置 endpoint；而且每個 Item 至少呼叫過一次 `/transactions/sync` 後才會開始收到 `SYNC_UPDATES_AVAILABLE`。第一次 sync 若資料尚未 ready，會得到空 arrays 與空 `next_cursor`，但會啟動後續 webhook。[Transactions webhooks](https://plaid.com/docs/transactions/webhooks/)；[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+- `initial_update_complete` 表示最近 30 天可用；`historical_update_complete` 表示 requested history（上限 24 個月）可用。它們是 completeness milestones，不是每筆 transaction 的 state。[Transactions webhooks](https://plaid.com/docs/transactions/webhooks/)
+- 使用 `/transactions/sync` 時應處理 `SYNC_UPDATES_AVAILABLE`；舊的 `INITIAL_UPDATE`、`HISTORICAL_UPDATE`、`DEFAULT_UPDATE`、`TRANSACTIONS_REMOVED` 仍可能為相容性送達，但不應驅動 sync business logic。[Transactions API — webhooks](https://plaid.com/docs/api/products/transactions/#sync_updates_available)；[Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+- Plaid 通常每日向機構檢查一到四次，依機構而異；webhook 不等於即時銀行事件。`/transactions/refresh` 是另購的 on-demand extraction，成功後若有 changes 才觸發 webhook。[Transactions API](https://plaid.com/docs/api/products/transactions/)；[Transactions webhooks](https://plaid.com/docs/transactions/webhooks/)
+
+## 6. 不能移植成「台灣爬取資料必然具備」的 Plaid 能力
+
+以下是 source capability 差異，不是 canonical schema 決策：
+
+| Plaid 能力 | Plaid contract | 對台灣爬取資料的事實護欄 |
+| --- | --- | --- |
+| Stable provider IDs | `item_id`、`account_id`、`transaction_id`、部分 enrichment entity ID | 只有來源明確提供且描述 lifecycle 的 ID 才能依賴；畫面列號、排序位置、描述文字或自行 hash 沒有等同 Plaid ID 的官方穩定性保證 |
+| Cross-link account identity | `persistent_account_id` 僅少數 TAN institutions 支援；一般 `account_id` 重連可變 | 不能假設能靠帳號 mask、名稱或單次 scrape ID 跨次／跨來源唯一識別同一帳戶 |
+| Incremental patch stream | cursor + `added`／`modified`／`removed`，含完整 pagination retry contract | Snapshot scrape 若未提供 source cursor、tombstone 與 modification event，就沒有等價的 delta semantics；兩次 snapshot diff 是 consumer inference，不是來源事件 |
+| Pending-posted linkage | Plaid matching 後提供 `pending_transaction_id` | 若銀行頁面不揭露 stable pending ID 或 matching link，就不能保證 pending 與 posted 一對一；金額＋日期＋描述比對只能是 heuristic |
+| Push update notification | Item-scoped `SYNC_UPDATES_AVAILABLE` webhook | 爬取來源除非另有正式 event API，否則只有排程／手動擷取 freshness，不能宣稱 webhook 或 push semantics |
+| Merchant／category enrichment | `merchant_name`、PFC、counterparties、entity IDs、logo、location 等由 Plaid enrichment | 原始 statement description 不等於 cleansed merchant；分類、counterparty identity、confidence、logo 與地點不能憑欄位名稱假設存在 |
+| Balance freshness | 特定 paid endpoint 可 live fetch；一般 response 可 cached | 每個來源必須各自表達擷取時間與 freshness contract；不能由 balance 數值本身推斷「即時」 |
+| Closed／removed detection | closed account 從 API 消失；sync 明示 removed transaction IDs | Snapshot 中缺席可能是頁面範圍、登入權限、抓取錯誤或關閉／刪除，若來源未提供 tombstone 就不能等同 removed event |
+
+## 7. 給後續 canonical-model 討論的事實護欄
+
+以下只界定問題必須容納的事實，不選定表、欄位或命名：
+
+1. **Identity 必須有 scope 與 lifecycle。** 討論任何 account／transaction key 時，要能回答它由哪個 source 發出、在哪個 connection／account 範圍唯一、何時可能換值，以及沒有 provider ID 時怎麼表達不確定性。
+2. **觀測值與金融實體不可先驗等同。** Plaid Item、Plaid Account、pending record、posted record 都有不同 lifecycle；爬取的一列也只是一個 source observation，是否代表同一金融實體需另行決策。
+3. **缺席、null、unknown 與 not-applicable 不同。** Plaid 已示範欄位可能 nullable、條件性省略、整個 object 存在但子欄位無保證，及來源未提供能力等不同情況；後續詞彙應避免把它們壓成同一語義。
+4. **交易變更不只 append。** Plaid contract 包含 added、modified、removed；pending 轉 posted 還可能 remove + add。任何 canonical model 若只描述不可變新增，會無法無損表達此已知 provider 行為。
+5. **日期與時間至少有 authorization／occurrence／posting 差異。** `date` 在 pending 與 posted 的語義不同，精確 datetime 又可能缺失或是假預設值；後續不可只靠單一 timestamp 名稱暗示精度與事件種類。
+6. **金額 sign 是 source convention。** Plaid Transactions（Income 除外）以流出正、流入負；這不是全球帳務的自然定律。後續必須明確決定是否保留 source sign、轉成方向＋絕對值，或採另一套 convention。
+7. **Enrichment 要和 source facts 分層討論。** Merchant cleansing、分類、counterparty matching、confidence、logo、location 可能來自 Plaid，而非金融機構；原始描述與 enrichment 不應在概念上互相覆蓋。
+8. **Freshness 與 completeness 是資料批次屬性。** Cursor、更新狀態、webhook milestone、擷取時間描述資料管線進度；它們不等於交易發生日或 balance 的經濟事件時間。
+9. **同步 correctness 依賴 source contract。** Plaid 的 cursor、全頁 pagination、mutation restart 與 removed tombstone 組成一套完整保證；不能只借用 `cursor` 或 `sync` 詞彙，就推定 snapshot crawler 有同等一致性。
+
+## 官方來源索引
+
+- [Plaid Accounts API](https://plaid.com/docs/api/accounts/)
+- [Plaid Transactions API](https://plaid.com/docs/api/products/transactions/)
+- [Plaid Transaction states](https://plaid.com/docs/transactions/transactions-data/)
+- [Plaid Transactions Sync migration guide](https://plaid.com/docs/transactions/sync-migration/)
+- [Plaid Transactions webhooks](https://plaid.com/docs/transactions/webhooks/)
+- [Plaid Transactions errors](https://plaid.com/docs/errors/transactions/)
+- [Plaid Items API](https://plaid.com/docs/api/items/)
+- [Plaid Preventing duplicate Items](https://plaid.com/docs/link/duplicate-items/)

--- a/docs/research/plaid-effective-time-semantics.md
+++ b/docs/research/plaid-effective-time-semantics.md
@@ -1,0 +1,49 @@
+# Plaid reference semantics for missing or imprecise effective time
+
+## Question
+
+How does Plaid remain operational when a financial value lacks an exact effective timestamp, and which parts of that model are useful to OctopusBeak without treating Plaid as a planned integration?
+
+## Official model findings
+
+### Transactions require a domain date, not always an exact timestamp
+
+Plaid Transactions requires `date`: for a pending transaction it means the date the transaction occurred, while for a posted transaction it means the posting date. The more precise `authorized_date`, `authorized_datetime`, and posted `datetime` are nullable; datetime fields are available only from select institutions and may contain default time values such as midnight. Plaid therefore preserves coarse date precision instead of requiring or inventing an exact timestamp.
+
+Plaid also models pending and posted as distinct transaction occurrences linked when possible. Some institutions do not supply pending transactions, and a posted occurrence may lack `pending_transaction_id`; this missing relationship does not remove the required posted transaction date or status.
+
+Sources:
+
+- [Plaid Transactions API](https://plaid.com/docs/api/products/transactions/)
+- [Plaid transaction states](https://plaid.com/docs/transactions/transactions-data/)
+
+### Balance values often lack a value-specific update time
+
+Plaid's account balances may be cached, while `/accounts/balance/get` obtains live values for supported cases. The balance-level `last_updated_datetime` is nullable and documented as available only for Capital One, so Plaid does not require every returned balance to carry a universal effective timestamp. Plaid separately exposes product-level `last_successful_update`, which records successful institution contact even when no data changed.
+
+Where freshness is contractually required, Plaid uses a gate rather than fabricating a timestamp: `min_last_updated_datetime` can reject an unacceptable Capital One balance with `LAST_UPDATED_DATETIME_OUT_OF_RANGE`.
+
+Sources:
+
+- [Plaid Accounts API](https://plaid.com/docs/api/accounts/)
+- [Plaid Items API](https://plaid.com/docs/api/items/)
+- [Plaid Signal and Balance API](https://plaid.com/docs/api/products/signal/)
+
+### Holdings retain values when price-time metadata is absent
+
+Plaid returns holding quantity, institution value, and institution price, while `institution_price_as_of` and `institution_price_datetime` are nullable. The datetime comes from the institution, is available only for select institutions, and may contain a default time. Plaid Investments uses periodic or requested refreshes and update notifications to communicate snapshot freshness separately from an exact price effective time.
+
+Sources:
+
+- [Plaid Investments API](https://plaid.com/docs/api/products/investments/)
+- [Plaid Investments overview](https://plaid.com/docs/investments/)
+
+## Interpretation for OctopusBeak
+
+The following separates an inference from Plaid's model from OctopusBeak's deliberately stricter project decision:
+
+- Plaid demonstrates that missing exact effective time need not block a current or as-observed API view, but it does block or weaken financial-time uses such as an exact historical balance, historical position, valuation attribution, or cross-source ordering.
+- OctopusBeak therefore chooses a stricter boundary for Balance and Holding Observations: their integration contract must establish `effective_at`, or the attempted Source Capture fails admission. This trades source coverage for reproducible historical valuation.
+- A domain fact that requires time to be meaningful, such as an admitted transaction, should require the precision its integration contract promises (for example, a date without inventing a timestamp).
+- Observation or successful-update time remains separate from financial effective time. It can establish freshness and knowledge history but must not be copied into `effective_at`.
+- Canonical fact types still declare whether effective time is required or not applicable; a required time that cannot be established fails admission.

--- a/docs/research/taiwan-credit-card-account-management.md
+++ b/docs/research/taiwan-credit-card-account-management.md
@@ -1,0 +1,130 @@
+# 台灣銀行信用卡帳戶管理與 Financial Account identity
+
+## 研究問題
+
+台灣銀行如何區分信用卡契約／授信帳戶、帳單與付款單位、正卡與附卡、卡片及卡號？這些事實能否支持以卡號末碼推導 canonical `Financial Account`？本筆研究只作 model reference，不代表 OctopusBeak 要串接任何一家銀行。
+
+## 結論先行
+
+官方資料支持下列邊界：
+
+1. **卡片不是帳戶。** 發卡機構可以在同一正卡帳戶下管理多種卡別（含正卡、附卡），並讓它們共用信用額度；卡片是可被補發、換發、到期續發的支付憑證。
+2. **正卡帳戶／歸戶是授信與帳務聚合單位。** 正卡人對本人與附卡產生的應付帳款負責；附卡權利、額度與正卡契約狀態通常受正卡影響。銀行也會把回饋、代扣繳或帳單付款歸到正卡人的信用卡帳戶。
+3. **帳單週期不是帳戶 identity。** `入帳日`、`結帳日`、`繳款截止日`與帳單是帳務生命週期；同一帳戶可有多張卡及不同卡號的交易，不能用帳單日期或卡號末碼代替帳戶 identity。
+4. **換卡通常延續契約／帳戶關係，但卡號可能改變。** 玉山明示換卡後卡號可能異動，並將代扣繳轉至同一歸戶內的其他正卡；富邦條款則明示可換新卡號或沿用原卡號而契約繼續有效。這直接反駁「卡號不變才是同一帳戶」的假設。
+5. **公開銀行文件未必提供可供第三方穩定重建的 account-level key。** 文件提供的是正卡帳戶、歸戶、信用卡帳戶、銷帳編號等業務概念；若來源 Capture 只有卡號、末四碼、卡別或持卡人 label，不能自行推導同一 Financial Account。這是對現有證據的保守推論，不是銀行資料庫 schema 的斷言。
+
+因此，信用卡 integration 的 contract 應要求來源明確提供或可驗證地映射到**帳戶層級 stable source key**，並將 `Card Instrument`（卡片／卡號生命週期）作為帳戶下的子識別。若只有 card key 而沒有帳戶歸屬證據，該 Capture 不符合目前 Model；不可把同一家銀行的所有卡合併，也不可把每張卡都當成一個 Financial Account。
+
+## 主管機關基準
+
+金融監督管理委員會的《信用卡定型化契約範本》將「持卡人」定義為包含正卡與附卡持卡人，並把「信用額度」定義為發卡機構依信用資料核給持卡人累計使用信用卡所生帳款的最高限額；同一範本另把入帳日、結帳日、繳款截止日與帳單分開定義。這表示法規模型至少分出持卡人／契約、信用額度、交易入帳及帳單週期，不能把卡片表面的卡號當成全部語義。[金管會《信用卡定型化契約範本》](https://law.fsc.gov.tw/LawContent.aspx?id=FL049932&kw=.%E8%A9%90&media=print)
+
+範本第三條規定，正卡持卡人得為第三人申請附卡；正卡人對本人與附卡使用所生應付帳款負責，正卡人可通知停止附卡使用，且正卡契約停止或終止時附卡通常隨之停止或終止。這是「附卡從屬於正卡契約／帳戶關係」的法規基準，不等於附卡與正卡共用同一個持卡人 identity。[金管會《信用卡定型化契約範本》](https://law.fsc.gov.tw/LawContent.aspx?id=FL049932&kw=.%E8%A9%90&media=print)
+
+《信用卡業務機構管理辦法》則把正卡申請人的還款能力、身分及債務列為核卡管理事項，另規範附卡申請人的資格。它支持「授信核給以正卡申請人／正卡關係為核心」的解讀，但沒有提供一個可由外部資料通用推導的 account identifier。[金管會《信用卡業務機構管理辦法》](https://law.fsc.gov.tw/LawContent.aspx?id=FL006433&kw=%E5%BA%97%E5%85%A7&media=print)
+
+## 玉山銀行
+
+### 正卡、附卡與共享額度
+
+玉山信用卡申請說明寫明：信用額度依個人財務狀況核定；若名下持有附卡或其他種類卡別，仍共用一個信用額度。[玉山信用卡申請說明 PDF](https://www.esunbank.com.tw/bank/_/media/42072dd851d64531bd168ae73bc65680.pdf)
+
+玉山申請書另提供「指定附卡可使用額度」欄位，並寫明同一正卡人名下同一附卡人的所有附卡共用其指定額度。這證明附卡額度可以是正卡授信額度下的二級限制，而不是一個獨立授信帳戶。[玉山信用卡申請書 PDF](https://www.esunbank.com.tw/bank/_/media/1424598A03AB46D0B573BAC5F27D9ABB.pdf)
+
+玉山的 e 指附卡說明更直接寫明附卡「附屬於正卡名下」，正卡人未持有卡片時不能單獨申辦附卡。[玉山銀行 e 指附卡](https://event.esunbank.com.tw/credit/1090603ecard/index.html)
+
+### 帳戶、帳單與交易時間
+
+玉山信用卡約定條款把消費交易列在帳單／帳務生命週期中，並以「入帳日」說明銀行代持卡人付款或負擔墊款義務、登錄於持卡人帳上的日期；條款同時區分結帳日與繳款截止日。這些是 transaction／statement timing，不是卡片 identity。[玉山信用卡約定條款 PDF](https://www.esunbank.com.tw/bank/_/media/E7400DE731184286A4D5D898C1B57ECF.pdf)
+
+### 換卡與卡號生命週期
+
+玉山公務人員國民旅遊卡公告說明，換發新卡後卡號會異動；水電瓦斯等代扣繳會自動轉由同一「歸戶」內任一張正卡流通卡繼續扣繳，其他代扣繳則可能需由持卡人自行變更卡號。公告也說換卡時會同步換發名下附卡，正卡開卡後舊卡及附卡停用。[玉山公務人員國民旅遊卡公告](https://event.esunbank.com.tw/credit/travel-card-activity/index.html)
+
+這是很強的實例：同一歸戶內存在多張正卡／附卡，卡號可以變動，部分服務仍以歸戶延續。故 canonical collection 不應用卡號作為不可變 Financial Account key；卡號應記為 Card Instrument 的歷史／目前識別，並保留銀行提供的 replacement relation（若來源有提供）。
+
+## 台北富邦銀行
+
+### 正、附卡與額度／付款範圍
+
+富邦用卡須知寫明正、附卡暨所有卡別共用同一信用額度，正卡人可指定每一附卡人每期消費上限；新申請與現有附卡對正卡人新增應付帳款的責任也在文件中分開說明。[富邦信用卡用卡須知 PDF](https://www.fubon.com/banking/document/personal/credit_card/TW/card_rights_02.pdf)
+
+富邦申請書的自動轉帳授權範圍是「本人於本行所持有之所有信用卡正卡及其附卡」的應付帳款，表示銀行付款設定可以涵蓋同一客戶名下多張正卡與附卡；這不能反推所有正卡必然是同一個信用卡帳戶，但足以證明「一張卡＝一個付款單位」是不可靠的。[富邦信用卡綜合版申請書 PDF](https://www.fubon.com/banking/document/form/TW/bankcard.pdf)
+
+富邦約定條款將「信用卡銷帳編號」定義為發卡機構為供持卡人繳納應付帳款所編訂的帳號，同時把入帳日、結帳日、繳款截止日及帳單分開定義。這個銷帳編號是付款／對帳識別，不應在沒有來源 contract 的情況下直接當成 Financial Account identity。[富邦信用卡約定條款 PDF](https://www.fubon.com/banking/document/form/TW/creditcard_provision.pdf)
+
+### 附卡的契約從屬性
+
+富邦條款規定正卡人可申請附卡；正卡人對附卡應付帳款負責，正卡人的額度調整、拒絕授權、暫停或強制停卡等效力及於附卡，正卡人也可停止或終止附卡使用。這與金管會範本的關係一致：附卡是正卡契約下的 Card Instrument／持卡人，而非可由卡號獨立推導的 Financial Account。[富邦信用卡約定條款 PDF](https://www.fubon.com/banking/document/form/TW/creditcard_provision.pdf)
+
+### 補發、換發、續發
+
+富邦條款明確允許因遺失、被竊或損壞而「更換新卡號或使用原卡號」換發，且在有效期屆滿續發時原約定條款繼續有效，不需另行換約。這直接說明卡號是可變的 instrument identifier，而契約／帳務關係可以延續。[富邦信用卡約定條款 PDF](https://www.fubon.com/banking/document/form/TW/creditcard_provision.pdf)
+
+## 元大銀行
+
+### 「同一正卡帳戶」與共享額度
+
+元大信用卡用卡須知使用「同一正卡帳戶」一詞：同一正卡帳戶下所持有的各類信用卡別（含正、附卡）共用同一信用額度。這是目前三家銀行中最直接把帳戶層級與卡別層級分開寫出的官方文字。[元大銀行信用卡用卡須知](https://www.yuantabank.com.tw/bank/creditCard/creditCardInstruction/list.do)
+
+元大文件也說，若同時申請多張信用卡或附卡，銀行最後核准的信用額度由各卡共用；這可支持 canonical model 建立「account／credit-limit group → card instruments」的關係，但不能據此宣稱同一持卡人所有正卡都一定屬於同一正卡帳戶。[元大銀行信用卡約定／合併說明](https://www.yuantabank.com.tw/bank/tcbankMergerArea/changeItem/list2.do)
+
+### 換卡後續與代扣繳
+
+元大公用事業／路邊停車代繳約定書寫明，指定代繳信用卡因遺失、毀損或到期續卡而換發時，銀行得以新編號或號碼繼續扣繳。這表示某些代扣繳關係由銀行在換卡後延續，不能把原始卡號視為永遠不變的付款 identity。[元大銀行代繳約定書 PDF](https://www.yuantabank.com.tw/bank/download/download.do?id=275bec82fd00000264be)
+
+元大 FAQ 說明到期前約一個月主動寄發新卡；這是 Card Instrument lifecycle 的正常事件，不代表建立了新的信用卡契約或新的 Financial Account。[元大信用卡 FAQ](https://www.yuantabank.com.tw/bank/creditCard/creditCard/faq/list.do?id=275b6a9a5c0000078b93)
+
+## 跨銀行比較
+
+| 業務概念 | 玉山 | 富邦 | 元大 | Model implication |
+| --- | --- | --- | --- | --- |
+| 正卡／附卡 | 附卡附屬於正卡名下；共享額度 | 正、附卡及所有卡別共享額度，附卡受正卡狀態影響 | 同一正卡帳戶下各卡別共享額度 | 需要 account-to-card relation；不能將每卡獨立成 Financial Account |
+| 多種卡別 | 名下附卡或其他卡別可共用額度 | 自動扣款授權可涵蓋所有正、附卡 | 同一正卡帳戶可有各類卡別 | 「卡別／卡面」不是帳戶 identity |
+| 帳務單位 | 入帳日、結帳日、繳款截止日分開 | 另有信用卡銷帳編號 | 以正卡帳戶與額度說明 | statement/payment key 與 account key 分開 |
+| 換卡 | 卡號異動，部分代扣繳按歸戶延續 | 可原卡號或新卡號換發，契約繼續 | 代扣繳可按銀行新編號／號碼延續 | Card Instrument 是可替換的；需 replacement lineage |
+
+## 對 OctopusBeak Model 的限制與建議
+
+### 建議的最小關係
+
+在不假設銀行內部 schema 的前提下，canonical domain 至少應能表達：
+
+```text
+Financial Account (source-scoped, stable account key)
+├─ Card Instrument 1 (card key / card number / validity / status)
+├─ Card Instrument 2 (additional or replacement card)
+└─ Account-level billing/credit facts
+   ├─ credit limit / available limit observation
+   ├─ statement cycle and due date
+   └─ transactions attributed to an account and optionally a card instrument
+```
+
+其中 `Card Instrument` 可因補發、掛失、到期或產品換卡而新增；同一 Financial Account 的歷史交易不能因卡號變更而被視為新帳戶。若來源只呈現卡號，最多建立 Card Instrument candidate；只有來源 contract 能證明卡號與帳戶層級 key 的歸屬時，才可建立 canonical Financial Account relation。
+
+### New collection admission
+
+Canonical reset 後的新信用卡 Capture 應採以下 admission；舊資料不參與判斷，也不建立相容例外：
+
+- 有銀行提供的 account-level key，或來源明確提供「同一正卡帳戶／歸戶」且能在 Capture 內穩定定位：可建立 Financial Account，並把卡號／卡末碼放在 Card Instrument。
+- 只有卡號、末四碼、卡別名稱、持卡人名稱或同一家銀行 label：不能推導 account identity；該次 Capture 失敗並發出 integration error，不建立 provisional 或 legacy identity 例外。
+- 同一銀行出現多個 card keys：不能直接合併成一個帳戶，也不能直接各自建立帳戶；必須等待來源 contract 提供 account-level relation。
+- 同一 card key 跨 Capture 出現：只能說明來源 key 可能穩定，仍須由 integration contract 確認它代表 Card Instrument 還是 Financial Account；不能靠字串相等自行提升語義。
+- 新卡與舊卡同時出現：若來源提供 replacement／renewal relation，兩者屬同一 Financial Account 下不同 Card Instruments；若沒有 relation，兩者不能自動合併。
+
+### 不應採用的推導
+
+以下規則均沒有被本研究的官方資料支持：
+
+- `bank + product + cardKey` 永遠等於 Financial Account。
+- 同一家銀行同一個持卡人名下的所有正卡必然是同一帳戶。
+- 相同卡號末四碼代表同一帳戶。
+- 同一帳單日期或同一結帳日代表同一帳戶。
+- 卡號改變必然代表新 Financial Account。
+
+這些字串可作 display label、去重輔助或待驗證 source key，但不能在 strict admission 中充當未經 contract 證明的帳戶 identity。
+
+## 證據邊界
+
+本研究找到的是銀行對外約款、申請書、用卡說明、公告與主管機關規範。它們足以確認正卡帳戶／歸戶／卡片／帳單之間的業務關係與換卡語義，但沒有公開三家銀行一致的 API schema 或可跨銀行使用的 account identifier 欄位。因此「需由 integration contract 提供 stable account key」是對 domain identity 的設計推論；不是聲稱所有銀行都不提供該欄位。實作時應先檢查實際下載報表或頁面是否有帳戶號碼、繳款編號、歸戶識別或其他銀行明示的 account-level key，並將其語義寫入該 integration contract。

--- a/docs/research/transaction-posting-semantics.md
+++ b/docs/research/transaction-posting-semantics.md
@@ -39,4 +39,4 @@ Sources:
 - Payment-network settlement is a separate lifecycle and must not define account-transaction posting status.
 - Taiwan `unbilled` and `billed` describe statement-cycle membership. A merchant-presented transaction may be posted while still unbilled.
 - Each Supported Source Integration must verify and version the semantics of the page, endpoint, or report it collects. A filename, successful download, posting-date-shaped column, or appearance in a list is not sufficient by itself.
-- The current Taiwan-source inventory usually lacks row-level status. `unknown` therefore remains a valid exceptional fail-safe, while a verified Integration contract may map a whole Source Record kind deterministically.
+- A Supported Source Integration must map every admitted record kind deterministically to `pending` or `posted`, including a verified whole-record-kind mapping when no row-level status exists. A source kind whose semantics cannot support that total contract is rejected rather than represented by canonical `unknown`.

--- a/docs/research/transaction-posting-semantics.md
+++ b/docs/research/transaction-posting-semantics.md
@@ -1,0 +1,42 @@
+# Transaction posting semantics across Plaid, UK Open Banking, and Taiwan banks
+
+## Question
+
+What durable semantic boundary can OctopusBeak use for `pending` and `posted` without treating Plaid as a planned provider or confusing Taiwan credit-card billing stages with account-ledger booking?
+
+## Findings
+
+### Plaid and UK Open Banking
+
+Plaid Core Exchange accepts `PENDING` and `POSTED`, treating `AUTHORIZATION` and `MEMO` as pending. It expects pending and posted versions to have separate transaction IDs, permits a reference ID to relate them, and requires `postedTimestamp` for posted records while omitting it for pending records. These are useful model semantics, but the IDs and linkage are Plaid provider capabilities rather than guarantees OctopusBeak may assume for Taiwan sources.
+
+UK Open Banking defines `Booked` as a transfer of money completed between the account servicer and account owner, while warning that booked does not necessarily mean end-to-end payment finality. `Pending` means booking in the account servicer's ledger has not completed and covers expected items or items awaiting conditions before booking.
+
+Sources:
+
+- [Plaid Core Exchange API reference](https://plaid.com/core-exchange/docs/reference/4.6/)
+- [UK Open Banking Account and Transaction API specification](https://openbankinguk.github.io/read-write-api-site2/standards/v3.1.3/resources-and-data-models/aisp/images/Account%20and%20Transaction%20API%20Specification/)
+- [UK Open Banking Transactions resource](https://openbankinguk.github.io/read-write-api-site2/standards/v3.1.3/resources-and-data-models/aisp/Transactions/)
+
+### Taiwan card and deposit-account language
+
+Taiwan banks expose the same lifecycle through different user-facing terms:
+
+- Cathay United Bank calls an authorized card purchase whose merchant has not submitted presentment an "immediate transaction"; its "unbilled amount" is a merchant-presented amount that will enter the next statement.
+- E.SUN likewise separates immediate authorization records from "unposted statement details": the latter have already been presented by the merchant but have not reached the statement cut-off date.
+- CTBC and Taishin explain debit-card authorization as a hold that reduces available balance without reducing account balance; merchant presentment later releases the hold and debits account balance.
+
+Sources:
+
+- [Cathay United Bank credit-card transaction guide](https://www.cathaybk.com.tw/cathaybk/personal/campaigns/ebanking/card-management-guide/?eventname=cmg_spending_ap_faq)
+- [E.SUN Wallet credit-card FAQ](https://www.esunbank.com/zh-tw/about/faq/faqlist?tag=esunwallet-credit-card-services)
+- [CTBC account and available balance FAQ](https://service.ctbcbank.com/FAQ/Page01?KM=&kmid=4688)
+- [Taishin account and available balance FAQ](https://www.taishinbank.com.tw/TSB/customer-service-center/qa/index.html?nav1=type03&page=3)
+
+## Interpretation guardrails
+
+- The portable boundary is account-ledger booking: pending is authorized, expected, or reserved but not booked; posted is recorded in the Institution's account ledger.
+- Payment-network settlement is a separate lifecycle and must not define account-transaction posting status.
+- Taiwan `unbilled` and `billed` describe statement-cycle membership. A merchant-presented transaction may be posted while still unbilled.
+- Each Supported Source Integration must verify and version the semantics of the page, endpoint, or report it collects. A filename, successful download, posting-date-shaped column, or appearance in a list is not sufficient by itself.
+- The current Taiwan-source inventory usually lacks row-level status. `unknown` therefore remains a valid exceptional fail-safe, while a verified Integration contract may map a whole Source Record kind deterministically.

--- a/docs/specs/canonical-financial-storage.md
+++ b/docs/specs/canonical-financial-storage.md
@@ -2,7 +2,7 @@
 
 Status: implementation-ready planning specification
 
-This specification resolves GitHub issue 124. It translates ADRs 0004–0010 and the root glossary into a first-version physical storage and query boundary. It specifies table responsibilities, mandatory constraints, transaction boundaries, and verification criteria; exact SQL names may change during implementation only when the same guarantees remain mechanically enforceable.
+This specification resolves GitHub issue 124. It translates ADRs 0004–0010 and the root glossary into a first-version physical storage and query boundary. It specifies table responsibilities, mandatory constraints, transaction boundaries, and verification criteria; exact SQL names may change during implementation only when the same guarantees remain mechanically enforceable. The typed enrichment extensions to this storage boundary are defined by [Transaction taxonomy and enrichment specification](./transaction-taxonomy-and-enrichment.md) and ADR 0011.
 
 ## 1. Storage boundary
 
@@ -216,6 +216,7 @@ Typed assertion target/value extensions
 - Enforce exactly one target family per Assertion with constraints and admission tests.
 - User-governed fields are registered and migration-controlled. Text, category, tag, and note values use typed representations; arbitrary field names or JSON values are forbidden.
 - User Assertions cannot target financial amounts, currencies, directions, dates, posting status, balances, holdings, Statement totals, identity, or membership.
+- Transaction Kind, Personal Category, Category Allocation, Counterparty Participation/display, and Transaction Tag use the typed registries, value tables, origin matrix, applicability rules, and current projection contract in the transaction taxonomy and enrichment specification; they do not use arbitrary field names or generic JSON values.
 
 Canonical storage has no required-value `unknown`, conflict status, candidate set, manual financial selector, or Identity Correction. Missing, unsupported, or mutually incompatible required values cancel the attempted Capture before canonical commit.
 
@@ -254,6 +255,7 @@ Failed or partial runs leave the previous complete result unchanged and write on
 - Typed, query-oriented rows for current Financial Accounts, Transactions, Statements, balances, holdings, relations, and user-governed fields.
 - Every selected value references its authority route and canonical revision or Assertion.
 - Projection rows contain no independent financial authority and are fully rebuildable.
+- Current transaction enrichment returns the selected typed Kind and categorization, all Counterparty Participations, display label with origin, active Tags, classification coverage, and report-eligibility coverage without creating another assertion or event system.
 
 Do not materialize daily historical snapshots in the first version. Historical queries resolve immutable revisions, lifecycle transitions, and routes using both explicit financial-time and knowledge-time cutoffs.
 

--- a/docs/specs/canonical-financial-storage.md
+++ b/docs/specs/canonical-financial-storage.md
@@ -1,0 +1,376 @@
+# Canonical financial storage specification
+
+Status: implementation-ready planning specification
+
+This specification resolves GitHub issue 124. It translates ADRs 0004–0010 and the root glossary into a first-version physical storage and query boundary. It specifies table responsibilities, mandatory constraints, transaction boundaries, and verification criteria; exact SQL names may change during implementation only when the same guarantees remain mechanically enforceable.
+
+## 1. Storage boundary
+
+Use one canonical SQLite database for all admitted financial evidence and projections:
+
+- canonical schema version and commit ordering;
+- Source Connections, Collection Scope Versions, Identity Epochs, and committed Source Sync State;
+- accepted Source Captures, typed Capture Scopes, and compact Source Records;
+- source-scoped identities and immutable typed revisions;
+- Source, Derived, and User Assertion lineage and provenance;
+- successful complete-scope Import Runs;
+- Source Authority Routing; and
+- disposable Current Financial Projection generations.
+
+Keep the following in operational configuration or operational audit storage, outside the canonical database:
+
+- authentication secrets and sign-in details;
+- integration settings, schedules, UI preferences, and Statement Selections;
+- incomplete Sync Attempt Checkpoints and collection staging;
+- failed collection and Import Run diagnostics;
+- deletion scrub jobs and non-financial deletion audit; and
+- Legacy Data Quarantine.
+
+Operational configuration links to a canonical Source Connection through an opaque configuration reference. The canonical store retains a sanitized, versioned Collection Scope Version and fingerprint, never credentials. Because no cross-database transaction or foreign key exists, admission rechecks the scope version immediately before its canonical commit; a semantic change cancels and retries the attempt.
+
+## 2. Physical conventions
+
+### 2.1 Identifiers
+
+- Application-generated UUIDv7 is the durable local identifier for canonical rows.
+- Store UUIDs as 16-byte `BLOB`; convert to text only at API and log boundaries.
+- UUID time bits do not define `recorded_at`, ordering, identity, or uniqueness.
+- Every source-scoped identity has an explicit natural-key `UNIQUE` constraint including its integration namespace, Source Connection, Identity Epoch, product stream where applicable, and contract-defined stable source key.
+
+### 2.2 Exact decimal values
+
+Represent every monetary quantity, balance, holding quantity, price, and rate with typed columns:
+
+- normalized decimal digits as text `coefficient`;
+- integer `scale`;
+- explicit sign or domain direction when negative values are meaningful; and
+- denomination columns appropriate to the domain, such as ISO currency or Security ID.
+
+Transaction amounts are non-negative and store direction separately. Do not use SQLite `REAL` or JavaScript `Number` for financial arithmetic. Use `BigInt` or an exact decimal implementation; SQL aggregation requires registered exact-decimal functions. Source formatting may remain only in a compact Source Record payload.
+
+### 2.3 Time and knowledge
+
+`canonical_commits` provides one knowledge point for every atomic canonical change:
+
+- `commit_id BLOB(16)` primary key;
+- strictly increasing local `commit_sequence INTEGER` unique and not null;
+- `recorded_at_utc_us INTEGER` not null; and
+- controlled `commit_kind` plus non-financial operation reference where needed.
+
+Every row created by a commit references its `commit_id`. Knowledge-time comparison uses `commit_sequence`; wall-clock timestamps never break ties or backdate newly admitted facts.
+
+Financial time is fact-specific. Typed revision tables preserve the source precision and meaning using the necessary combination of local date, local time, timezone or offset, precision enum, UTC instant in integer microseconds, and a UTC sorting anchor. A date-only value may use UTC midnight as an internal anchor but must never be presented as a source timestamp. Transactions, Statements, Balance and Holding Observations, and account lifecycle facts require their contract-defined effective time; descriptive user fields do not.
+
+### 2.4 Immutability and foreign keys
+
+- Enable `PRAGMA foreign_keys = ON` on every connection.
+- Identity rows contain only identity invariants and are never updated in place.
+- Financial and descriptive changes create immutable revisions or assertions.
+- All domain references use real foreign keys. Do not use generic `(target_type, target_id)` references.
+- Compact integration JSON is permitted only in `source_records`; it cannot be a canonical value, identity, completeness, withdrawal, or projection authority.
+
+Contract Purge, Canonical Reset, and separately specified user deletion are the only hard-deletion paths. Assertion withdrawal is not deletion.
+
+## 3. Table families
+
+### 3.1 Schema and commit tables
+
+`schema_migrations`
+
+- Records the monotonic canonical schema version and applied commit metadata.
+- The application refuses to open its writer against an unsupported newer version.
+- First-version migrations are forward-only.
+
+`canonical_commits`
+
+- Owns strict knowledge ordering for captures, import results, user assertions, routing changes, purges, and projection switches.
+- One application-level writer allocates `commit_sequence` inside `BEGIN IMMEDIATE`.
+
+### 3.2 Collection and evidence tables
+
+`source_connections`
+
+- Source-scoped namespace linked to an opaque operational configuration reference.
+- Stores integration namespace and lifecycle metadata, not financial account lifecycle or secrets.
+
+`collection_scope_versions`
+
+- Immutable sanitized description and fingerprint of collection semantics admitted from operational configuration.
+- Secret rotation, scheduling, and presentation-only settings do not require a new version.
+
+`identity_epochs`
+
+- Immutable fence for stable-key scope, normalization, reuse rules, and identified subject meaning.
+- A change to those semantics starts a new epoch; epochs never reconcile.
+
+`source_sync_states`
+
+- Scoped to Source Connection, product stream, and optional Financial Account when the provider requires it.
+- Stores only opaque provider continuation state and health metadata.
+- Has a natural unique constraint on that scope.
+- Advances only in the same commit as the complete accepted Capture it covers. Providers without continuation state leave it absent.
+
+`source_captures`
+
+- Immutable envelope for one independently observed, admitted collection event.
+- References Source Connection, contract version, Collection Scope Version, Canonical Commit, and observation time.
+- Contains no partial or failed attempt.
+
+`capture_scopes`
+
+- Typed rows describing subject reference, product stream, optional start/end financial range, and completeness enum such as complete snapshot, complete range, or incremental.
+- References the contract rule that proves completeness.
+- Empty results and absence of a next page do not establish completeness without that rule.
+
+`source_records`
+
+- Immutable occurrence within exactly one Capture.
+- Stores contract-defined record kind, stable source record key when available, compact contract-versioned JSON payload, and content hash.
+- Each independent Capture retains its own occurrence even when hashes match. The hash supports integrity and equality checks, not identity.
+
+`source_record_scopes`
+
+- Join table linking one Source Record to one or more scopes within its Capture.
+- Composite foreign-key or trigger enforcement must prevent linking across Captures.
+
+The first version stores compact payloads inline. It has no Source Artifact, replayable raw file, response, DOM, content-addressed blob table, or shared payload row.
+
+### 3.3 Typed identity tables
+
+Provide separate identity tables for at least:
+
+- `financial_accounts`;
+- `card_instruments`;
+- `securities`;
+- `financial_transactions`;
+- `statements`; and
+- `balance_observations` and `holding_observations`.
+
+Each table contains its UUID, source-scoped natural identity, Identity Epoch, creation commit, and only true identity invariants. Optional account subtype, name, lifecycle, and other changing properties belong to revisions or assertions. Account top-level type is required and contract-defined; a later semantic contradiction is a contract/epoch error requiring purge or reset, not an in-place update.
+
+A Card Instrument belongs to a Financial Account but never substitutes for it. Different primary or supplementary card masks do not create separate accounts unless the contract independently proves separate account identity.
+
+### 3.4 Typed revision and relation tables
+
+`account_revisions`
+
+- Immutable typed account facts and lifecycle assertions supported at one financial effective time and knowledge point.
+
+`transaction_revisions`
+
+- Immutable transaction facts including required posting status `pending | posted`, non-negative exact amount, direction, denomination, effective date/time precision, description fields, and source revision identity.
+- A revision is created only when the contract proves correction or continuation of the same source-scoped Transaction identity.
+
+`statement_revisions`
+
+- Immutable source-proven revision of the same Statement, with cycle, billing dates, due dates, and exact totals as supported by the contract.
+- A new billing cycle creates a new Statement, not a revision.
+
+`statement_memberships`
+
+- Owned by one Statement Revision and pinned to a specific Transaction Revision.
+- A later Transaction Revision cannot rewrite historical Statement membership.
+- User selection cannot change canonical membership or financial totals.
+
+`balance_observation_revisions` and `holding_observation_revisions`
+
+- Store exact observed value, required contract-defined effective time, and knowledge point.
+- Each independent measurement creates a new Observation even when its value matches. Only a contract-proven correction of the same measurement creates another revision under one Observation.
+- Balance scope is Financial Account, balance kind, and denomination. Holding scope is Financial Account and Security.
+- A transaction `balance_after` may support a clearly marked derived post-transaction Balance Observation only when the contract proves its ledger point and ordering. It never becomes provider current balance, and incomplete transaction history never synthesizes a balance.
+
+`transaction_relations`
+
+- Immutable typed edge between two Transactions with real foreign keys and no self relation.
+- Directed relation kinds retain endpoint direction. Symmetric transfer relations use canonical endpoint ordering.
+- Enforce uniqueness for relation type, endpoint pair, and source scope.
+- Do not impose global one-to-one cardinality: multiple refunds, reversals, installments, and transfers may be valid.
+- First-version relations remain within one contract-provable Source Connection and Identity Epoch. Cross-connection similarity does not create a relation.
+
+### 3.5 Assertion spine and typed targets
+
+`assertion_lineages`
+
+- Defines one continuous origin, producer, rule lineage, subject, and governed field or typed fact scope.
+- Origins are controlled values: Source, Derived, or User.
+
+`assertions`
+
+- Immutable claim metadata referencing lineage, producer/rule version, creation commit, and typed value or revision through an extension table.
+- Direct source-backed coherent revisions may inherit revision-level lineage. Independently governed entity fields use field-level assertions.
+
+`assertion_transitions`
+
+- Append-only `observed`, `superseded`, `withdrawn`, or `restored` transitions with commit and cause.
+- No mutable current-status column is authoritative.
+- Supersession is allowed only within the same continuous producer lineage.
+
+`assertion_provenance`
+
+- Links Assertions to Source Records, successful Import Runs, supporting Assertions, or user action metadata using typed extension tables and real foreign keys.
+- Reobserving an identical claim adds provenance instead of duplicating its typed revision or Assertion value.
+
+Typed assertion target/value extensions
+
+- Use separate tables for Transaction Revision, Observation Revision, Statement Revision, Transaction Relation, entity field, and registered user-governed value targets.
+- Enforce exactly one target family per Assertion with constraints and admission tests.
+- User-governed fields are registered and migration-controlled. Text, category, tag, and note values use typed representations; arbitrary field names or JSON values are forbidden.
+- User Assertions cannot target financial amounts, currencies, directions, dates, posting status, balances, holdings, Statement totals, identity, or membership.
+
+Canonical storage has no required-value `unknown`, conflict status, candidate set, manual financial selector, or Identity Correction. Missing, unsupported, or mutually incompatible required values cancel the attempted Capture before canonical commit.
+
+### 3.6 Import Run tables
+
+`import_runs`
+
+- Stores only successful, committed runs over retained Source Records, with parser/rule versions and producer identity.
+
+`import_run_output_scopes`
+
+- Declares the complete subject, field, producer, and rule-lineage output scope.
+- A run stages all output before commit. Its complete result atomically adds Derived Assertions, transitions, provenance, and affected current projection rows.
+- A missing optional output may withdraw only when the declared complete output scope and rule semantics explicitly establish that result.
+
+Failed or partial runs leave the previous complete result unchanged and write only operational diagnostics outside canonical storage. Initial required mapping failure cancels the attempted Capture; a later rerun failure cannot invalidate an already accepted Capture or its Source Assertions.
+
+### 3.7 Authority and projection tables
+
+`source_authority_routes`
+
+- Immutable, versioned assignment of exactly one authoritative contract version, Source Connection, product stream, subject/fact/field scope, and producer at each knowledge point.
+- Missing or overlapping active routes fail admission or projection rebuild.
+- There is no numeric runtime priority, latest-source rule, fuzzy reconciliation, or user-selected financial authority.
+
+`projection_generations`
+
+- Tracks building, validated, active, and retired generations plus their projection rule version and build cutoff.
+
+`active_projection_generation`
+
+- Singleton pointer switched atomically after complete validation.
+
+`current_*` projection tables
+
+- Typed, query-oriented rows for current Financial Accounts, Transactions, Statements, balances, holdings, relations, and user-governed fields.
+- Every selected value references its authority route and canonical revision or Assertion.
+- Projection rows contain no independent financial authority and are fully rebuildable.
+
+Do not materialize daily historical snapshots in the first version. Historical queries resolve immutable revisions, lifecycle transitions, and routes using both explicit financial-time and knowledge-time cutoffs.
+
+## 4. Atomic operations
+
+### 4.1 Accept Capture
+
+Collect, paginate, and validate outside the canonical transaction. After complete staging:
+
+1. recheck contract, Identity Epoch, Collection Scope Version, total required mappings, Capture Scope completeness, and authority coverage;
+2. enter the single writer queue and `BEGIN IMMEDIATE`;
+3. allocate one Canonical Financial Commit;
+4. insert Capture, scopes, compact Records, identities/revisions, Source Assertions, transitions, and provenance;
+5. advance the exact Source Sync State covered by the Capture;
+6. update affected active current projection rows; and
+7. commit all changes together.
+
+Any failure rolls back the whole operation. A transport checkpoint never enters these tables.
+
+### 4.2 Apply successful Import Run
+
+Stage the complete declared output outside the transaction. In one canonical commit, insert the successful run and output scope, apply all Derived Assertion/provenance/lifecycle changes, and update the current projection. Failure changes none of them.
+
+### 4.3 Apply User Assertion
+
+Validate that the target is a registered user-governed field. In one canonical commit, append the User Assertion and any same-lineage supersession or withdrawal transition, then update the current projection. Clearing a field withdraws the user lineage so projection falls back; it does not delete source evidence.
+
+### 4.4 Rebuild current projection
+
+Routine canonical commits update the active generation incrementally. A projection schema, rule, authority, or precedence change uses a full rebuild:
+
+1. pause the canonical writer queue while readers continue using the active generation;
+2. build one shadow generation at a fixed Canonical Knowledge Point;
+3. validate completeness, uniqueness, routes, references, exact arithmetic, and query invariants;
+4. atomically switch `active_projection_generation`; and
+5. resume queued writes.
+
+The first version has no delta catch-up protocol. A failed build leaves the prior generation active.
+
+### 4.5 Contract Purge
+
+Before deletion, compute and validate the exact ownership closure for the disabled integration namespace, Source Connection, product stream, contract version, or Identity Epoch. The closure includes Captures, Records, owned identities, revisions, Assertions and transitions, relationships, sync state, and affected projections, and must not cross another connection/epoch or shared operational configuration.
+
+One `BEGIN IMMEDIATE` transaction hard-deletes the validated closure, rebuilds affected active projections, and commits metadata sufficient to report the non-financial purge reason, counts, and fingerprint outside the financial lineage. Unexpected external references, constraint failures, or projection failures roll back the purge. Explicit owned children may use cascades; cross-ownership relations require explicit closure handling.
+
+After financial deletion commits, a resumable operational scrub checkpoints/truncates WAL, enables secure deletion for subsequent work, vacuums when required, and records local scrub completion. Product guarantees application-level unreachability, not forensic erasure from APFS snapshots, Time Machine, external backups, or SSD internals.
+
+## 5. Query boundary
+
+Product modules may use only three typed query contracts:
+
+1. **Current Projection Query** — reads one active generation and returns the presently authoritative domain view.
+2. **Historical Projection Query** — requires explicit financial-time and Canonical Knowledge Point cutoffs, then resolves typed immutable facts and the authority route valid at that cutoff.
+3. **Lineage Inspection Query** — returns the selected typed revision, assertion lineage and transitions, producer/rule metadata, supporting compact Source Records, and relevant commits without exposing secrets or raw replay.
+
+Products must not:
+
+- read compact JSON to calculate financial values;
+- implement assertion precedence or Source Authority Routing;
+- select latest observations or statement revisions themselves;
+- combine legacy and canonical reads;
+- query retired projection generations as fallback; or
+- infer identity, withdrawal, effective time, or status from presentation data.
+
+## 6. Index policy
+
+Add indexes only for a declared query contract or integrity rule, and lock each important query shape with `EXPLAIN QUERY PLAN` regression tests.
+
+Required index families are:
+
+- natural-key unique indexes for every source-scoped identity and assertion lineage;
+- foreign-key traversal indexes;
+- active-generation and subject indexes for each `current_*` projection;
+- financial-time indexes for Historical Projection scope and ordering;
+- `commit_sequence` and lineage-transition indexes for knowledge-time resolution;
+- bidirectional assertion provenance indexes;
+- Capture, Capture Scope, Source Record, and completeness traversal indexes;
+- Statement Revision membership indexes; and
+- Transaction Relation endpoint and type indexes.
+
+Do not add first-version indexes for compact JSON content, arbitrary description/note full text, approximate amount matching, UUID time bits, speculative Plaid access patterns, or redundant standalone `recorded_at` values.
+
+## 7. SQLite runtime policy
+
+- Use WAL mode, `synchronous = FULL`, foreign keys on every connection, and a bounded busy timeout.
+- Route every canonical mutation through one application-owned writer queue.
+- Start canonical commits with `BEGIN IMMEDIATE`.
+- Use read-only snapshot connections for query contracts.
+- On busy timeout, roll back and retry the whole operation; never continue a partially applied operation.
+- Startup performs WAL recovery, schema-version compatibility, foreign-key integrity, and active-projection checks before opening the query boundary.
+
+## 8. Schema evolution
+
+- Apply monotonic semantics-preserving migrations transactionally before opening the writer or query boundary.
+- Projection-only changes rebuild and switch a shadow generation without rewriting canonical history.
+- A change requiring identity, effective-time, or evidence that retained data cannot prove must not backfill guesses. Purge and recollect the affected contract/epoch, or perform Canonical Reset when the incompatibility is global.
+- Do not support downgrade in the first version. An older application must refuse to write a newer schema.
+
+## 9. Acceptance checks
+
+Implementation is acceptable only when automated tests prove:
+
+1. required mapping, identity, effective-time, completeness, and route failures persist no partial Capture and do not advance Source Sync State;
+2. one accepted Capture makes evidence, typed revisions, assertions, committed cursor, and current projection visible atomically;
+3. equal compact payloads from independent Captures remain distinct occurrences without duplicating an unchanged assertion value;
+4. failed or partial Import Runs leave canonical lineage and projections unchanged;
+5. Current Projection selects only contract-routed, active assertions and is reproducible from the immutable write model;
+6. Historical Projection changes correctly and independently across financial-time and knowledge-time cutoffs;
+7. Statement membership remains pinned to Transaction Revisions after later revisions;
+8. repeated Observations and contract-proven Observation corrections follow different identity paths;
+9. exact decimal round trips and aggregates never lose precision;
+10. no product query reads Source Record JSON, assertion tables, or legacy tables directly;
+11. projection rebuild failure keeps the previous generation readable, while successful switching exposes no mixed generation;
+12. Contract Purge either removes the complete validated ownership closure and its projection reachability or changes nothing;
+13. an unsupported newer schema blocks the writer; and
+14. declared query plans use the intended identity, current, historical, lineage, membership, and relation indexes.
+
+## 10. Explicit first-version exclusions
+
+This specification does not add raw artifact replay, Plaid connectivity, cross-source identity or deduplication, Identity Correction, conflict persistence, required-value `unknown`, manual financial correction, user Statement selection, parser/workflow semantics in the domain model, generic event sourcing, EAV, arbitrary JSON facts, approximate transaction matching, historical snapshot tables, or compatibility reads from the legacy ledger.

--- a/docs/specs/transaction-taxonomy-and-enrichment.md
+++ b/docs/specs/transaction-taxonomy-and-enrichment.md
@@ -1,0 +1,365 @@
+# Transaction taxonomy and enrichment specification
+
+Status: implementation-ready planning specification
+
+This specification resolves GitHub issue 125. It extends [Canonical financial storage specification](./canonical-financial-storage.md) with the first-version universal Transaction Kind, Personal Category, Counterparty, display, Tag, routing, publishing, query, and verification contracts. Plaid is a coverage comparison only; OctopusBeak does not integrate with Plaid or adopt Plaid provider identity, sign, type, or category semantics.
+
+## 1. Independent dimensions
+
+One Financial Transaction may have the following independent enrichment:
+
+- **Transaction Kind**: what financial operation occurred;
+- **Personal Category**: the personal-finance purpose of a compatible transaction;
+- **Counterparty Participations**: who participated and in which registered roles;
+- **Transaction Tags**: user-owned, many-valued organization; and
+- **Transaction Display Label**: a typed presentation result with explicit origin.
+
+Do not infer Transaction Relation, direction, posting status, account type, Statement membership, identity, or report eligibility from these fields. Integration contracts decompose source-specific values into the canonical dimensions they actually prove.
+
+## 2. Taxonomy registries
+
+### 2.1 Transaction Kind
+
+Publish the following first-version hierarchy. A producer asserts the most specific code it can prove and may stop at any registered parent.
+
+```text
+purchase
+transfer
+  internal
+  external
+  investment_contribution
+  investment_withdrawal
+  security_position
+payment
+  bill
+  credit_card
+  loan
+cash
+  deposit
+  withdrawal
+income
+  employment
+    salary
+    bonus
+  business
+  pension
+  government_benefit
+  rental
+  reward
+  dividend
+  investment_distribution
+fee
+  bank
+  card
+  loan
+  investment
+interest
+  earned
+  charged
+tax
+  payment
+  refund
+  withholding
+refund
+reversal
+adjustment
+loan
+  disbursement
+investment
+  trade
+    buy
+    sell
+    sell_short
+    buy_to_cover
+    reinvestment
+  corporate_action
+    split
+    merger
+    spin_off
+    exercise
+    assignment
+    expiration
+```
+
+Transaction Kind is optional enrichment unless an integration contract declares it necessary to interpret a record kind, such as an investment trade whose buy/sell semantics govern cash and quantity. Missing optional Kind is absence. Missing, unsupported, or ambiguous required Kind cancels the attempted Capture.
+
+`transfer.internal` proves only that the source identifies a movement between the person's accounts. A `transfer_counterpart` Relation additionally requires both canonical Transaction endpoints and contract-proven linkage. `refund` and `reversal` likewise do not establish `refund_of` or `reversal_of` Relations by themselves.
+
+### 2.2 Personal Category
+
+Publish only these first-version top-level codes:
+
+```text
+food_and_groceries
+dining
+alcohol_and_tobacco
+clothing_and_footwear
+housing_and_utilities
+household_goods_and_services
+healthcare
+transportation
+travel
+information_and_communication
+recreation_sports_and_culture
+education
+personal_and_family_care
+insurance
+taxes_and_government
+gifts_and_donations
+work_and_business
+```
+
+Do not publish `other`, `general`, `unknown`, `uncategorized`, income, transfer, payment, or fee as Personal Categories. A detailed child may be added only with a non-overlapping definition, real product use case, positive/negative/boundary fixtures, and proof that aggregation to its parent is semantically safe.
+
+The product manages this taxonomy. First-version users may select registered codes but cannot create, rename, move, or delete taxonomy nodes.
+
+### 2.3 Category applicability
+
+Personal Category is allowed for:
+
+- `purchase`;
+- general `payment`, `payment.bill`, and `payment.loan`;
+- `fee` and its descendants;
+- `interest.charged`;
+- `tax.payment`, `tax.refund`;
+- `refund`, `reversal`; and
+- future descendants explicitly registered as compatible.
+
+It is not allowed for:
+
+- `transfer` and its descendants;
+- cash deposit or withdrawal;
+- `income` and its descendants;
+- `interest.earned`;
+- `payment.credit_card`;
+- `loan.disbursement`;
+- `investment` and its descendants; or
+- `adjustment`.
+
+An absent Kind cannot be filled with a Category. One atomic producer output may admit a compatible Kind and Category together. An incompatible Source or Derived pair is a producer/contract error; an incompatible User request is rejected without modifying the Transaction.
+
+### 2.4 Counterparty roles
+
+Publish these first-version roles:
+
+```text
+merchant
+marketplace
+payment_platform
+financial_institution
+income_source
+government
+person
+```
+
+Every Counterparty Participation has exactly one role and provenance. It may have an observed name without a reusable reference. Unsupported role is absence, never `other`.
+
+## 3. Categorization modes
+
+At one Canonical Knowledge Point, Current Categorization is exactly one of:
+
+1. one registered Personal Category;
+2. one complete Category Allocation; or
+3. absent.
+
+A Category Allocation has two or more non-negative exact components and must atomically reconcile to the unchanged booked Transaction amount in its booked currency. Currency conversion is allowed only with explicit conversion evidence. Any missing component, remainder, duplicate target, currency mismatch, or arithmetic mismatch rejects the complete allocation.
+
+Invoice items may derive a Transaction allocation only after contract-proven invoice/Transaction matching and exact complete reconciliation. Otherwise item categories remain attached to the invoice items and do not categorize the Transaction.
+
+An active complete User Categorization supersedes the user's previous single/allocation mode atomically and takes projection precedence over routed automatic output. Clearing it withdraws the user lineage and falls back to the current routed automatic result. A failed or partial Import Run preserves the previous automatic result. Only a successful complete-scope run that proves the prior result unsupported may withdraw a whole allocation; it never retains partial components or guesses a single category.
+
+### 3.1 Refund and reversal inheritance
+
+A versioned Derived producer may inherit categorization only through a valid `refund_of` or `reversal_of` Relation:
+
+- a full reversal may inherit the original categorization;
+- a partial refund of a single-category original may inherit that category;
+- a partial refund of an allocated original must have its own complete evidence-backed or User Allocation and cannot be proportionally guessed; and
+- without a relation, the refund/reversal requires its own categorization or remains absent.
+
+A successful complete-scope rerun supersedes or withdraws inherited categorization after the original category or Relation changes. A failed rerun preserves it. A User Categorization on the refund/reversal remains authoritative.
+
+## 4. Counterparty identity and display
+
+A reusable Counterparty Reference has natural identity `(producer_namespace, producer_entity_key)`. Names are never keys or uniqueness constraints. Different producers never merge references, even when names match.
+
+A reference may retain:
+
+- Source/Derived display name;
+- Source/Derived legal name; and
+- an optional contract-validated registered identifier consisting of scheme, jurisdiction, and value, such as a Taiwan seller business number.
+
+A Counterparty Participation retains role, observed name, optional reference, provenance, and optional source classification scheme/code. A merchant activity code such as ISO 18245 MCC describes business activity; it is not Personal Category, though a versioned Derived producer may use it as evidence.
+
+Do not promote first-version logos, websites, phone/email, social profiles, full address, geolocation, opening hours, inferred corporate groups, or unused provider fields. A compact Source Record may retain a field only when the current contract or derivation requires it.
+
+Current display precedence is:
+
+1. transaction-specific User display override;
+2. User alias on the selected stable Counterparty Reference;
+3. routed Source/Derived display for the selected participation; and
+4. source Transaction description.
+
+Role precedence for selecting one display participation is versioned by Transaction Kind and producer contract. Selection never removes other participations or creates financial authority. Falling back to Transaction description returns `display_counterparty = absent`; readable text never fabricates identity. Aliases and overrides change display only and never merge references, alter roles, select a different participation, or change Kind/Category.
+
+## 5. Tags
+
+A Transaction Tag is user-owned and has a stable local ID, renameable display label, and `active | archived` lifecycle. The normalized current label—trimmed, Unicode-normalized, and case-folded—is unique in the user scope while preserving the chosen display form.
+
+Every Transaction/Tag association has an independent User Assertion lifecycle. Removing a Tag from one Transaction withdraws only that link. Ordinary tag deletion archives the Tag and may bulk-withdraw current associations while preserving assertion history. Hard historical removal belongs to a separate user-data deletion workflow.
+
+Source and Derived producers cannot create or apply Tags. Tags never allocate money, change report inclusion, establish identity, or carry source meaning. The first version has no reusable future merchant categorization rule; a bulk categorization action creates explicit User Assertions for its selected targets only.
+
+## 6. Origins, routing, and confidence
+
+Allowed origins are:
+
+| Enrichment | Source | Derived | User |
+| --- | --- | --- | --- |
+| Transaction Kind | yes | yes | no |
+| Personal Category / Allocation | yes | yes | yes |
+| Counterparty role / reference | yes | yes | no |
+| Counterparty display | yes | yes | yes |
+| Transaction Tags | no | no | yes |
+
+A Source Assertion is a contract-versioned translation or conservative parent mapping of an explicit source field without added interpretation. Mapping from merchant name, free text, MCC, invoice items, or combined fields is a Derived Assertion. Unsafe or ambiguous optional mapping produces absence.
+
+Exactly one versioned Automatic Enrichment Authority Route selects the Source or Derived producer for each declared subject/field scope. Routes, not recency or confidence, select producers. Missing optional output is absence. Overlapping active routes fail admission or projection rebuild.
+
+A producer may record a calibrated confidence score in lineage metadata and declare a fixture-tested threshold. One unique result above threshold creates one Derived Assertion; a low score, tie, or unsupported case creates none. Scores never create candidate rows, a low-confidence canonical state, cross-producer comparison, or runtime ranking. A successful complete-scope run may withdraw a prior result when the new producer version proves it unsupported; failure or partial output changes nothing.
+
+All enrichment changes reuse `canonical_commits`, `assertion_lineages`, `assertions`, `assertion_transitions`, typed assertion values, and provenance from the canonical store. Do not create another enrichment event system.
+
+## 7. Physical responsibilities
+
+Extend the canonical schema with typed families equivalent to the following; exact SQL names may change only if all constraints remain mechanically enforceable.
+
+```text
+Taxonomy registry
+├─ taxonomy_versions
+├─ taxonomy_codes
+└─ taxonomy_code_applicability
+
+Transaction enrichment
+├─ transaction_kind_assertion_values
+├─ transaction_categorization_values
+├─ category_allocation_sets
+└─ category_allocation_components
+
+Counterparty
+├─ counterparty_references
+├─ counterparty_external_identifiers
+├─ counterparty_participations
+└─ counterparty_display_assertion_values
+
+User organization
+├─ user_tags
+├─ user_tag_label_revisions
+└─ transaction_tag_assertion_values
+
+Routing and projection
+├─ automatic_enrichment_authority_routes
+├─ enrichment_producer_versions
+├─ current_transaction_enrichment
+├─ current_category_allocations
+└─ current_transaction_tags
+```
+
+Required constraints:
+
+- Assertions reference an exact `(taxonomy_id, taxonomy_version, code)` row through typed foreign keys.
+- Published code meaning, definition, and parent are immutable; deprecated codes remain readable and reject new Assertions.
+- Single category, complete allocation, and absence are mutually exclusive in one selected projection.
+- Allocation components use exact-decimal types and cannot become current until the complete set reconciles.
+- Counterparty Reference is unique by producer namespace and producer entity key; no name uniqueness or fuzzy match exists.
+- Participation role and origin are required; reference is optional; observed name may be present.
+- Transaction/Tag links accept User origin only.
+- Confidence remains producer-version lineage metadata and is neither projected nor indexed for authority selection.
+- One Automatic Enrichment Authority Route is active per declared scope at a Canonical Knowledge Point.
+- Every current row references selected Assertion and route where applicable and is fully rebuildable.
+
+## 8. Query contract
+
+Current and Historical Projection Queries return typed enrichment instead of asking product modules to interpret Assertions:
+
+```text
+kind
+├─ code
+├─ taxonomy version
+└─ assertion origin
+
+categorization
+├─ mode: single | allocated | absent
+├─ selected assertion
+└─ category or complete allocation components
+
+counterparties[]
+├─ role
+├─ observed name
+├─ optional reference
+└─ provenance
+
+display
+├─ label
+├─ origin
+└─ optional selected counterparty
+
+tags[]
+classification coverage
+report eligibility coverage
+```
+
+Enrichment uses knowledge time only. It inherits the Transaction's financial date for report-period membership and has no separately backdated `effective_at`. A current-knowledge report may therefore reorganize an old Transaction; a Canonical Knowledge Point cutoff reproduces what the application knew and displayed then.
+
+Financial report inclusion is a separate, versioned policy evaluated from admitted financial semantics before Category, display, alias, notes, or Tags. An included Transaction with absent categorization contributes its whole amount to a query-time Unclassified bucket and to classification-coverage metrics. Unclassified is not stored or selectable.
+
+If an inclusion policy requires a missing optional Kind or other admitted semantic, the query returns an eligibility-coverage gap with affected count and amount and does not silently count, drop, or persist an unknown status. A supported integration that claims complete spending coverage must prove through fixtures that its declared scope has no such gap.
+
+## 9. Taxonomy authoring and publishing
+
+Keep one repository Taxonomy Package as the authoring source for each taxonomy version. It defines codes, parents, immutable semantics, applicability, localization keys, producer compatibility, and fixtures. CI must reject:
+
+- duplicate codes, missing parents, or cycles;
+- children that cannot safely aggregate to their parent;
+- mutation or deletion of a published definition or parent;
+- reuse of deprecated codes for new Assertions;
+- missing localization;
+- incompatible Kind/Category output;
+- producer output not declared compatible with the installed package; and
+- insufficient positive, negative, and boundary fixtures.
+
+Generate transactional database seeds, TypeScript typed registries, validators, localization references, and shared fixtures from that one source. A Desktop Release seeds required definitions before opening the canonical writer. Taxonomy packages never update remotely. A semantic correction deprecates the old code and adds a new one; installing code never rewrites historical Assertions. Source or Derived reclassification requires a new evidence-backed contract or producer run. Existing User Assertions remain historically readable and may prompt the user to choose a current replacement; they are not mapped by label.
+
+## 10. Acceptance checks
+
+Implementation is acceptable only when automated tests prove:
+
+1. every published Kind, Category, and Counterparty Role has a definition plus positive, negative, and boundary fixtures;
+2. every integration crosswalk maps each supported source value uniquely, retains original value plus contract/crosswalk version in provenance, and cancels the Capture when a required Kind cannot resolve;
+3. every allowed and disallowed Kind/Category combination is enforced for Source, Derived, and User paths;
+4. allocations are exact, complete, atomic, currency-safe, and never expose a component before the whole set reconciles;
+5. invoice-derived allocation requires reliable matching and exact reconciliation;
+6. Counterparty References reuse only an exact producer-scoped key, names never merge, roles remain independent, and display selection is reproducible;
+7. transaction override, reference alias, automatic display, and description fallback follow precedence without changing identity;
+8. User, routed Source, and routed Derived categorization precedence and clearing fallback are reproducible at current and historical knowledge cutoffs;
+9. low score, tie, failed run, partial run, complete withdrawal, and producer-route change follow the declared confidence and lifecycle rules;
+10. single, allocated, and absent categorization are mutually exclusive, including refund/reversal inheritance and withdrawal;
+11. Tags are user-only, independently withdrawable, renameable without identity change, and financially inert;
+12. Unclassified totals and classification coverage include every financially admitted uncategorized amount without persisted status;
+13. report eligibility gaps expose affected count and amount and prevent an incomplete total from being claimed complete;
+14. financial inclusion remains unchanged under Category, Tag, alias, display, and note changes;
+15. Current, Historical, and Lineage queries return typed taxonomy version, origin, selection, provenance, and dual-cutoff behavior without reading compact payloads in product code;
+16. taxonomy CI prevents cycles, unsafe parents, definition mutation, code deletion, missing localization, incompatible applicability, and undeclared producer output;
+17. taxonomy seeding and schema upgrade commit before the writer opens, while a failed upgrade exposes neither partial registry nor projection; and
+18. no legacy categorization or enrichment data is migrated across the Canonical Reset established by ADR 0009.
+
+## 11. Comparison references
+
+- [Plaid Transactions API](https://plaid.com/docs/api/products/transactions/) — comparison for versioned Personal Finance Categories, merchant/counterparty roles, entity identifiers, nullable merchant data, and enrichment confidence.
+- [Plaid Investments API](https://plaid.com/docs/api/products/investments/) — comparison for investment operation coverage; Plaid sign and subtype conventions are deliberately decomposed rather than copied.
+- [Plaid Personal Finance Category migration](https://plaid.com/docs/transactions/pfc-migration/) — comparison for taxonomy evolution and primary/detailed levels.
+- [Taiwan DGBAS consumption classification](https://www.stat.gov.tw/public/data/dgbas03/bs4/ninews/9807/%E9%99%84%E8%A1%A84.pdf) — coverage check for Taiwan household-consumption purposes, not a direct canonical-code import.
+
+## 12. Explicit first-version exclusions
+
+This specification does not add Plaid connectivity, global merchant identity, fuzzy Counterparty merge, Institution/Counterparty merge, user merchant merge, user-created category trees, future merchant categorization rules, partial allocation, canonical `other`/`unknown`/`unclassified`, confidence candidates, cross-producer score ranking, enrichment-specific event storage, remote taxonomy updates, speculative merchant profiles, or legacy enrichment migration.


### PR DESCRIPTION
This pull request adds a new Architecture Decision Record (ADR) documenting the adoption of a Plaid-inspired canonical financial model for OctopusBeak. The ADR establishes a unified, source-scoped domain model for financial data, clarifying entity boundaries, required fields, and provenance requirements. It also outlines how the model aligns with Plaid concepts, where it is adapted for Taiwan sources, and what is excluded or deferred.

The most important changes are:

**Canonical Model Definition**
* Introduces a logical canonical model centered on source-scoped Financial Accounts and immutable source evidence, ensuring all canonical projections are traceable to their source records and distinguish source facts from inference.
* Defines core entities and relationships, including Institution, Supported Source, Source Connection, Source Capture, Source Record, Import Run, Financial Account, Account Identifier, Balance Observation, Financial Transaction, Card Instrument, Credit Card Billing Statement, Security, and Holding Observation, with clear requirements for each.

**Identity, Provenance, and Admission Rules**
* Establishes strict identity and admission rules: accounts are source-scoped, never merged across sources or connections, and must have stable, contract-defined identifiers; provenance is maintained at both entity and field level.
* Specifies that unresolved or ambiguous semantics (e.g., missing required identifiers or transaction status) cause admission failure rather than introducing canonical uncertainty. (Ff6