### PR TITLE
Add canonical Cathay statement workflows and financial query loaders

### DIFF
--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -273,6 +273,39 @@ for (const [label, corruptField] of [
   } finally { await rm(dir, { recursive: true, force: true }); }
 }
 
+// Every assertion selected into the active projection must retain at least one
+// origin-appropriate provenance row. Removing all rows is distinct from a
+// malformed row and must fail both startup and candidate rebuild validation.
+for (const origin of ["source", "derived", "user"] as const) {
+  const { dir, transactionId } = await makeFieldLedger(`cathay-canonical-v7-red-provenance-missing-${origin}-`);
+  try {
+    if (origin === "derived") {
+      await commitCathayDerivedImportRun(dir, {
+        sourceConnectionId: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.sourceConnectionId,
+        identityEpoch: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.identityEpoch,
+        authorityRoute: "cathay/domestic-deposit/v1",
+        stream: "domestic-deposit",
+        producerId: "missing-provenance-enricher",
+        ruleLineage: "missing-provenance-rule",
+        complete: true,
+        status: "complete",
+        subjectIds: [transactionId],
+        fields: ["note"],
+        scope: [{ transactionId, field: "note", state: "supported", value: "Missing provenance note" }],
+      });
+    }
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const assertion = origin === "source"
+      ? corrupt.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' LIMIT 1").get()
+      : corrupt.prepare("SELECT CASE WHEN origin = 'derived' THEN derived_assertion_id ELSE user_assertion_id END AS assertion_id FROM projection_generation_transaction_fields WHERE origin = ? LIMIT 1").get(origin);
+    assert.ok(assertion && (assertion as { assertion_id?: Uint8Array }).assertion_id);
+    corrupt.prepare("DELETE FROM assertion_provenance WHERE assertion_id = ?").run(Buffer.from((assertion as { assertion_id: Uint8Array }).assertion_id));
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /provenance|lineage|source|assertion|selected/i, origin);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /provenance|lineage|source|assertion|selected/i, origin);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
 {
   const { dir, otherTransactionId } = await makeFieldLedger("cathay-canonical-v7-red-lifecycle-coordinate-");
   try {
@@ -405,23 +438,23 @@ for (const [label, corruptField] of [
 // rejected by the read-only startup verifier and rebuild gate.
 for (const [label, corrupt] of [
   ["deleted history", (db: DatabaseSync) => {
-    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete");
+    db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_delete");
     db.exec("DELETE FROM projection_generation_provenance WHERE ordinal = 4");
   }],
   ["wrong digest", (db: DatabaseSync) => {
-    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update");
     db.exec("UPDATE projection_generation_provenance SET event_digest = randomblob(32) WHERE ordinal = 4");
   }],
   ["wrong ordinal", (db: DatabaseSync) => {
-    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update");
     db.exec("UPDATE projection_generation_provenance SET ordinal = 99 WHERE ordinal = 4");
   }],
   ["wrong previous event", (db: DatabaseSync) => {
-    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update");
     db.exec("UPDATE projection_generation_provenance SET previous_event_id = randomblob(16) WHERE ordinal = 4");
   }],
   ["wrong event source", (db: DatabaseSync) => {
-    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update");
     db.exec("UPDATE projection_generation_provenance SET event_source = 'migration' WHERE ordinal = 4");
   }],
   ["wrong commit kind", (db: DatabaseSync) => {
@@ -467,7 +500,7 @@ for (const [label, corrupt] of [
   try {
     await rebuildCathayCanonicalProjection(dir);
     const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
-    corrupt.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    corrupt.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update");
     corrupt.exec("UPDATE projection_generation_provenance SET generation_id = 2 WHERE generation_id = 1 AND ordinal = 4");
     corrupt.close();
     assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /chain|provenance|knowledge|generation/i);
@@ -482,8 +515,8 @@ for (const [label, corrupt] of [
   try {
     const legacy = new DatabaseSync(canonicalSqlitePath(dir));
     legacy.exec(`PRAGMA foreign_keys = OFF;
-      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
-      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
+      DROP TRIGGER IF EXISTS projection_generation_events_no_update;
+      DROP TRIGGER IF EXISTS projection_generation_events_no_delete;
       ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy;
       CREATE TABLE projection_generation_provenance(
         event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16), generation_id INTEGER NOT NULL,
@@ -516,8 +549,8 @@ for (const [label, corrupt] of [
   try {
     const legacy = new DatabaseSync(canonicalSqlitePath(dir));
     legacy.exec(`PRAGMA foreign_keys = OFF;
-      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
-      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
+      DROP TRIGGER IF EXISTS projection_generation_events_no_update;
+      DROP TRIGGER IF EXISTS projection_generation_events_no_delete;
       DELETE FROM projection_generation_provenance WHERE event_kind = 'created';
       ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy;
       CREATE TABLE projection_generation_provenance(
@@ -535,6 +568,25 @@ for (const [label, corrupt] of [
     try {
       assert.deepEqual((migrated.prepare("SELECT event_kind FROM projection_generation_provenance WHERE generation_id = 1 ORDER BY ordinal").all() as Array<{ event_kind: string }>).map((row) => row.event_kind).slice(0, 3), ["created", "validated", "switched"]);
     } finally { migrated.close(); }
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// Trigger names are part of the recovery contract: two present triggers with
+// swapped operations are not equivalent to the required update/delete pair.
+{
+  const { dir } = await makePopulatedLedger("cathay-canonical-v7-red-trigger-definition-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec(`DROP TRIGGER projection_generation_events_no_update;
+      DROP TRIGGER projection_generation_events_no_delete;
+      CREATE TRIGGER projection_generation_events_no_update
+      BEFORE DELETE ON projection_generation_provenance
+      BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
+      CREATE TRIGGER projection_generation_events_no_delete
+      BEFORE UPDATE ON projection_generation_provenance
+      BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;`);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /trigger|append-only|provenance/i);
   } finally { await rm(dir, { recursive: true, force: true }); }
 }
 

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -69,3 +69,90 @@ try {
 } finally {
   await rm(ledgerDir, { recursive: true, force: true });
 }
+
+async function makePopulatedLedger(prefix: string): Promise<{ dir: string; commitId: Buffer }> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  await commitCathayDomesticDeposit(dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const db = new DatabaseSync(canonicalSqlitePath(dir), { readOnly: true });
+  try {
+    return { dir, commitId: Buffer.from((db.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence LIMIT 1").get() as { commit_id: Uint8Array }).commit_id) };
+  } finally { db.close(); }
+}
+
+// These are deliberately isolated red cases: each corrupts a copy of an otherwise
+// valid ledger, so a startup gate cannot be accidentally masked by a prior case.
+{
+  const { dir } = await makePopulatedLedger("cathay-canonical-v7-red-arithmetic-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("UPDATE transaction_revisions SET amount_coefficient = '12abc'");
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /exact arithmetic|decimal/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir, commitId } = await makePopulatedLedger("cathay-canonical-v7-red-route-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.prepare("INSERT INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run("evil/route", "evil", "domestic-deposit", "evil/v1", commitId);
+    corrupt.prepare("UPDATE source_captures SET authority_route = 'evil/route'").run();
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /authority|route/i);
+    assert.rejects(() => rebuildCathayCanonicalProjection(dir), /authority|route/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir, commitId } = await makePopulatedLedger("cathay-canonical-v7-red-active-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
+      VALUES (2, 'active', 1, 'canonical/projection/v1', ?, ?, ?)`).run(commitId, commitId, commitId);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /active projection/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir } = await makePopulatedLedger("cathay-canonical-v7-red-pointer-null-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("DROP TRIGGER trg_active_projection_generation_switch_update; DROP TRIGGER trg_active_projection_generation_commit_update");
+    corrupt.exec("UPDATE active_projection_generation SET switched_commit_id = NULL");
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /pointer|switch|projection state/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const dir = await mkdtemp(join(tmpdir(), "cathay-canonical-v7-red-pointer-mismatch-"));
+  try {
+    const first = await commitCathayDomesticDeposit(dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+    await commitCathayDomesticDeposit(dir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "2026-08-18T00:00:00+08:00" });
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const ids = corrupt.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence").all() as Array<{ commit_id: Uint8Array }>;
+    assert.equal(ids.length >= 2, true);
+    corrupt.exec("DROP TRIGGER trg_active_projection_generation_commit_update");
+    corrupt.prepare("UPDATE active_projection_generation SET switched_commit_id = ?").run(Buffer.from(ids[0]!.commit_id));
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /pointer|switch|projection state/i);
+    assert.equal(first.commitSequence, 1);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir } = await makePopulatedLedger("cathay-canonical-v7-exact-valid-");
+  try {
+    const largeSigned = "-123456789012345678901234567890123456789";
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.prepare("UPDATE transaction_revisions SET amount_coefficient = ?, amount_scale = 2").run(largeSigned);
+    corrupt.close();
+    const readable = openCanonicalDatabase(dir, { readOnly: true });
+    readable.close();
+    const rebuilt = await rebuildCathayCanonicalProjection(dir);
+    assert.equal(rebuilt.status, "switched");
+    const query = createCathayCanonicalFinancialQuery(dir);
+    assert.equal((await query.current({ kind: "current" })).transactions[0]?.amount.coefficient, largeSigned);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -460,3 +460,37 @@ for (const [label, corrupt] of [
     } finally { migrated.close(); }
   } finally { await rm(dir, { recursive: true, force: true }); }
 }
+
+// A committed candidate without a switch is never a recoverable active
+// generation. It must block both read-only startup and a subsequent rebuild;
+// the writer must not silently retire or delete it.
+for (const [status, phaseCount] of [["building", 1], ["validated", 2]] as const) {
+  const { dir } = await makeFieldLedger(`cathay-canonical-v7-red-stray-${status}-`);
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const maxSequence = Number((corrupt.prepare("SELECT MAX(commit_sequence) AS sequence FROM canonical_commits").get() as { sequence?: number }).sequence ?? 0);
+    const commitId = Buffer.alloc(16, status === "building" ? 0x71 : 0x72);
+    corrupt.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, 'canonical/projection/v1', 'projection_rebuild')").run(commitId, maxSequence + 1, 0);
+    corrupt.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id)
+      VALUES (2, ?, ?, 'canonical/projection/v1', ?, ?)`)
+      .run(status, maxSequence, commitId, phaseCount === 2 ? commitId : null);
+    const createdId = Buffer.alloc(16, status === "building" ? 0x81 : 0x82);
+    const createdDigest = createHash("sha256").update(`canonical-projection-provenance/v1|2|1|created|rebuild|${commitId.toString("hex")}|`, "utf8").digest();
+    corrupt.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest)
+      VALUES (?, 2, 1, NULL, 'created', 'rebuild', ?, ?)`).run(createdId, commitId, createdDigest);
+    if (phaseCount === 2) {
+      const validatedId = Buffer.alloc(16, 0x83);
+      const validatedDigest = createHash("sha256").update(`canonical-projection-provenance/v1|2|2|validated|rebuild|${commitId.toString("hex")}|${createdId.toString("hex")}`, "utf8").digest();
+      corrupt.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest)
+        VALUES (?, 2, 1 + 1, ?, 'validated', 'rebuild', ?, ?)`).run(validatedId, createdId, commitId, validatedDigest);
+    }
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /building|validated|recovery|generation/i, status);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /building|validated|recovery|generation/i, status);
+    const unchanged = new DatabaseSync(canonicalSqlitePath(dir), { readOnly: true });
+    try {
+      assert.equal(unchanged.prepare("SELECT COUNT(*) AS count FROM projection_generations WHERE generation_id > 1").get()?.count, 1);
+      assert.equal(unchanged.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get()?.generation_id, 1);
+    } finally { unchanged.close(); }
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { DatabaseSync } from "node:sqlite";
 import {
   CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+  CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE,
   CANONICAL_SCHEMA_VERSION,
   canonicalSqlitePath,
   commitCathayDomesticDeposit,
@@ -225,5 +226,98 @@ for (const [label, corruptField] of [
     corrupt.close();
     assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /field|assertion|projection|origin|generation/i, label);
     await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /field|assertion|projection|origin|generation/i, label);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir, otherTransactionId } = await makeFieldLedger("cathay-canonical-v7-red-lifecycle-coordinate-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("DROP TRIGGER IF EXISTS trg_assertion_transitions_integrity_insert; DROP TRIGGER IF EXISTS trg_assertion_transitions_integrity_update");
+    corrupt.prepare(`UPDATE assertion_transitions SET transaction_id = ? WHERE assertion_id = (
+      SELECT user_assertion_id FROM projection_generation_transaction_fields WHERE origin = 'user' LIMIT 1
+    )`).run(Buffer.from(otherTransactionId.replaceAll("-", ""), "hex"));
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /lifecycle|coordinate|assertion|transaction/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /lifecycle|coordinate|assertion|transaction/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-field-moved-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("DROP TRIGGER IF EXISTS trg_projection_generation_fields_integrity_insert; DROP TRIGGER IF EXISTS trg_projection_generation_fields_integrity_update");
+    const commitId = (corrupt.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence LIMIT 1").get() as { commit_id: Uint8Array }).commit_id;
+    corrupt.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
+      VALUES (2, 'retired', 3, 'canonical/projection/v1', ?, ?, ?)`).run(Buffer.from(commitId), Buffer.from(commitId), Buffer.from(commitId));
+    corrupt.exec("UPDATE projection_generation_transaction_fields SET generation_id = 2 WHERE origin = 'user'");
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /field|complete|projection/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /field|complete|projection/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const dir = await mkdtemp(join(tmpdir(), "cathay-canonical-v7-red-old-revision-"));
+  try {
+    const first = await commitCathayDomesticDeposit(dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+    await commitCathayDomesticDeposit(dir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace('"incomeAmt":12500', '"incomeAmt":13000').replace('"balance":12500', '"balance":13000'), observedAt: "2026-08-18T00:00:00+08:00" });
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const target = corrupt.prepare(`SELECT transaction_id, revision_id FROM current_transactions
+      WHERE transaction_id IN (SELECT transaction_id FROM transaction_revisions WHERE revision_number = 2) LIMIT 1`).get() as { transaction_id: Uint8Array; revision_id: Uint8Array };
+    const oldRevision = corrupt.prepare("SELECT revision_id, commit_id FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number LIMIT 1").get(Buffer.from(target.transaction_id)) as { revision_id: Uint8Array; commit_id: Uint8Array };
+    corrupt.prepare(`UPDATE projection_generation_transactions SET revision_id = ?, revision_commit_id = ?
+      WHERE generation_id = (SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1) AND transaction_id = ?`).run(Buffer.from(oldRevision.revision_id), Buffer.from(oldRevision.commit_id), Buffer.from(target.transaction_id));
+    corrupt.close();
+    assert.equal(first.transactions.length, 3);
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /revision|projection|identity|complete/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /revision|projection|identity|complete/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-too-new-commit-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const maxSequence = Number((corrupt.prepare("SELECT MAX(commit_sequence) AS sequence FROM canonical_commits").get() as { sequence?: number }).sequence ?? 0);
+    const tooNew = Buffer.alloc(16, 0x66);
+    corrupt.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, 'user/local', 'user_assertion')").run(tooNew, maxSequence + 1, 0);
+    corrupt.prepare("UPDATE projection_generation_transactions SET projection_commit_id = ? WHERE transaction_id = (SELECT transaction_id FROM projection_generation_transactions LIMIT 1)").run(tooNew);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /commit|projection|cutoff/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /commit|projection|cutoff/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+{
+  const dir = await mkdtemp(join(tmpdir(), "cathay-canonical-v7-valid-unchanged-fields-"));
+  try {
+    const source = await commitCathayDomesticDeposit(dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+    const transactionId = source.transactions[0]!.transactionId;
+    const derivedInput = {
+      sourceConnectionId: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.sourceConnectionId,
+      identityEpoch: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.identityEpoch,
+      authorityRoute: "cathay/domestic-deposit/v1",
+      stream: "domestic-deposit",
+      producerId: "valid-combination-enricher",
+      ruleLineage: "valid-combination-rule",
+      complete: true as const,
+      status: "complete" as const,
+      subjectIds: [transactionId],
+      fields: ["note" as const],
+      scope: [{ transactionId, field: "note" as const, state: "supported" as const, value: "Stable note" }],
+    };
+    const derived = await commitCathayDerivedImportRun(dir, derivedInput);
+    const user = await commitCathayUserAssertion(dir, { transactionId, field: "display_name", value: "Stable user label" });
+    await commitCathayDerivedImportRun(dir, derivedInput);
+    const query = createCathayCanonicalFinancialQuery(dir);
+    const current = (await query.current({ kind: "current" })).transactions[0]!;
+    assert.equal(current.displayLabel, "Stable user label");
+    assert.equal(current.note, "Stable note");
+    assert.equal(current.displayLabelCommitSequence, user.commitSequence);
+    assert.equal(current.noteCommitSequence, derived.commitSequence);
+    const readable = openCanonicalDatabase(dir, { readOnly: true });
+    try { assert.equal(readable.prepare("SELECT COUNT(*) AS count FROM projection_generation_transaction_fields WHERE origin = 'derived'").get()?.count, 1); } finally { readable.close(); }
   } finally { await rm(dir, { recursive: true, force: true }); }
 }

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -353,5 +354,109 @@ for (const [label, corruptField] of [
     corrupt.close();
     assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /switch|knowledge|provenance|projection/i);
     await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /switch|knowledge|provenance|projection/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// The provenance chain is a recovery boundary, not merely an append-only
+// convention. Each tamper case disables the normal trigger and must still be
+// rejected by the read-only startup verifier and rebuild gate.
+for (const [label, corrupt] of [
+  ["deleted history", (db: DatabaseSync) => {
+    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete");
+    db.exec("DELETE FROM projection_generation_provenance WHERE ordinal = 4");
+  }],
+  ["wrong digest", (db: DatabaseSync) => {
+    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("UPDATE projection_generation_provenance SET event_digest = randomblob(32) WHERE ordinal = 4");
+  }],
+  ["wrong ordinal", (db: DatabaseSync) => {
+    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("UPDATE projection_generation_provenance SET ordinal = 99 WHERE ordinal = 4");
+  }],
+  ["wrong previous event", (db: DatabaseSync) => {
+    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("UPDATE projection_generation_provenance SET previous_event_id = randomblob(16) WHERE ordinal = 4");
+  }],
+  ["wrong event source", (db: DatabaseSync) => {
+    db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    db.exec("UPDATE projection_generation_provenance SET event_source = 'migration' WHERE ordinal = 4");
+  }],
+  ["wrong commit kind", (db: DatabaseSync) => {
+    db.exec("UPDATE canonical_commits SET commit_kind = 'source_capture' WHERE commit_kind = 'derived_import'");
+  }],
+] as Array<[string, (db: DatabaseSync) => void]>) {
+  const { dir } = await makeFieldLedger(`cathay-canonical-v7-red-chain-${label.replaceAll(" ", "-")}-`);
+  try {
+    const corruptDb = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt(corruptDb);
+    corruptDb.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /chain|provenance|knowledge|digest|commit|source/i, label);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /chain|provenance|knowledge|digest|commit|source/i, label);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// A valid semantic duplicate from a different source must not hide a missing
+// or relocated event. The digest is recomputed here so this exercises the
+// full-history/source verifier rather than only the digest check.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-chain-semantic-duplicate-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const last = corrupt.prepare(`SELECT event_id, commit_id, ordinal FROM projection_generation_provenance
+      WHERE generation_id = 1 ORDER BY ordinal DESC LIMIT 1`).get() as { event_id: Uint8Array; commit_id: Uint8Array; ordinal: number };
+    const ordinal = Number(last.ordinal) + 1;
+    const previous = Buffer.from(last.event_id);
+    const commitId = Buffer.from(last.commit_id);
+    const duplicateId = Buffer.alloc(16, 0x55);
+    const digest = createHash("sha256").update(`canonical-projection-provenance/v1|1|${ordinal}|knowledge|migration|${commitId.toString("hex")}|${previous.toString("hex")}`, "utf8").digest();
+    corrupt.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest)
+      VALUES (?, 1, ?, ?, 'knowledge', 'migration', ?, ?)`).run(duplicateId, ordinal, previous, commitId, digest);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /chain|provenance|knowledge|source/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /chain|provenance|knowledge|source/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// Moving a correctly shaped event to another generation must invalidate both
+// chains, even when foreign keys and the active pointer remain valid.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-chain-relocation-");
+  try {
+    await rebuildCathayCanonicalProjection(dir);
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update");
+    corrupt.exec("UPDATE projection_generation_provenance SET generation_id = 2 WHERE generation_id = 1 AND ordinal = 4");
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /chain|provenance|knowledge|generation/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /chain|provenance|knowledge|generation/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// A pre-chain v7 relation is upgraded in-place and its deterministic chain is
+// committed atomically before the writer-open validation gate runs.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-chain-migration-");
+  try {
+    const legacy = new DatabaseSync(canonicalSqlitePath(dir));
+    legacy.exec(`PRAGMA foreign_keys = OFF;
+      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
+      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
+      ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy;
+      CREATE TABLE projection_generation_provenance(
+        event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16), generation_id INTEGER NOT NULL,
+        event_kind TEXT NOT NULL, event_source TEXT NOT NULL, commit_id BLOB NOT NULL
+      );
+      INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id)
+        SELECT event_id, generation_id, event_kind, event_source, commit_id FROM projection_generation_provenance_legacy;
+      DROP TABLE projection_generation_provenance_legacy;
+      PRAGMA user_version = 7;`);
+    legacy.close();
+    const writer = openCanonicalDatabase(dir);
+    writer.close();
+    const migrated = openCanonicalDatabase(dir, { readOnly: true });
+    try {
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM projection_generation_provenance WHERE ordinal IS NULL OR event_digest IS NULL").get()?.count, 0);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM projection_generation_provenance WHERE previous_event_id IS NULL").get()?.count, 1);
+    } finally { migrated.close(); }
   } finally { await rm(dir, { recursive: true, force: true }); }
 }

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -159,7 +159,7 @@ async function makeFieldLedger(prefix: string): Promise<{ dir: string; transacti
     const ids = corrupt.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence").all() as Array<{ commit_id: Uint8Array }>;
     assert.equal(ids.length >= 2, true);
     corrupt.exec("DROP TRIGGER trg_active_projection_generation_commit_update");
-    corrupt.prepare("UPDATE active_projection_generation SET switched_commit_id = ?").run(Buffer.from(ids[0]!.commit_id));
+    corrupt.prepare("UPDATE active_projection_generation SET switched_commit_id = ?").run(Buffer.from(ids[1]!.commit_id));
     corrupt.close();
     assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /pointer|switch|projection state/i);
     assert.equal(first.commitSequence, 1);
@@ -319,5 +319,39 @@ for (const [label, corruptField] of [
     assert.equal(current.noteCommitSequence, derived.commitSequence);
     const readable = openCanonicalDatabase(dir, { readOnly: true });
     try { assert.equal(readable.prepare("SELECT COUNT(*) AS count FROM projection_generation_transaction_fields WHERE origin = 'derived'").get()?.count, 1); } finally { readable.close(); }
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// A valid canonical commit is not automatically a valid projection-selection
+// commit: an unchanged transaction must retain the source lifecycle commit
+// that selected its revision, not an unrelated later Derived/User commit.
+{
+  const { dir, otherTransactionId } = await makeFieldLedger("cathay-canonical-v7-red-transaction-selection-commit-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const unrelated = (corrupt.prepare("SELECT commit_id FROM canonical_commits WHERE commit_sequence = 2").get() as { commit_id: Uint8Array }).commit_id;
+    corrupt.prepare("UPDATE projection_generation_transactions SET projection_commit_id = ? WHERE transaction_id = ?").run(Buffer.from(unrelated), Buffer.from(otherTransactionId.replaceAll("-", ""), "hex"));
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /selection|projection|commit|provenance/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /selection|projection|commit|provenance/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// Pointer, generation and current-state fields may all point at a real commit;
+// without an append-only switch/knowledge event that commit is still orphaned.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-orphan-knowledge-commit-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const maxSequence = Number((corrupt.prepare("SELECT MAX(commit_sequence) AS sequence FROM canonical_commits").get() as { sequence?: number }).sequence ?? 0);
+    const orphan = Buffer.alloc(16, 0x77);
+    corrupt.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, 'user/local', 'user_assertion')").run(orphan, maxSequence + 1, 0);
+    corrupt.exec("DROP TRIGGER IF EXISTS trg_active_projection_generation_switch_update; DROP TRIGGER IF EXISTS trg_active_projection_generation_commit_update");
+    corrupt.prepare("UPDATE projection_generations SET switched_commit_id = ? WHERE status = 'active'").run(orphan);
+    corrupt.prepare("UPDATE active_projection_generation SET switched_commit_id = ? WHERE singleton_id = 1").run(orphan);
+    corrupt.prepare("UPDATE current_projection_state SET commit_id = ? WHERE generation = 1").run(orphan);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /switch|knowledge|provenance|projection/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /switch|knowledge|provenance|projection/i);
   } finally { await rm(dir, { recursive: true, force: true }); }
 }

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import {
+  CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+  CANONICAL_SCHEMA_VERSION,
+  canonicalSqlitePath,
+  commitCathayDomesticDeposit,
+  createCathayCanonicalFinancialQuery,
+  openCanonicalDatabase,
+  rebuildCathayCanonicalProjection,
+} from "./cathay-domestic-deposit.ts";
+import { CanonicalBusyRetryExhaustedError } from "./canonical-runtime.ts";
+
+const ledgerDir = await mkdtemp(join(tmpdir(), "cathay-canonical-v7-runtime-"));
+try {
+  const first = await commitCathayDomesticDeposit(ledgerDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const db = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    assert.equal(Number(db.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(String(db.prepare("PRAGMA journal_mode").get()?.journal_mode).toLowerCase(), "wal");
+    assert.equal(db.prepare("PRAGMA foreign_keys").get()?.foreign_keys, 1);
+    assert.equal(db.prepare("PRAGMA synchronous").get()?.synchronous, 2);
+    assert.deepEqual(db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get()?.generation_id, 1);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transactions WHERE generation_id = 1").get()?.count, first.transactions.length);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM current_transactions").get()?.count, first.transactions.length);
+  } finally { db.close(); }
+
+  const query = createCathayCanonicalFinancialQuery(ledgerDir);
+  const before = await query.current({ kind: "current" });
+  const rebuilt = await rebuildCathayCanonicalProjection(ledgerDir);
+  assert.equal(rebuilt.previousGeneration, 1);
+  assert.equal(rebuilt.generation, 2);
+  assert.equal((await query.current({ kind: "current" })).transactions.length, before.transactions.length);
+
+  const switched = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  let activeGeneration = 0;
+  try {
+    activeGeneration = Number(switched.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get()?.generation_id);
+    assert.equal(activeGeneration, rebuilt.generation);
+    assert.equal(switched.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(activeGeneration)?.status, "active");
+    assert.equal(switched.prepare("SELECT status FROM projection_generations WHERE generation_id = 1").get()?.status, "retired");
+  } finally { switched.close(); }
+
+  await assert.rejects(() => rebuildCathayCanonicalProjection(ledgerDir, { injectFailure: "validation" }), /Injected projection rebuild failure/);
+  const afterFailure = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    assert.equal(Number(afterFailure.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get()?.generation_id), activeGeneration);
+    assert.equal(afterFailure.prepare("SELECT COUNT(*) AS count FROM projection_generations WHERE status = 'building'").get()?.count, 0);
+  } finally { afterFailure.close(); }
+
+  const lock = new DatabaseSync(canonicalSqlitePath(ledgerDir));
+  lock.exec("PRAGMA busy_timeout = 1; BEGIN IMMEDIATE");
+  const retried = commitCathayDomesticDeposit(ledgerDir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "2026-08-18T00:00:00+08:00" }, { runtime: { busyTimeoutMs: 1, maxAttempts: 10, initialBackoffMs: 1, maxBackoffMs: 4 } });
+  setTimeout(() => lock.exec("COMMIT"), 10);
+  await retried;
+  lock.close();
+  const exhausted = new DatabaseSync(canonicalSqlitePath(ledgerDir));
+  exhausted.exec("PRAGMA busy_timeout = 1; BEGIN IMMEDIATE");
+  await assert.rejects(() => commitCathayDomesticDeposit(ledgerDir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "2026-08-19T00:00:00+08:00" }, { runtime: { busyTimeoutMs: 1, maxAttempts: 2, initialBackoffMs: 1, maxBackoffMs: 1 } }), CanonicalBusyRetryExhaustedError);
+  exhausted.exec("ROLLBACK");
+  exhausted.close();
+
+  const newer = new DatabaseSync(canonicalSqlitePath(ledgerDir));
+  try { newer.exec("PRAGMA user_version = 8"); } finally { newer.close(); }
+  assert.throws(() => openCanonicalDatabase(ledgerDir), /newer than supported/);
+} finally {
+  await rm(ledgerDir, { recursive: true, force: true });
+}

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -8,6 +8,8 @@ import {
   CANONICAL_SCHEMA_VERSION,
   canonicalSqlitePath,
   commitCathayDomesticDeposit,
+  commitCathayDerivedImportRun,
+  commitCathayUserAssertion,
   createCathayCanonicalFinancialQuery,
   openCanonicalDatabase,
   rebuildCathayCanonicalProjection,
@@ -77,6 +79,28 @@ async function makePopulatedLedger(prefix: string): Promise<{ dir: string; commi
   try {
     return { dir, commitId: Buffer.from((db.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence LIMIT 1").get() as { commit_id: Uint8Array }).commit_id) };
   } finally { db.close(); }
+}
+
+async function makeFieldLedger(prefix: string): Promise<{ dir: string; transactionId: string; otherTransactionId: string }> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  const source = await commitCathayDomesticDeposit(dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const transactionId = source.transactions[0]!.transactionId;
+  const otherTransactionId = source.transactions[1]!.transactionId;
+  await commitCathayDerivedImportRun(dir, {
+    sourceConnectionId: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.sourceConnectionId,
+    identityEpoch: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.identityEpoch,
+    authorityRoute: "cathay/domestic-deposit/v1",
+    stream: "domestic-deposit",
+    producerId: "red-test-enricher",
+    ruleLineage: "red-test-rule",
+    complete: true,
+    status: "complete",
+    subjectIds: [transactionId],
+    fields: ["display_name"],
+    scope: [{ transactionId, field: "display_name", state: "supported", value: "Red test label" }],
+  });
+  await commitCathayUserAssertion(dir, { transactionId, field: "display_name", value: "Red test user label" });
+  return { dir, transactionId, otherTransactionId };
 }
 
 // These are deliberately isolated red cases: each corrupts a copy of an otherwise
@@ -154,5 +178,52 @@ async function makePopulatedLedger(prefix: string): Promise<{ dir: string; commi
     assert.equal(rebuilt.status, "switched");
     const query = createCathayCanonicalFinancialQuery(dir);
     assert.equal((await query.current({ kind: "current" })).transactions[0]?.amount.coefficient, largeSigned);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// A latest revision can be structurally valid while its Source Assertion is
+// missing. Rebuild population must report the missing identity rather than
+// silently dropping it through an inner join.
+{
+  const { dir } = await makePopulatedLedger("cathay-canonical-v7-red-completeness-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const sourceRevision = corrupt.prepare("SELECT revision_id FROM transaction_revisions ORDER BY revision_number, revision_id LIMIT 1").get() as { revision_id: Uint8Array };
+    const columns = (corrupt.prepare("PRAGMA table_info(transaction_revisions)").all() as Array<{ name: string }>).map((column) => column.name);
+    const expressions = columns.map((column) => column === "revision_id" ? "randomblob(16)" : column === "commit_id" ? "?" : column === "revision_number" ? "99" : column);
+    const maxSequence = Number((corrupt.prepare("SELECT MAX(commit_sequence) AS sequence FROM canonical_commits").get() as { sequence?: number }).sequence ?? 0);
+    const commitId = Buffer.alloc(16, 0x44);
+    corrupt.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, 'source_capture')").run(commitId, maxSequence + 1, 0, "cathay/domestic-deposit/v1");
+    corrupt.prepare(`INSERT INTO transaction_revisions(${columns.join(", ")}) SELECT ${expressions.join(", ")} FROM transaction_revisions WHERE revision_id = ?`).run(commitId, Buffer.from(sourceRevision.revision_id));
+    corrupt.close();
+    const valid = openCanonicalDatabase(dir, { readOnly: true });
+    valid.close();
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /complete|missing|identity|projection/i);
+    const after = new DatabaseSync(canonicalSqlitePath(dir), { readOnly: true });
+    try {
+      assert.equal(after.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get()?.generation_id, 1);
+      assert.equal(after.prepare("SELECT COUNT(*) AS count FROM projection_generations WHERE status = 'building'").get()?.count, 0);
+    } finally { after.close(); }
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+for (const [label, corruptField] of [
+  ["user assertion used as derived", (db: DatabaseSync) => db.exec("UPDATE projection_generation_transaction_fields SET origin = 'derived', derived_assertion_id = user_assertion_id, user_assertion_id = NULL WHERE origin = 'user'")],
+  ["source assertion used as user", (db: DatabaseSync) => {
+    const source = db.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' LIMIT 1").get() as { assertion_id: Uint8Array };
+    db.prepare("UPDATE projection_generation_transaction_fields SET origin = 'user', user_assertion_id = ?, derived_assertion_id = NULL WHERE origin = 'user'").run(Buffer.from(source.assertion_id));
+  }],
+  ["field row points at another transaction", (db: DatabaseSync, otherTransactionId?: string) => db.prepare("UPDATE projection_generation_transaction_fields SET transaction_id = ? WHERE origin = 'user'").run(Buffer.from(otherTransactionId!.replaceAll("-", ""), "hex"))],
+  ["field key disagrees with assertion", (db: DatabaseSync) => db.exec("UPDATE projection_generation_transaction_fields SET field_name = 'note' WHERE origin = 'user'")],
+  ["field projection commit disagrees with generation", (db: DatabaseSync) => db.exec("UPDATE projection_generation_transaction_fields SET projection_commit_id = (SELECT commit_id FROM canonical_commits ORDER BY commit_sequence LIMIT 1) WHERE origin = 'user'")],
+] as Array<[string, (db: DatabaseSync, otherTransactionId?: string) => void]>) {
+  const { dir, otherTransactionId } = await makeFieldLedger(`cathay-canonical-v7-red-field-${label.replaceAll(" ", "-")}-`);
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    corrupt.exec("DROP TRIGGER IF EXISTS trg_projection_generation_fields_integrity_insert; DROP TRIGGER IF EXISTS trg_projection_generation_fields_integrity_update");
+    corruptField(corrupt, otherTransactionId);
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /field|assertion|projection|origin|generation/i, label);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /field|assertion|projection|origin|generation/i, label);
   } finally { await rm(dir, { recursive: true, force: true }); }
 }

--- a/src/ledger/canonical/canonical-runtime.check.ts
+++ b/src/ledger/canonical/canonical-runtime.check.ts
@@ -105,6 +105,32 @@ async function makeFieldLedger(prefix: string): Promise<{ dir: string; transacti
   return { dir, transactionId, otherTransactionId };
 }
 
+// The documented empty-store state has no canonical evidence or projection
+// generation yet. Read-only startup and all three public query contracts must
+// treat that state as a valid empty result, while any partial state remains a
+// recovery error.
+{
+  const dir = await mkdtemp(join(tmpdir(), "cathay-canonical-v7-empty-"));
+  try {
+    const writer = openCanonicalDatabase(dir);
+    writer.close();
+    const readable = openCanonicalDatabase(dir, { readOnly: true });
+    readable.close();
+    const query = createCathayCanonicalFinancialQuery(dir);
+    assert.deepEqual(await query.current({ kind: "current" }), {
+      status: "ok", kind: "current", accounts: [], transactions: [], commitSequence: 0,
+    });
+    assert.deepEqual((await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-01-01", knowledgeAt: "0" } })).transactions, []);
+    assert.deepEqual((await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: "00000000-0000-0000-0000-000000000000" } })).entries, []);
+
+    const partial = new DatabaseSync(canonicalSqlitePath(dir));
+    const commitId = Buffer.alloc(16, 0x2a);
+    partial.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, 1, 0, 'cathay/domestic-deposit/v1', 'source_capture')").run(commitId);
+    partial.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /empty|projection|generation|pointer|provenance/i);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
 // These are deliberately isolated red cases: each corrupts a copy of an otherwise
 // valid ledger, so a startup gate cannot be accidentally masked by a prior case.
 {
@@ -227,6 +253,23 @@ for (const [label, corruptField] of [
     corrupt.close();
     assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /field|assertion|projection|origin|generation/i, label);
     await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /field|assertion|projection|origin|generation/i, label);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// User assertion provenance is local user authority, even when the nullable
+// source/run/coordinate columns are all empty. A source-capture commit must
+// never be accepted as the provenance of a user assertion.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-red-user-provenance-route-");
+  try {
+    const corrupt = new DatabaseSync(canonicalSqlitePath(dir));
+    const sourceCommit = (corrupt.prepare("SELECT commit_id FROM canonical_commits WHERE commit_kind = 'source_capture' LIMIT 1").get() as { commit_id: Uint8Array }).commit_id;
+    corrupt.prepare(`UPDATE assertion_provenance SET commit_id = ? WHERE assertion_id = (
+      SELECT user_assertion_id FROM projection_generation_transaction_fields WHERE origin = 'user' LIMIT 1
+    )`).run(Buffer.from(sourceCommit));
+    corrupt.close();
+    assert.throws(() => openCanonicalDatabase(dir, { readOnly: true }), /user|provenance|authority|route|commit/i);
+    await assert.rejects(() => rebuildCathayCanonicalProjection(dir), /user|provenance|authority|route|commit/i);
   } finally { await rm(dir, { recursive: true, force: true }); }
 }
 
@@ -457,6 +500,40 @@ for (const [label, corrupt] of [
     try {
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM projection_generation_provenance WHERE ordinal IS NULL OR event_digest IS NULL").get()?.count, 0);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM projection_generation_provenance WHERE previous_event_id IS NULL").get()?.count, 1);
+    } finally { migrated.close(); }
+    const immutable = new DatabaseSync(canonicalSqlitePath(dir));
+    assert.throws(() => immutable.exec("UPDATE projection_generation_provenance SET event_source = 'routine' WHERE ordinal = 1"), /append-only/i);
+    assert.throws(() => immutable.exec("DELETE FROM projection_generation_provenance WHERE ordinal = 1"), /append-only/i);
+    immutable.close();
+  } finally { await rm(dir, { recursive: true, force: true }); }
+}
+
+// A genuine legacy chain may have lost an early phase row. Migration must
+// reconstruct the complete ordered chain from generation state before the
+// writer-open gate, rather than appending `created` after later phases.
+{
+  const { dir } = await makeFieldLedger("cathay-canonical-v7-chain-migration-missing-phase-");
+  try {
+    const legacy = new DatabaseSync(canonicalSqlitePath(dir));
+    legacy.exec(`PRAGMA foreign_keys = OFF;
+      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
+      DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
+      DELETE FROM projection_generation_provenance WHERE event_kind = 'created';
+      ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy;
+      CREATE TABLE projection_generation_provenance(
+        event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16), generation_id INTEGER NOT NULL,
+        event_kind TEXT NOT NULL, event_source TEXT NOT NULL, commit_id BLOB NOT NULL
+      );
+      INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id)
+        SELECT event_id, generation_id, event_kind, event_source, commit_id FROM projection_generation_provenance_legacy;
+      DROP TABLE projection_generation_provenance_legacy;
+      PRAGMA user_version = 7;`);
+    legacy.close();
+    const writer = openCanonicalDatabase(dir);
+    writer.close();
+    const migrated = openCanonicalDatabase(dir, { readOnly: true });
+    try {
+      assert.deepEqual((migrated.prepare("SELECT event_kind FROM projection_generation_provenance WHERE generation_id = 1 ORDER BY ordinal").all() as Array<{ event_kind: string }>).map((row) => row.event_kind).slice(0, 3), ["created", "validated", "switched"]);
     } finally { migrated.close(); }
   } finally { await rm(dir, { recursive: true, force: true }); }
 }

--- a/src/ledger/canonical/canonical-runtime.ts
+++ b/src/ledger/canonical/canonical-runtime.ts
@@ -1,0 +1,108 @@
+import { DatabaseSync } from "node:sqlite";
+
+export type CanonicalRuntimeOptions = {
+  busyTimeoutMs?: number;
+  maxAttempts?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+};
+
+export type CanonicalRetryObservation = {
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+};
+
+export class CanonicalBusyRetryExhaustedError extends Error {
+  readonly attempts: number;
+  readonly observations: CanonicalRetryObservation[];
+
+  constructor(attempts: number, observations: CanonicalRetryObservation[], cause: unknown) {
+    super(`Canonical writer busy retry exhausted after ${attempts} attempts.`, { cause });
+    this.name = "CanonicalBusyRetryExhaustedError";
+    this.attempts = attempts;
+    this.observations = observations;
+  }
+}
+
+const writerQueues = new Map<string, Promise<void>>();
+
+export function configureCanonicalRuntime(db: DatabaseSync, options: { readOnly?: boolean; busyTimeoutMs?: number } = {}): void {
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(`PRAGMA busy_timeout = ${Math.max(1, Math.floor(options.busyTimeoutMs ?? 30_000))}`);
+  if (!options.readOnly) {
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA synchronous = FULL");
+  }
+}
+
+export function verifyCanonicalRuntime(db: DatabaseSync, options: { readOnly?: boolean } = {}): void {
+  const foreignKeys = Number((db.prepare("PRAGMA foreign_keys").get() as { foreign_keys?: unknown }).foreign_keys ?? 0);
+  if (foreignKeys !== 1) throw new Error("Canonical runtime requires foreign_keys=ON.");
+  const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
+  if (journalMode !== "wal") throw new Error("Canonical runtime requires WAL journal mode.");
+  const busyTimeout = Number((db.prepare("PRAGMA busy_timeout").get() as { timeout?: unknown }).timeout ?? 0);
+  if (!Number.isFinite(busyTimeout) || busyTimeout <= 0) throw new Error("Canonical runtime requires a finite busy timeout.");
+  if (!options.readOnly) {
+    const synchronous = Number((db.prepare("PRAGMA synchronous").get() as { synchronous?: unknown }).synchronous ?? 0);
+    if (synchronous !== 2) throw new Error("Canonical runtime requires FULL synchronous mode.");
+  }
+}
+
+function isBusyError(error: unknown): boolean {
+  return /busy|locked/i.test(error instanceof Error ? error.message : String(error));
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Serialize writer operations per canonical database and retry the whole operation.
+ * The operation is deliberately retried as one unit so BEGIN IMMEDIATE and its
+ * rollback boundary are never split across attempts. */
+export async function withCanonicalWriterQueue<T>(
+  databasePath: string,
+  operation: () => T,
+  options: CanonicalRuntimeOptions = {},
+): Promise<T> {
+  const previous = writerQueues.get(databasePath) ?? Promise.resolve();
+  let release!: () => void;
+  const turn = new Promise<void>((resolve) => { release = resolve; });
+  const queued = previous.then(() => turn);
+  writerQueues.set(databasePath, queued);
+  await previous;
+  const maxAttempts = Math.max(1, Math.floor(options.maxAttempts ?? 3));
+  const initialBackoffMs = Math.max(0, Math.floor(options.initialBackoffMs ?? 5));
+  const maxBackoffMs = Math.max(initialBackoffMs, Math.floor(options.maxBackoffMs ?? 250));
+  const observations: CanonicalRetryObservation[] = [];
+  try {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try { return operation(); }
+      catch (error) {
+        if (!isBusyError(error)) throw error;
+        if (attempt === maxAttempts) throw new CanonicalBusyRetryExhaustedError(attempt, observations, error);
+        const delayMs = Math.min(maxBackoffMs, initialBackoffMs * (2 ** (attempt - 1)));
+        observations.push({ attempt, delayMs, error });
+        await wait(delayMs);
+      }
+    }
+    throw new Error("Canonical writer retry loop terminated unexpectedly.");
+  } finally {
+    release();
+    if (writerQueues.get(databasePath) === queued) writerQueues.delete(databasePath);
+  }
+}
+
+/** Keep a read transaction open for the complete query so all tables observe
+ * one SQLite snapshot before or after an active-generation switch. */
+export function withCanonicalSnapshot<T>(db: DatabaseSync, operation: () => T): T {
+  db.exec("BEGIN");
+  try {
+    const value = operation();
+    db.exec("COMMIT");
+    return value;
+  } catch (error) {
+    try { db.exec("ROLLBACK"); } catch { /* preserve the query failure */ }
+    throw error;
+  }
+}

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -689,6 +689,18 @@ try {
   assert.equal(userCurrent.displayLabelCommitSequence, user.commitSequence);
   await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: null });
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
+  const authorityDb = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    for (const compatibility of ["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+      assert.equal(authorityDb.prepare("SELECT type FROM sqlite_master WHERE name = ?").get(compatibility)?.type, "view", compatibility);
+    }
+    const sharedEventIds = (authorityDb.prepare("SELECT event_id FROM assertion_transitions ORDER BY event_id").all() as Array<Record<string, unknown>>).map((row) => Buffer.from(row.event_id as Uint8Array).toString("hex"));
+    const compatibilityEventIds = (authorityDb.prepare(`SELECT event_id FROM assertion_lifecycle_events
+      UNION SELECT event_id FROM derived_assertion_lifecycle_events
+      UNION SELECT event_id FROM user_assertion_lifecycle_events ORDER BY event_id`).all() as Array<Record<string, unknown>>).map((row) => Buffer.from(row.event_id as Uint8Array).toString("hex"));
+    assert.deepEqual(compatibilityEventIds, sharedEventIds);
+    assert.equal(authorityDb.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count, new Set(sharedEventIds).size);
+  } finally { authorityDb.close(); }
   const userLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
   assert.equal(userLineage.entries[0]?.userAssertions.some((assertion) => assertion.state === "withdrawn"), true);
 
@@ -889,7 +901,7 @@ const v3MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-
 try {
   await commitCathayDomesticDeposit(v3MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
   const v3Seed = new DatabaseSync(canonicalSqlitePath(v3MigrationDir));
-  v3Seed.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes;");
+  v3Seed.exec("DROP VIEW assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes;");
   v3Seed.exec("DELETE FROM schema_migrations WHERE version IN (4, 5); PRAGMA user_version = 3;");
   v3Seed.close();
   const migratedV3 = openCanonicalDatabase(v3MigrationDir);
@@ -903,7 +915,7 @@ try {
   try {
     await commitCathayDomesticDeposit(v3RollbackDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
     const downgrade = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));
-    downgrade.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes; DELETE FROM schema_migrations WHERE version IN (4, 5); PRAGMA user_version = 3; CREATE VIEW capture_scopes AS SELECT 1 AS unusable;");
+    downgrade.exec("DROP VIEW assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes; DELETE FROM schema_migrations WHERE version IN (4, 5); PRAGMA user_version = 3; CREATE VIEW capture_scopes AS SELECT 1 AS unusable;");
     downgrade.close();
     assert.throws(() => openCanonicalDatabase(v3RollbackDir), /capture_scopes|views may not be indexed/);
     const afterFailure = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));
@@ -921,7 +933,7 @@ const populatedV5MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp",
 try {
   await commitCathayDomesticDeposit(populatedV5MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
   const downgrade = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
-  downgrade.exec("DROP TABLE current_transaction_fields; DROP TABLE user_assertion_provenance; DROP TABLE user_assertion_lifecycle_events; DROP TABLE user_assertions; DROP TABLE derived_assertion_lifecycle_events; DROP TABLE derived_assertion_provenance; DROP TABLE derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
+  downgrade.exec("DROP TABLE current_transaction_fields; DROP VIEW user_assertion_provenance; DROP VIEW user_assertion_lifecycle_events; DROP TABLE user_assertions; DROP VIEW derived_assertion_lifecycle_events; DROP VIEW derived_assertion_provenance; DROP TABLE derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
   downgrade.close();
   assert.throws(() => openCanonicalDatabase(populatedV5MigrationDir, { injectMigrationFailure: "v5-v6-after-derived-schema" }), /Injected v5-v6 migration failure/);
   const failedPopulatedV5 = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -3,7 +3,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import {
+  CANONICAL_SCHEMA_VERSION,
   CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+  CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE,
   CATHAY_DOMESTIC_DEPOSIT_PROVENANCE,
   commitCathayDomesticDeposit,
   createCathayCanonicalFinancialQuery,
@@ -49,6 +51,18 @@ try {
     ] as const) {
       assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, expected, table);
     }
+    const commitRow = db.prepare("SELECT commit_id, recorded_at_utc_us FROM canonical_commits").get() as Record<string, unknown>;
+    assert.equal(commitRow.commit_id instanceof Uint8Array, true);
+    assert.equal((commitRow.commit_id as Uint8Array).byteLength, 16);
+    assert.equal(typeof commitRow.recorded_at_utc_us, "number");
+    assert.equal(Number.isInteger(commitRow.recorded_at_utc_us), true);
+    const captureRow = db.prepare("SELECT capture_id, commit_id FROM source_captures").get() as Record<string, unknown>;
+    assert.equal(captureRow.capture_id instanceof Uint8Array, true);
+    assert.equal(captureRow.commit_id instanceof Uint8Array, true);
+    const revisionColumns = db.prepare("PRAGMA table_info(transaction_revisions)").all() as Array<{ name?: string }>;
+    assert.equal(revisionColumns.some((column) => column.name === "balance_coefficient"), false);
+    assert.equal(revisionColumns.some((column) => column.name === "balance_scale"), false);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM current_transactions WHERE commit_id IS NOT NULL").get()?.count, 3);
   } finally {
     db.close();
   }
@@ -59,6 +73,10 @@ try {
   assert.equal(current.transactions[0]?.currency, "TWD");
   assert.equal(current.transactions[0]?.postingStatus, "posted");
   assert.equal(current.transactions[0]?.timeZone, "Asia/Taipei");
+  assert.equal(current.transactions[0]?.timePrecision, "second");
+  assert.equal(current.transactions[0]?.timeOrigin, "source_reported");
+  assert.equal(current.transactions[0]?.utcInstantUtcUs, new Date("2026-07-01T09:00:00+08:00").getTime() * 1000);
+  assert.equal("balance" in (current.transactions[0] ?? {}), false);
   assert.equal(current.transactions[0]?.effectiveOn, "2026-07-01");
   assert.equal(current.transactions[0]?.id, first.transactions[0]?.transactionId);
 
@@ -115,6 +133,61 @@ try {
   await rm(ledgerDir, { recursive: true, force: true });
 }
 
+const blockStart = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.indexOf('{"queryStatus"');
+const blockEnd = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.lastIndexOf("}]}}") + 1;
+const singleResultBlock = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.slice(blockStart, blockEnd);
+for (const [label, rawResponse] of [
+  ["zero result blocks", CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(`[${singleResultBlock}]`, "[]")],
+  ["multiple result blocks", CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(`[${singleResultBlock}]`, `[${singleResultBlock},${singleResultBlock}]`)],
+] as const) {
+  const rejectedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-result-block-"));
+  try {
+    assert.throws(() => commitCathayDomesticDeposit(rejectedDir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse }), /exactly one transfer result/, label);
+    const rejectedDb = openCanonicalDatabase(rejectedDir);
+    try {
+      assert.equal(rejectedDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 0, label);
+      assert.equal(rejectedDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 0, label);
+    } finally { rejectedDb.close(); }
+  } finally { await rm(rejectedDir, { recursive: true, force: true }); }
+}
+
+const emptyDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-empty-"));
+try {
+  const emptyRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(/"count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":\[[\s\S]*?\]\}/, '"count":0,"startDate":"2025-08-17","endDate":"2026-08-17","details":[]}');
+  const empty = await commitCathayDomesticDeposit(emptyDir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: emptyRaw });
+  assert.equal(empty.transactions.length, 0);
+  const emptyDb = openCanonicalDatabase(emptyDir, { readOnly: true });
+  try {
+    assert.equal(emptyDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 1);
+    assert.equal(emptyDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 1);
+    for (const table of ["source_records", "financial_transactions", "transaction_revisions", "source_assertions", "current_transactions"]) {
+      assert.equal(emptyDb.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0, table);
+    }
+  } finally { emptyDb.close(); }
+} finally { await rm(emptyDir, { recursive: true, force: true }); }
+
+const contendedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-writer-"));
+try {
+  await Promise.all([
+    commitCathayDomesticDeposit(contendedDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE),
+    commitCathayDomesticDeposit(contendedDir, { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "2026-08-18T00:00:00+08:00" }),
+  ]);
+  const contendedDb = openCanonicalDatabase(contendedDir, { readOnly: true });
+  try {
+    assert.equal(contendedDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 2);
+    assert.equal(contendedDb.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 3);
+    assert.equal(contendedDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 6);
+  } finally { contendedDb.close(); }
+} finally { await rm(contendedDir, { recursive: true, force: true }); }
+
+const newerSchemaDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-schema-"));
+try {
+  const schemaDb = openCanonicalDatabase(newerSchemaDir);
+  schemaDb.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION + 1}`);
+  schemaDb.close();
+  assert.throws(() => openCanonicalDatabase(newerSchemaDir), /newer than supported/);
+} finally { await rm(newerSchemaDir, { recursive: true, force: true }); }
+
 for (const [label, capture] of [
   ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],
   ["legacy return code", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"returnCode":"0000"', '"returnCode":"000"') }],
@@ -124,6 +197,7 @@ for (const [label, capture] of [
   ["missing sequence", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"sequenceNumber":1,', '') }],
   ["ambiguous direction", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"incomeAmt":null', '"incomeAmt":100') }],
   ["missing date", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"accountDate":"2026-07-01"', '"accountDate":null') }],
+  ["invalid local date time", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"txnDateTime":"2026-07-01T09:00:00"', '"txnDateTime":"2026-02-30T09:00:00"') }],
   ["scope mismatch", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, scope: { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope, endDate: "2026-08-16" } }],
   ["invalid authority", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, authorityRoute: "cathay/domestic-deposit/other" }],
   ["non-exact amount", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"incomeAmt":12500', '"incomeAmt":1.25e4') }],

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -385,6 +385,42 @@ try {
   } finally {
     repeatDb.close();
   }
+  // Force the repeated observation's source-record id to sort before the
+  // immutable revision source-record id. The compatibility view must expose
+  // revision origin, not MIN(provenance.source_record_id).
+  const sourceIdentityRepair = new DatabaseSync(canonicalSqlitePath(ledgerDir));
+  sourceIdentityRepair.exec("PRAGMA foreign_keys = OFF");
+  const identityRows = sourceIdentityRepair.prepare(`SELECT sr.source_record_id
+    FROM source_records sr JOIN source_captures sc ON sc.capture_id = sr.capture_id
+    JOIN canonical_commits c ON c.commit_id = sc.commit_id
+    WHERE sr.sequence_lexeme = '1' ORDER BY c.commit_sequence`).all() as Array<{ source_record_id?: Uint8Array }>;
+  assert.equal(identityRows.length, 2);
+  const firstObservedRecord = identityRows[0]!.source_record_id!;
+  const repeatedObservedRecord = identityRows[1]!.source_record_id!;
+  const immutableRevisionRecord = sourceIdentityRepair.prepare(`SELECT source_record_id FROM transaction_revisions
+    WHERE transaction_id = ?`).get(Buffer.from(first.transactions[0]!.transactionId.replaceAll("-", ""), "hex"))?.source_record_id as Uint8Array;
+  assert.deepEqual(Buffer.from(immutableRevisionRecord), Buffer.from(firstObservedRecord));
+  const lowOccurrence = Buffer.alloc(16, 1);
+  const highRevision = Buffer.alloc(16, 254);
+  for (const table of ["source_records", "transaction_revisions", "transaction_time_observations", "assertion_provenance", "source_record_scopes"]) {
+    sourceIdentityRepair.prepare(`UPDATE ${table} SET source_record_id = ? WHERE source_record_id = ?`).run(highRevision, firstObservedRecord);
+    sourceIdentityRepair.prepare(`UPDATE ${table} SET source_record_id = ? WHERE source_record_id = ?`).run(lowOccurrence, repeatedObservedRecord);
+  }
+  sourceIdentityRepair.close();
+  const sourceIdentityAfter = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    const sourceAssertion = sourceIdentityAfter.prepare("SELECT source_record_id FROM source_assertions WHERE transaction_id = ?").get(Buffer.from(first.transactions[0]!.transactionId.replaceAll("-", ""), "hex")) as { source_record_id?: Uint8Array };
+    assert.deepEqual(Buffer.from(sourceAssertion.source_record_id!), highRevision);
+    const sourceLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: first.transactions[0]!.transactionId } });
+    const sourceEntry = sourceLineage.entries[0]!;
+    assert.deepEqual(Buffer.from(sourceEntry.sourceRecord.id.replaceAll("-", ""), "hex"), highRevision);
+    assert.equal(sourceEntry.provenance.length, 2);
+    const sourceIdText = (id: Uint8Array): string => {
+      const hex = Buffer.from(id).toString("hex");
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    };
+    assert.deepEqual(sourceEntry.provenance.map((item) => item.sourceRecordId).sort(), [lowOccurrence, highRevision].map(sourceIdText).sort());
+  } finally { sourceIdentityAfter.close(); }
   const boundaryQuery = createBoundaryCanonicalQuery(ledgerDir);
   assert.equal((await boundaryQuery.current({ kind: "current" })).commitSequence, repeated.commitSequence);
 
@@ -707,6 +743,17 @@ try {
   const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", fields: ["display_name" as const], scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
   assert.equal(producerDiagnostic.status, "diagnostic");
   const withdrawn = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
+  const unsupportedRetryBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const unsupportedRetryTransitions = unsupportedRetryBefore.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count;
+  const unsupportedRetryProvenance = unsupportedRetryBefore.prepare("SELECT COUNT(*) AS count FROM assertion_provenance WHERE run_id IS NOT NULL").get()?.count;
+  unsupportedRetryBefore.close();
+  const unsupportedRetry = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
+  assert.equal(unsupportedRetry.commitSequence > withdrawn.commitSequence, true);
+  const unsupportedRetryAfter = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(unsupportedRetryAfter.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count, unsupportedRetryTransitions);
+    assert.equal(unsupportedRetryAfter.prepare("SELECT COUNT(*) AS count FROM assertion_provenance WHERE run_id IS NOT NULL").get()?.count, Number(unsupportedRetryProvenance) + 2);
+  } finally { unsupportedRetryAfter.close(); }
   const historicalLineageBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
   const historicalLineageSnapshot = {
     commits: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
@@ -746,10 +793,12 @@ try {
   const derivedKinds = lineage.entries.flatMap((entry) => entry.derivedAssertions.map((assertion) => assertion.state));
   assert.equal(derivedKinds.includes("withdrawn"), true);
   assert.equal(lineage.entries[0]?.derivedAssertions.some((assertion) => assertion.value === "Changed label"), true);
+  assert.equal(lineage.entries[0]?.derivedAssertions.find((assertion) => assertion.value === "Derived note")?.provenance.length, 3);
   const db = openCanonicalDatabase(derivedDir, { readOnly: true });
   try {
-    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4);
-    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, 4);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 5);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, 8);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance provenance JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = provenance.coordinate_id WHERE coordinate.output_state = 'unsupported'").get()?.count, 4);
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'withdrawn'").get()?.count, 2);
   } finally { db.close(); }
 

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -593,8 +593,26 @@ try {
   assert.equal(currentDerived.displayLabelOrigin, "derived");
   assert.equal(currentDerived.note, null);
   assert.equal(currentDerived.displayLabelCommitSequence, firstDerived.commitSequence);
+  const sharedSpineAfterFirst = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(sharedSpineAfterFirst.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'source'").get()?.count, source.transactions.length);
+    assert.equal(sharedSpineAfterFirst.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'derived'").get()?.count, 1);
+    assert.equal(sharedSpineAfterFirst.prepare("SELECT COUNT(*) AS count FROM assertion_transitions WHERE event_kind = 'observed'").get()?.count, source.transactions.length + 1);
+    assert.equal(sharedSpineAfterFirst.prepare("SELECT COUNT(*) AS count FROM assertion_provenance WHERE run_id IS NOT NULL").get()?.count, 1);
+  } finally { sharedSpineAfterFirst.close(); }
 
+  const sharedSpineBeforeUnchanged = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const sharedSpineBeforeUnchangedCounts = {
+    transitions: sharedSpineBeforeUnchanged.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+    provenance: sharedSpineBeforeUnchanged.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+  };
+  sharedSpineBeforeUnchanged.close();
   const unchanged = await commitCathayDerivedImportRun(derivedDir, derivedInput);
+  const sharedSpineAfterUnchanged = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(sharedSpineAfterUnchanged.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count, sharedSpineBeforeUnchangedCounts.transitions);
+    assert.equal(sharedSpineAfterUnchanged.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, Number(sharedSpineBeforeUnchangedCounts.provenance) + 1);
+  } finally { sharedSpineAfterUnchanged.close(); }
   const changed = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Changed label" }, { transactionId, field: "note" as const, state: "supported" as const, value: "Derived note" }] });
   const beforeRuleLineage = openCanonicalDatabase(derivedDir, { readOnly: true });
   const beforeRuleLineageCounts = {
@@ -661,7 +679,6 @@ try {
   try {
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4);
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, 4);
-    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'provenance_only'").get()?.count, 1);
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'withdrawn'").get()?.count, 2);
   } finally { db.close(); }
 
@@ -675,10 +692,29 @@ try {
   const userLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
   assert.equal(userLineage.entries[0]?.userAssertions.some((assertion) => assertion.state === "withdrawn"), true);
 
-  const diagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, complete: false });
+  const emptyScopeBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const emptyScopeSnapshot = {
+    commits: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+    runs: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+    assertions: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM assertions").get()?.count,
+    transitions: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+    provenance: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+    projection: emptyScopeBefore.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+  };
+  emptyScopeBefore.close();
+  const diagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [] });
   assert.equal(diagnostic.status, "diagnostic");
   const diagnosticDb = openCanonicalDatabase(derivedDir, { readOnly: true });
-  try { assert.equal(diagnosticDb.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4); } finally { diagnosticDb.close(); }
+  try {
+    assert.deepEqual({
+      commits: diagnosticDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+      runs: diagnosticDb.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+      assertions: diagnosticDb.prepare("SELECT COUNT(*) AS count FROM assertions").get()?.count,
+      transitions: diagnosticDb.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+      provenance: diagnosticDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+      projection: diagnosticDb.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+    }, emptyScopeSnapshot);
+  } finally { diagnosticDb.close(); }
   await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" }), /transaction targets only/);
   await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, field: "amount", value: "999" } as never), /only display_name or note/);
 } finally { await rm(derivedDir, { recursive: true, force: true }); }
@@ -782,6 +818,8 @@ for (const version of [1, 2] as const) {
       assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
       assert.equal(migrated.prepare("SELECT cursor FROM source_sync_states").get()?.cursor, "legacy-cursor", `v${version} cursor preservation`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_time_observations").get()?.count, 2, `v${version} time lineage`);
+      assert.equal(migrated.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_canonical_commits_sequence'").get()?.["1"], 1, `v${version} commit sequence index`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'source'").get()?.count, 1, `v${version} shared source spine`);
     } finally { migrated.close(); }
 
     const reopened = openCanonicalDatabase(migrationDir);
@@ -879,6 +917,28 @@ try {
   } finally { await rm(v3RollbackDir, { recursive: true, force: true }); }
 } finally { await rm(v3MigrationDir, { recursive: true, force: true }); }
 
+const populatedV5MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-populated-v5-"));
+try {
+  await commitCathayDomesticDeposit(populatedV5MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const downgrade = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
+  downgrade.exec("DROP TABLE current_transaction_fields; DROP TABLE user_assertion_provenance; DROP TABLE user_assertion_lifecycle_events; DROP TABLE user_assertions; DROP TABLE derived_assertion_lifecycle_events; DROP TABLE derived_assertion_provenance; DROP TABLE derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
+  downgrade.close();
+  assert.throws(() => openCanonicalDatabase(populatedV5MigrationDir, { injectMigrationFailure: "v5-v6-after-derived-schema" }), /Injected v5-v6 migration failure/);
+  const failedPopulatedV5 = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
+  try {
+    assert.equal(Number(failedPopulatedV5.prepare("PRAGMA user_version").get()?.user_version), 5);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM current_transactions").get()?.count, 3);
+    assert.equal(failedPopulatedV5.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_canonical_commits_sequence'").get()?.["1"], 1);
+  } finally { failedPopulatedV5.close(); }
+  const retriedPopulatedV5 = openCanonicalDatabase(populatedV5MigrationDir);
+  try {
+    assert.equal(Number(retriedPopulatedV5.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'source'").get()?.count, 3);
+  } finally { retriedPopulatedV5.close(); }
+} finally { await rm(populatedV5MigrationDir, { recursive: true, force: true }); }
+
 const corruptDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-corrupt-"));
 try {
   await commitCathayDomesticDeposit(corruptDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
@@ -897,6 +957,15 @@ try {
   malformedV5.close();
   assert.throws(() => openCanonicalDatabase(malformedV5Dir, { readOnly: true }), /schema v6 index idx_source_record_scopes_scope_sequence is missing/);
 } finally { await rm(malformedV5Dir, { recursive: true, force: true }); }
+
+const malformedV6SpineDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-malformed-v6-spine-"));
+try {
+  await commitCathayDomesticDeposit(malformedV6SpineDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const malformedV6Spine = new DatabaseSync(canonicalSqlitePath(malformedV6SpineDir));
+  malformedV6Spine.exec("DROP INDEX idx_assertions_lineage");
+  malformedV6Spine.close();
+  assert.throws(() => openCanonicalDatabase(malformedV6SpineDir, { readOnly: true }), /schema v6 index idx_assertions_lineage is missing/);
+} finally { await rm(malformedV6SpineDir, { recursive: true, force: true }); }
 
 for (const [label, capture] of [
   ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -202,6 +202,73 @@ function restoreLegacySyncState(db: DatabaseSync): void {
   db.prepare("INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(2), legacyId(6), "domestic-deposit", "2026-07-01", "2026-07-01", "legacy-cursor", legacyId(4), legacyId(1));
 }
 
+function seedLegacyV5Database(directory: string): void {
+  seedLegacyDatabase(directory, 2);
+  const db = new DatabaseSync(canonicalSqlitePath(directory));
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec("ALTER TABLE source_captures ADD COLUMN completeness_basis TEXT NOT NULL DEFAULT 'success-status-scope-count-details' CHECK(completeness_basis = 'success-status-scope-count-details')");
+  db.exec("ALTER TABLE source_captures ADD COLUMN completeness_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1')");
+  db.exec("ALTER TABLE transaction_revisions ADD COLUMN economic_status TEXT NOT NULL DEFAULT 'normal' CHECK(economic_status IN ('normal','canceled','refund','reversal'))");
+  db.exec("ALTER TABLE transaction_revisions ADD COLUMN administrative_state TEXT NOT NULL DEFAULT 'active' CHECK(administrative_state IN ('active','deleted','purged'))");
+  db.exec("ALTER TABLE transaction_revisions ADD COLUMN semantic_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1')");
+  db.exec("ALTER TABLE current_transactions ADD COLUMN projection_commit_id BLOB REFERENCES canonical_commits(commit_id)");
+  db.exec("ALTER TABLE current_transactions ADD COLUMN revision_commit_id BLOB REFERENCES canonical_commits(commit_id)");
+  db.prepare("UPDATE current_transactions SET projection_commit_id = commit_id, revision_commit_id = commit_id").run();
+  db.exec(`CREATE TABLE capture_scopes (
+    scope_id BLOB PRIMARY KEY CHECK(length(scope_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+    source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id),
+    account_id BLOB NOT NULL REFERENCES financial_accounts(account_id), account_no TEXT NOT NULL, stream TEXT NOT NULL,
+    scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, scope_kind TEXT NOT NULL CHECK(scope_kind = 'bounded-range'),
+    completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),
+    completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range')),
+    contract_fingerprint TEXT NOT NULL, preflight_fingerprint TEXT NOT NULL, page_count INTEGER NOT NULL CHECK(page_count > 0),
+    terminal INTEGER NOT NULL CHECK(terminal IN (0, 1)), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+    UNIQUE(scope_id, capture_id), UNIQUE(scope_id, account_id), UNIQUE(capture_id, account_id, scope_start, scope_end)
+  );
+  CREATE TABLE capture_scope_pages (
+    scope_page_id BLOB PRIMARY KEY CHECK(length(scope_page_id) = 16), scope_id BLOB NOT NULL REFERENCES capture_scopes(scope_id),
+    page_ordinal INTEGER NOT NULL CHECK(page_ordinal >= 0), terminal INTEGER NOT NULL CHECK(terminal IN (0, 1)), row_count INTEGER NOT NULL CHECK(row_count >= 0),
+    response_digest TEXT NOT NULL, proof_kind TEXT NOT NULL CHECK(proof_kind = 'success-status-scope-count-details'),
+    contract_fingerprint TEXT NOT NULL, preflight_fingerprint TEXT NOT NULL, commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+    UNIQUE(scope_id, page_ordinal)
+  );
+  CREATE TABLE source_record_scopes (
+    source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), scope_id BLOB NOT NULL CHECK(length(scope_id) = 16),
+    capture_id BLOB NOT NULL CHECK(length(capture_id) = 16) REFERENCES source_captures(capture_id),
+    account_id BLOB NOT NULL CHECK(length(account_id) = 16) REFERENCES financial_accounts(account_id),
+    sequence_lexeme TEXT NOT NULL, commit_id BLOB NOT NULL CHECK(length(commit_id) = 16) REFERENCES canonical_commits(commit_id),
+    FOREIGN KEY(source_record_id, capture_id) REFERENCES source_records(source_record_id, capture_id),
+    FOREIGN KEY(scope_id, capture_id) REFERENCES capture_scopes(scope_id, capture_id),
+    FOREIGN KEY(scope_id, account_id) REFERENCES capture_scopes(scope_id, account_id),
+    UNIQUE(scope_id, sequence_lexeme)
+  );
+  CREATE TABLE assertion_lifecycle_events (
+    event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16), assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id),
+    transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+    capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), scope_id BLOB REFERENCES capture_scopes(scope_id),
+    commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','restored'))
+  );
+  `);
+  db.exec("CREATE UNIQUE INDEX source_records_source_record_capture ON source_records(source_record_id, capture_id)");
+  db.prepare("INSERT INTO capture_scopes(scope_id, capture_id, source_connection_id, identity_epoch_id, account_id, account_no, stream, scope_start, scope_end, scope_kind, completeness, completeness_basis, completeness_rule_version, absence_authority, contract_fingerprint, preflight_fingerprint, page_count, terminal, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(12), legacyId(4), legacyId(2), legacyId(3), legacyId(6), "SYNTHETIC-LEGACY-001", "domestic-deposit", "2026-07-01", "2026-07-01", "bounded-range", "complete-range", "success-status-scope-count-details", "cathay/domestic-deposit/v1", "comparable-complete-range", "legacy-v5-contract", "legacy-v5-preflight", 1, 1, legacyId(1));
+  db.prepare("INSERT INTO capture_scope_pages(scope_page_id, scope_id, page_ordinal, terminal, row_count, response_digest, proof_kind, contract_fingerprint, preflight_fingerprint, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(13), legacyId(12), 0, 1, 1, "legacy-v5-digest", "success-status-scope-count-details", "legacy-v5-contract", "legacy-v5-preflight", legacyId(1));
+  db.prepare("INSERT INTO source_record_scopes(source_record_id, scope_id, capture_id, account_id, sequence_lexeme, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(legacyId(5), legacyId(12), legacyId(4), legacyId(6), "1", legacyId(1));
+  db.prepare("INSERT INTO assertion_lifecycle_events(event_id, assertion_id, transaction_id, revision_id, capture_id, scope_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(14), legacyId(9), legacyId(7), legacyId(8), legacyId(4), legacyId(12), legacyId(1), "observed");
+  db.exec("CREATE INDEX idx_capture_scopes_account_time ON capture_scopes(source_connection_id, identity_epoch_id, account_id, scope_start, scope_end, commit_id)");
+  db.exec("CREATE INDEX idx_capture_scope_pages_proof ON capture_scope_pages(scope_id, page_ordinal, commit_id)");
+  db.exec("CREATE INDEX idx_source_record_scopes_scope_sequence ON source_record_scopes(scope_id, sequence_lexeme, source_record_id)");
+  db.exec("CREATE INDEX idx_source_record_scopes_account_capture ON source_record_scopes(account_id, capture_id, source_record_id)");
+  db.exec("CREATE INDEX idx_assertion_lifecycle_assertion_knowledge ON assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id)");
+  db.exec("CREATE INDEX idx_assertion_lifecycle_transaction_knowledge ON assertion_lifecycle_events(transaction_id, commit_id, event_kind, event_id)");
+  db.exec("CREATE INDEX idx_assertion_lifecycle_scope ON assertion_lifecycle_events(scope_id, commit_id, assertion_id)");
+  db.exec("CREATE INDEX idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
+  db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(3, 1782864000000002);
+  db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(4, 1782864000000003);
+  db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(5, 1782864000000004);
+  db.exec("PRAGMA user_version = 5");
+  db.close();
+}
+
 const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-"));
 try {
   const first = await commitCathayDomesticDeposit(ledgerDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
@@ -585,6 +652,10 @@ try {
     stream: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.stream,
     producerId: "synthetic-enricher-v1",
     ruleLineage: "synthetic-rule-v1",
+    complete: true as const,
+    status: "complete" as const,
+    subjectIds: [transactionId],
+    fields: ["display_name" as const, "note" as const],
     scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Derived label" }, { transactionId, field: "note" as const, state: "unsupported" as const }],
   };
   const firstDerived = await commitCathayDerivedImportRun(derivedDir, derivedInput);
@@ -623,7 +694,7 @@ try {
     current: beforeRuleLineage.prepare("SELECT value_text, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
   };
   beforeRuleLineage.close();
-  const ruleLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ruleLineage: "synthetic-rule-v2", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Rule v2 label" }] });
+  const ruleLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ruleLineage: "synthetic-rule-v2", fields: ["display_name" as const], scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Rule v2 label" }] });
   assert.equal(ruleLineageDiagnostic.status, "diagnostic");
   const afterRuleLineage = openCanonicalDatabase(derivedDir, { readOnly: true });
   try {
@@ -633,7 +704,7 @@ try {
     assert.equal(afterRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, beforeRuleLineageCounts.provenance);
     assert.deepEqual(afterRuleLineage.prepare("SELECT value_text, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")), beforeRuleLineageCounts.current);
   } finally { afterRuleLineage.close(); }
-  const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
+  const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", fields: ["display_name" as const], scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
   assert.equal(producerDiagnostic.status, "diagnostic");
   const withdrawn = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
   const historicalLineageBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
@@ -652,7 +723,7 @@ try {
     { producerId: "other-producer" },
     { origin: "other-origin" },
   ] as const) {
-    const historicalLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ...mismatch, scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Historical mismatch label" }] });
+    const historicalLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ...mismatch, fields: ["display_name" as const], scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Historical mismatch label" }] } as never);
     assert.equal(historicalLineageDiagnostic.status, "diagnostic");
     const historicalLineageAfter = openCanonicalDatabase(derivedDir, { readOnly: true });
     try {
@@ -691,16 +762,19 @@ try {
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
   const authorityDb = openCanonicalDatabase(derivedDir, { readOnly: true });
   try {
-    for (const compatibility of ["derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+    for (const compatibility of ["source_assertions", "derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
       assert.equal(authorityDb.prepare("SELECT type FROM sqlite_master WHERE name = ?").get(compatibility)?.type, "view", compatibility);
     }
     const compatibilityAssertionCounts = {
+      source: authorityDb.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count,
       derived: authorityDb.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
       user: authorityDb.prepare("SELECT COUNT(*) AS count FROM user_assertions").get()?.count,
     };
+    assert.throws(() => authorityDb.exec("UPDATE source_assertions SET commit_id = commit_id"), /cannot modify source_assertions because it is a view/);
     assert.throws(() => authorityDb.exec("UPDATE derived_assertions SET value_text = 'tampered'"), /cannot modify derived_assertions because it is a view/);
     assert.throws(() => authorityDb.exec("UPDATE user_assertions SET value_text = 'tampered'"), /cannot modify user_assertions because it is a view/);
     assert.deepEqual({
+      source: authorityDb.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count,
       derived: authorityDb.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
       user: authorityDb.prepare("SELECT COUNT(*) AS count FROM user_assertions").get()?.count,
     }, compatibilityAssertionCounts);
@@ -718,6 +792,14 @@ try {
   sharedMetadataEdit.close();
   const sharedAuthorityLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
   assert.equal(sharedAuthorityLineage.entries[0]?.derivedAssertions.some((assertion) => assertion.value === "Shared authority label"), true);
+
+  await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: "Origin trigger user", userId: "origin-trigger-user" });
+  const originTriggerDb = new DatabaseSync(canonicalSqlitePath(derivedDir));
+  try {
+    const sourceAssertionId = originTriggerDb.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' LIMIT 1").get()?.assertion_id as Uint8Array;
+    assert.throws(() => originTriggerDb.prepare("UPDATE current_transaction_fields SET origin = 'derived', derived_assertion_id = ?, user_assertion_id = NULL WHERE transaction_id = ? AND field_name = 'display_name'").run(sourceAssertionId, Buffer.from(transactionId.replaceAll("-", ""), "hex")), /origin mismatch/);
+  } finally { originTriggerDb.close(); }
+  await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: null, userId: "origin-trigger-user" });
 
   const malformedTargetBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
   const malformedTargetSnapshot = {
@@ -776,7 +858,49 @@ try {
       projection: diagnosticDb.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
     }, emptyScopeSnapshot);
   } finally { diagnosticDb.close(); }
-  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" }), /valid transaction target/);
+  const validMatrix = derivedInput.scope;
+  const invalidMatrixSnapshotDb = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const invalidMatrixSnapshot = {
+    commits: invalidMatrixSnapshotDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+    runs: invalidMatrixSnapshotDb.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+    assertions: invalidMatrixSnapshotDb.prepare("SELECT COUNT(*) AS count FROM assertions").get()?.count,
+    transitions: invalidMatrixSnapshotDb.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+    provenance: invalidMatrixSnapshotDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+    current: invalidMatrixSnapshotDb.prepare("SELECT transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields ORDER BY transaction_id, field_name").all(),
+    projection: invalidMatrixSnapshotDb.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+  };
+  invalidMatrixSnapshotDb.close();
+  const unknownSubjectId = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+  const invalidMatrixCases = [
+    ["missing subject ids", { ...derivedInput, subjectIds: [], scope: [] }],
+    ["missing fields", { ...derivedInput, fields: [], scope: [] }],
+    ["missing scope", { ...derivedInput, scope: undefined }],
+    ["missing coordinate", { ...derivedInput, fields: ["display_name", "note"], scope: validMatrix.filter((coordinate) => coordinate.field === "display_name") }],
+    ["extra coordinate", { ...derivedInput, fields: ["display_name"], scope: validMatrix }],
+    ["duplicate coordinate", { ...derivedInput, fields: ["display_name"], scope: [validMatrix[0], validMatrix[0]] },],
+    ["unknown subject", { ...derivedInput, subjectIds: [unknownSubjectId], fields: ["display_name"], scope: [{ transactionId: unknownSubjectId, field: "display_name", state: "supported", value: "unknown" }] },],
+    ["failed marker", { ...derivedInput, complete: false }],
+    ["partial status", { ...derivedInput, status: "partial" }],
+    ["failed status", { ...derivedInput, status: "failed" }],
+    ["permissive field alias", { ...derivedInput, fields: ["display_name"], scope: [{ transactionId, field: "displayLabel", state: "supported", value: "alias" }] },],
+  ] as const;
+  for (const [label, invalidInput] of invalidMatrixCases) {
+    const invalidResult = await runCathayDerivedImportRun(derivedDir, invalidInput as never);
+    assert.equal(invalidResult.status, "diagnostic", label);
+    const invalidAfter = openCanonicalDatabase(derivedDir, { readOnly: true });
+    try {
+      assert.deepEqual({
+        commits: invalidAfter.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+        runs: invalidAfter.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+        assertions: invalidAfter.prepare("SELECT COUNT(*) AS count FROM assertions").get()?.count,
+        transitions: invalidAfter.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+        provenance: invalidAfter.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+        current: invalidAfter.prepare("SELECT transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields ORDER BY transaction_id, field_name").all(),
+        projection: invalidAfter.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+      }, invalidMatrixSnapshot, label);
+    } finally { invalidAfter.close(); }
+  }
+  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" } as never), /valid transaction target/);
   await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, field: "amount", value: "999" } as never), /only display_name or note/);
 } finally { await rm(derivedDir, { recursive: true, force: true }); }
 
@@ -910,6 +1034,7 @@ try {
   try {
     assert.equal(Number(afterV1Failure.prepare("PRAGMA user_version").get()?.user_version), 2);
     assert.equal(afterV1Failure.prepare("SELECT 1 FROM schema_migrations WHERE version = 2").get()?.["1"], 1);
+    assert.equal(afterV1Failure.prepare("SELECT 1 FROM sqlite_master WHERE name IN ('assertions', 'assertion_transitions', 'derived_import_runs')").get(), undefined);
     const v2CaptureColumns = afterV1Failure.prepare("PRAGMA table_info(source_captures)").all() as Array<{ name?: string }>;
     assert.equal(v2CaptureColumns.some((column) => column.name === "completeness_basis"), false);
     afterV1Failure.exec("DROP VIEW source_sync_states");
@@ -980,24 +1105,42 @@ try {
 
 const populatedV5MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-populated-v5-"));
 try {
-  await commitCathayDomesticDeposit(populatedV5MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
-  const downgrade = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
-  downgrade.exec("DROP TABLE current_transaction_fields; DROP VIEW user_assertion_provenance; DROP VIEW user_assertion_lifecycle_events; DROP VIEW user_assertions; DROP VIEW derived_assertion_lifecycle_events; DROP VIEW derived_assertion_provenance; DROP VIEW derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
-  downgrade.close();
+  seedLegacyV5Database(populatedV5MigrationDir);
+  const genuineV5 = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
+  try {
+    assert.equal(Number(genuineV5.prepare("PRAGMA user_version").get()?.user_version), 5);
+    assert.equal(genuineV5.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assertions'").get(), undefined);
+    assert.equal(genuineV5.prepare("SELECT type FROM sqlite_master WHERE name = 'source_assertions'").get()?.type, "table");
+    assert.equal(genuineV5.prepare("SELECT type FROM sqlite_master WHERE name = 'assertion_lifecycle_events'").get()?.type, "table");
+  } finally { genuineV5.close(); }
   assert.throws(() => openCanonicalDatabase(populatedV5MigrationDir, { injectMigrationFailure: "v5-v6-after-derived-schema" }), /Injected v5-v6 migration failure/);
   const failedPopulatedV5 = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
   try {
     assert.equal(Number(failedPopulatedV5.prepare("PRAGMA user_version").get()?.user_version), 5);
-    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
-    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM current_transactions").get()?.count, 3);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count, 1);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertion_lifecycle_events").get()?.count, 1);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 1);
+    assert.equal(failedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM current_transactions").get()?.count, 1);
     assert.equal(failedPopulatedV5.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_canonical_commits_sequence'").get()?.["1"], 1);
+    assert.equal(failedPopulatedV5.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'assertions'").get(), undefined);
   } finally { failedPopulatedV5.close(); }
   const retriedPopulatedV5 = openCanonicalDatabase(populatedV5MigrationDir);
   try {
     assert.equal(Number(retriedPopulatedV5.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
-    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
-    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'source'").get()?.count, 3);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'source'").get()?.count, 1);
+    assert.equal(retriedPopulatedV5.prepare("SELECT type FROM sqlite_master WHERE name = 'source_assertions'").get()?.type, "view");
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count, 1);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertion_lifecycle_events").get()?.count, 1);
+    assert.equal(retriedPopulatedV5.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 1);
   } finally { retriedPopulatedV5.close(); }
+  const migratedV5Query = createCathayCanonicalFinancialQuery(populatedV5MigrationDir);
+  assert.equal((await migratedV5Query.current({ kind: "current" })).transactions.length, 1);
+  assert.equal((await migratedV5Query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: "1" } })).transactions.length, 1);
+  assert.equal((await migratedV5Query.lineage({ kind: "lineage", subject: { kind: "transaction", id: "07070707-0707-0707-0707-070707070707" } })).entries.length, 1);
+  const migratedV5ReadOnly = openCanonicalDatabase(populatedV5MigrationDir, { readOnly: true });
+  migratedV5ReadOnly.close();
 } finally { await rm(populatedV5MigrationDir, { recursive: true, force: true }); }
 
 const corruptDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-corrupt-"));

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -1049,7 +1049,7 @@ for (const version of [1, 2] as const) {
     const migrated = openCanonicalDatabase(migrationDir);
     try {
       assert.equal(Number(migrated.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION, `v${version} final version`);
-      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 6, `v${version} migration history`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 7, `v${version} migration history`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} source row`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1, `v${version} revision`);
       assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
@@ -1134,7 +1134,7 @@ try {
   try {
     assert.equal(Number(migratedV3.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
     assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
-    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 3);
+    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 4);
     assert.equal(migratedV3.prepare("SELECT 1 FROM sqlite_master WHERE name = 'capture_scopes'").get()?.["1"], 1);
   } finally { migratedV3.close(); }
   const v3RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v3-rollback-"));

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -807,6 +807,9 @@ try {
   assert.equal(userCurrent.displayLabel, "User label");
   assert.equal(userCurrent.displayLabelOrigin, "user");
   assert.equal(userCurrent.displayLabelCommitSequence, user.commitSequence);
+  const historicalUser = await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(user.commitSequence) } });
+  assert.equal(historicalUser.transactions[0]?.displayLabel, "User label");
+  assert.equal(historicalUser.transactions[0]?.displayLabelOrigin, "user");
   await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: null });
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
   const authorityDb = openCanonicalDatabase(derivedDir, { readOnly: true });

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -596,6 +596,25 @@ try {
 
   const unchanged = await commitCathayDerivedImportRun(derivedDir, derivedInput);
   const changed = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Changed label" }, { transactionId, field: "note" as const, state: "supported" as const, value: "Derived note" }] });
+  const beforeRuleLineage = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const beforeRuleLineageCounts = {
+    commits: beforeRuleLineage.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+    runs: beforeRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+    assertions: beforeRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
+    provenance: beforeRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count,
+    current: beforeRuleLineage.prepare("SELECT value_text, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
+  };
+  beforeRuleLineage.close();
+  const ruleLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ruleLineage: "synthetic-rule-v2", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Rule v2 label" }] });
+  assert.equal(ruleLineageDiagnostic.status, "diagnostic");
+  const afterRuleLineage = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(afterRuleLineage.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, beforeRuleLineageCounts.commits);
+    assert.equal(afterRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, beforeRuleLineageCounts.runs);
+    assert.equal(afterRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count, beforeRuleLineageCounts.assertions);
+    assert.equal(afterRuleLineage.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, beforeRuleLineageCounts.provenance);
+    assert.deepEqual(afterRuleLineage.prepare("SELECT value_text, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")), beforeRuleLineageCounts.current);
+  } finally { afterRuleLineage.close(); }
   const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
   assert.equal(producerDiagnostic.status, "diagnostic");
   const withdrawn = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
@@ -629,6 +648,7 @@ try {
   assert.equal(diagnostic.status, "diagnostic");
   const diagnosticDb = openCanonicalDatabase(derivedDir, { readOnly: true });
   try { assert.equal(diagnosticDb.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4); } finally { diagnosticDb.close(); }
+  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" }), /transaction targets only/);
   await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, field: "amount", value: "999" } as never), /only display_name or note/);
 } finally { await rm(derivedDir, { recursive: true, force: true }); }
 

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -13,6 +13,9 @@ import {
   CATHAY_DOMESTIC_DEPOSIT_PROVENANCE,
   commitCathayDomesticDeposit,
   commitCathayDomesticDepositSync,
+  commitCathayDerivedImportRun,
+  runCathayDerivedImportRun,
+  commitCathayUserAssertion,
   canonicalSqlitePath,
   createCathayCanonicalFinancialQuery,
   openCanonicalDatabase,
@@ -569,6 +572,66 @@ try {
   assert.equal(seeded.transactions.length, 3);
 } finally { await rm(semanticDir, { recursive: true, force: true }); }
 
+// Issue #130: a complete derived run owns an explicit coordinate matrix. Its
+// output lifecycle is independent from Source Assertions and User Assertions.
+const derivedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-derived-v6-"));
+try {
+  const source = await commitCathayDomesticDeposit(derivedDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const transactionId = source.transactions[0]!.transactionId;
+  const derivedInput = {
+    sourceConnectionId: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.sourceConnectionId,
+    identityEpoch: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.identityEpoch,
+    authorityRoute: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.authorityRoute,
+    stream: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.stream,
+    producerId: "synthetic-enricher-v1",
+    ruleLineage: "synthetic-rule-v1",
+    scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Derived label" }, { transactionId, field: "note" as const, state: "unsupported" as const }],
+  };
+  const firstDerived = await commitCathayDerivedImportRun(derivedDir, derivedInput);
+  const currentDerived = (await createCathayCanonicalFinancialQuery(derivedDir).current({ kind: "current" })).transactions[0]!;
+  assert.equal(currentDerived.displayLabel, "Derived label");
+  assert.equal(currentDerived.displayLabelOrigin, "derived");
+  assert.equal(currentDerived.note, null);
+  assert.equal(currentDerived.displayLabelCommitSequence, firstDerived.commitSequence);
+
+  const unchanged = await commitCathayDerivedImportRun(derivedDir, derivedInput);
+  const changed = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Changed label" }, { transactionId, field: "note" as const, state: "supported" as const, value: "Derived note" }] });
+  const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
+  assert.equal(producerDiagnostic.status, "diagnostic");
+  const withdrawn = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
+  const query = createCathayCanonicalFinancialQuery(derivedDir);
+  assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
+  const historicalChanged = await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(changed.commitSequence) } });
+  assert.equal(historicalChanged.transactions[0]?.displayLabel, "Changed label");
+  const lineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
+  const derivedKinds = lineage.entries.flatMap((entry) => entry.derivedAssertions.map((assertion) => assertion.state));
+  assert.equal(derivedKinds.includes("withdrawn"), true);
+  assert.equal(lineage.entries[0]?.derivedAssertions.some((assertion) => assertion.value === "Changed label"), true);
+  const db = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count, 4);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'provenance_only'").get()?.count, 1);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'withdrawn'").get()?.count, 2);
+  } finally { db.close(); }
+
+  const user = await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: "User label" });
+  const userCurrent = (await query.current({ kind: "current" })).transactions[0]!;
+  assert.equal(userCurrent.displayLabel, "User label");
+  assert.equal(userCurrent.displayLabelOrigin, "user");
+  assert.equal(userCurrent.displayLabelCommitSequence, user.commitSequence);
+  await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: null });
+  assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
+  const userLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
+  assert.equal(userLineage.entries[0]?.userAssertions.some((assertion) => assertion.state === "withdrawn"), true);
+
+  const diagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, complete: false });
+  assert.equal(diagnostic.status, "diagnostic");
+  const diagnosticDb = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try { assert.equal(diagnosticDb.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count, 4); } finally { diagnosticDb.close(); }
+  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, field: "amount", value: "999" } as never), /only display_name or note/);
+} finally { await rm(derivedDir, { recursive: true, force: true }); }
+
 const blockStart = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.indexOf('{"queryStatus"');
 const blockEnd = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.lastIndexOf("}]}}") + 1;
 const singleResultBlock = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.slice(blockStart, blockEnd);
@@ -662,7 +725,7 @@ for (const version of [1, 2] as const) {
     const migrated = openCanonicalDatabase(migrationDir);
     try {
       assert.equal(Number(migrated.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION, `v${version} final version`);
-      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 5, `v${version} migration history`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 6, `v${version} migration history`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} source row`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1, `v${version} revision`);
       assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
@@ -744,7 +807,7 @@ try {
   try {
     assert.equal(Number(migratedV3.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
     assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
-    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 2);
+    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 3);
     assert.equal(migratedV3.prepare("SELECT 1 FROM sqlite_master WHERE name = 'capture_scopes'").get()?.["1"], 1);
   } finally { migratedV3.close(); }
   const v3RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v3-rollback-"));
@@ -781,7 +844,7 @@ try {
   const malformedV5 = new DatabaseSync(canonicalSqlitePath(malformedV5Dir));
   malformedV5.exec("DROP INDEX idx_source_record_scopes_scope_sequence");
   malformedV5.close();
-  assert.throws(() => openCanonicalDatabase(malformedV5Dir, { readOnly: true }), /schema v5 index idx_source_record_scopes_scope_sequence is missing/);
+  assert.throws(() => openCanonicalDatabase(malformedV5Dir, { readOnly: true }), /schema v6 index idx_source_record_scopes_scope_sequence is missing/);
 } finally { await rm(malformedV5Dir, { recursive: true, force: true }); }
 
 for (const [label, capture] of [

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -691,9 +691,19 @@ try {
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
   const authorityDb = openCanonicalDatabase(derivedDir, { readOnly: true });
   try {
-    for (const compatibility of ["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+    for (const compatibility of ["derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
       assert.equal(authorityDb.prepare("SELECT type FROM sqlite_master WHERE name = ?").get(compatibility)?.type, "view", compatibility);
     }
+    const compatibilityAssertionCounts = {
+      derived: authorityDb.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
+      user: authorityDb.prepare("SELECT COUNT(*) AS count FROM user_assertions").get()?.count,
+    };
+    assert.throws(() => authorityDb.exec("UPDATE derived_assertions SET value_text = 'tampered'"), /cannot modify derived_assertions because it is a view/);
+    assert.throws(() => authorityDb.exec("UPDATE user_assertions SET value_text = 'tampered'"), /cannot modify user_assertions because it is a view/);
+    assert.deepEqual({
+      derived: authorityDb.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
+      user: authorityDb.prepare("SELECT COUNT(*) AS count FROM user_assertions").get()?.count,
+    }, compatibilityAssertionCounts);
     const sharedEventIds = (authorityDb.prepare("SELECT event_id FROM assertion_transitions ORDER BY event_id").all() as Array<Record<string, unknown>>).map((row) => Buffer.from(row.event_id as Uint8Array).toString("hex"));
     const compatibilityEventIds = (authorityDb.prepare(`SELECT event_id FROM assertion_lifecycle_events
       UNION SELECT event_id FROM derived_assertion_lifecycle_events
@@ -703,6 +713,11 @@ try {
   } finally { authorityDb.close(); }
   const userLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
   assert.equal(userLineage.entries[0]?.userAssertions.some((assertion) => assertion.state === "withdrawn"), true);
+  const sharedMetadataEdit = new DatabaseSync(canonicalSqlitePath(derivedDir));
+  sharedMetadataEdit.prepare("UPDATE assertions SET value_text = ? WHERE origin = 'derived' AND field_name = 'display_name'").run("Shared authority label");
+  sharedMetadataEdit.close();
+  const sharedAuthorityLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
+  assert.equal(sharedAuthorityLineage.entries[0]?.derivedAssertions.some((assertion) => assertion.value === "Shared authority label"), true);
 
   const emptyScopeBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
   const emptyScopeSnapshot = {
@@ -933,7 +948,7 @@ const populatedV5MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp",
 try {
   await commitCathayDomesticDeposit(populatedV5MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
   const downgrade = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));
-  downgrade.exec("DROP TABLE current_transaction_fields; DROP VIEW user_assertion_provenance; DROP VIEW user_assertion_lifecycle_events; DROP TABLE user_assertions; DROP VIEW derived_assertion_lifecycle_events; DROP VIEW derived_assertion_provenance; DROP TABLE derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
+  downgrade.exec("DROP TABLE current_transaction_fields; DROP VIEW user_assertion_provenance; DROP VIEW user_assertion_lifecycle_events; DROP VIEW user_assertions; DROP VIEW derived_assertion_lifecycle_events; DROP VIEW derived_assertion_provenance; DROP VIEW derived_assertions; DROP TABLE derived_scope_coordinates; DROP TABLE derived_import_runs; DELETE FROM schema_migrations WHERE version = 6; PRAGMA user_version = 5;");
   downgrade.close();
   assert.throws(() => openCanonicalDatabase(populatedV5MigrationDir, { injectMigrationFailure: "v5-v6-after-derived-schema" }), /Injected v5-v6 migration failure/);
   const failedPopulatedV5 = new DatabaseSync(canonicalSqlitePath(populatedV5MigrationDir));

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -392,6 +392,24 @@ try {
   } finally { migratedV4.close(); }
 } finally { await rm(populatedV4ScopeMigrationDir, { recursive: true, force: true }); }
 
+const provenanceOnlyV4MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v4-provenance-only-"));
+try {
+  await commitCathayDomesticDepositSync(provenanceOnlyV4MigrationDir, syncInput());
+  await commitCathayDomesticDepositSync(provenanceOnlyV4MigrationDir, { ...syncInput(), observedAt: "2026-08-18T00:00:00+08:00" });
+  const provenanceOnlyV4Seed = openCanonicalDatabase(provenanceOnlyV4MigrationDir);
+  provenanceOnlyV4Seed.exec("DROP TABLE source_record_scopes; DELETE FROM schema_migrations WHERE version = 5; PRAGMA user_version = 4;");
+  provenanceOnlyV4Seed.close();
+  const provenanceOnlyV4Writer = openCanonicalDatabase(provenanceOnlyV4MigrationDir);
+  provenanceOnlyV4Writer.close();
+  const provenanceOnlyV4Migrated = openCanonicalDatabase(provenanceOnlyV4MigrationDir, { readOnly: true });
+  try {
+    assert.equal(provenanceOnlyV4Migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 6);
+    assert.equal(provenanceOnlyV4Migrated.prepare("SELECT COUNT(*) AS count FROM source_record_scopes").get()?.count, 6);
+    assert.equal(provenanceOnlyV4Migrated.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 6);
+    assert.equal(provenanceOnlyV4Migrated.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count, 3);
+  } finally { provenanceOnlyV4Migrated.close(); }
+} finally { await rm(provenanceOnlyV4MigrationDir, { recursive: true, force: true }); }
+
 const tombstoneDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-tombstone-") );
 try {
   assert.throws(() => commitCathayDomesticDepositSync(tombstoneDir, syncInput([{

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -203,6 +203,7 @@ const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canon
 try {
   const first = await commitCathayDomesticDeposit(ledgerDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
   assert.equal(first.transactions.length, 3);
+  assert.equal(first.accountIds.length, 1);
   assert.equal(first.transactions[0]?.direction, "inflow");
   assert.deepEqual(first.transactions[0]?.amount, { coefficient: "12500", scale: 0 });
 
@@ -295,6 +296,8 @@ try {
   assert.equal(lineage.entries[0]?.sourceRecord.captureId, lineage.entries[0]?.capture.id);
   assert.equal(lineage.entries[0]?.capture.authorityRoute, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.authorityRoute);
   assert.equal(lineage.entries[0]?.sourceRecord.description, "Synthetic Cathay deposit description");
+  assert.equal(lineage.entries[0]?.sourceRecord.scopeProof.accountNo, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo);
+  assert.equal(lineage.entries[0]?.sourceRecord.scopeProof.completeness, "complete-range");
 
   const repeated = await commitCathayDomesticDeposit(ledgerDir, {
     ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
@@ -336,6 +339,7 @@ try {
     syncPage(secondAccount, secondRaw),
   ]));
   assert.equal(firstCommit.scopes.length, 2);
+  assert.equal(firstCommit.accountIds.length, 2);
   assert.equal(firstCommit.commitSequence, 1);
   const multiDb = openCanonicalDatabase(multiScopeDir, { readOnly: true });
   try {
@@ -343,6 +347,10 @@ try {
     assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 1);
     assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM capture_scopes").get()?.count, 2);
     assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM capture_scope_pages").get()?.count, 2);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_record_scopes").get()?.count, 6);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_record_scopes WHERE sequence_lexeme IN ('1', '2', '3')").get()?.count, 6);
+    assert.equal(multiDb.prepare("SELECT account_no FROM source_captures").get()?.account_no, null);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_records WHERE sequence_lexeme LIKE '%:%'").get()?.count, 0);
     assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 2);
     assert.equal(multiDb.prepare("SELECT COUNT(DISTINCT commit_id) AS count FROM source_sync_states").get()?.count, 1);
     assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states WHERE cursor IS NOT NULL").get()?.count, 0);
@@ -364,6 +372,50 @@ try {
     assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 12);
   } finally { repeatedDb.close(); }
 } finally { await rm(multiScopeDir, { recursive: true, force: true }); }
+
+const populatedV4ScopeMigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v4-scopes-"));
+try {
+  const secondAccount = "SYNTHETIC-ACCOUNT-002";
+  const secondRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace("SYNTHETIC-ACCOUNT-001", secondAccount);
+  await commitCathayDomesticDepositSync(populatedV4ScopeMigrationDir, syncInput([syncPage(), syncPage(secondAccount, secondRaw)]));
+  const v4Seed = openCanonicalDatabase(populatedV4ScopeMigrationDir);
+  v4Seed.exec("UPDATE source_records SET sequence_lexeme = (SELECT scope.account_no || ':' || source_records.sequence_lexeme FROM source_record_scopes record_scope JOIN capture_scopes scope ON scope.scope_id = record_scope.scope_id WHERE record_scope.source_record_id = source_records.source_record_id); DROP TABLE source_record_scopes; DELETE FROM schema_migrations WHERE version = 5; PRAGMA user_version = 4;");
+  v4Seed.close();
+  const migratedV4Writer = openCanonicalDatabase(populatedV4ScopeMigrationDir);
+  migratedV4Writer.close();
+  const migratedV4 = openCanonicalDatabase(populatedV4ScopeMigrationDir, { readOnly: true });
+  try {
+    assert.equal(Number(migratedV4.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(migratedV4.prepare("SELECT COUNT(*) AS count FROM source_records WHERE sequence_lexeme LIKE '%:%'").get()?.count, 0);
+    assert.equal(migratedV4.prepare("SELECT COUNT(*) AS count FROM source_record_scopes").get()?.count, 6);
+    assert.equal(migratedV4.prepare("SELECT COUNT(DISTINCT sequence_lexeme) AS count FROM source_records").get()?.count, 3);
+  } finally { migratedV4.close(); }
+} finally { await rm(populatedV4ScopeMigrationDir, { recursive: true, force: true }); }
+
+const tombstoneDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-tombstone-") );
+try {
+  assert.throws(() => commitCathayDomesticDepositSync(tombstoneDir, syncInput([{
+    ...syncPage(),
+    absenceAuthority: "tombstone" as never,
+  }])), /tombstone.*unsupported|tombstone.*validated/i);
+  const tombstoneDb = openCanonicalDatabase(tombstoneDir);
+  try { assert.equal(tombstoneDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, 0); } finally { tombstoneDb.close(); }
+} finally { await rm(tombstoneDir, { recursive: true, force: true }); }
+
+const incomparableDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-incomparable-") );
+try {
+  await commitCathayDomesticDepositSync(incomparableDir, syncInput());
+  const emptyRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(/"count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":\[[\s\S]*?\]\}/, '"count":0,"startDate":"2025-08-17","endDate":"2026-08-17","details":[]}');
+  await commitCathayDomesticDepositSync(incomparableDir, {
+    ...syncInput([{
+      ...syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, emptyRaw),
+      preflightFingerprint: "synthetic-non-comparable-preflight-v2",
+    }]),
+    observedAt: "2026-08-19T00:00:00+08:00",
+  });
+  const incomparableQuery = createCathayCanonicalFinancialQuery(incomparableDir);
+  assert.equal((await incomparableQuery.current({ kind: "current" })).transactions.length, 3);
+} finally { await rm(incomparableDir, { recursive: true, force: true }); }
 
 for (const [label, pages, expected] of [
   ["duplicate page ordinal", [{ ...syncPage(), pageOrdinal: 0 }, { ...syncPage(), pageOrdinal: 0 }] as const, /duplicate ordinals/],
@@ -399,6 +451,14 @@ try {
     observedAt: "2026-08-19T00:00:00+08:00",
   });
   assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 3);
+  const restoredProjectionDb = openCanonicalDatabase(lifecycleDir, { readOnly: true });
+  try {
+    const projection = restoredProjectionDb.prepare("SELECT commit_id, projection_commit_id, revision_commit_id FROM current_transactions LIMIT 1").get() as Record<string, unknown>;
+    const projectionState = restoredProjectionDb.prepare("SELECT commit_id FROM current_projection_state WHERE generation = 1").get() as Record<string, unknown>;
+    assert.deepEqual(Buffer.from(projection.commit_id as Uint8Array), Buffer.from(projection.projection_commit_id as Uint8Array));
+    assert.deepEqual(Buffer.from(projection.commit_id as Uint8Array), Buffer.from(projectionState.commit_id as Uint8Array));
+    assert.notDeepEqual(Buffer.from(projection.revision_commit_id as Uint8Array), Buffer.from(projection.projection_commit_id as Uint8Array));
+  } finally { restoredProjectionDb.close(); }
   assert.equal((await withdrawnQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(restored.commitSequence) } })).transactions[0]?.assertionSupportState, "supported");
   const restoredLineage = await withdrawnQuery.lineage({ kind: "lineage", subject: { kind: "transaction", id: first.transactions[0]!.transactionId } });
   const lifecycleKinds = restoredLineage.entries.flatMap((entry) => entry.lifecycleEvents.map((event) => event.kind));
@@ -427,6 +487,37 @@ try {
     assert.equal(changedDb.prepare("SELECT COUNT(*) AS count FROM assertion_lifecycle_events WHERE event_kind = 'superseded'").get()?.count, 1);
   } finally { changedDb.close(); }
 } finally { await rm(lifecycleDir, { recursive: true, force: true }); }
+
+const semanticDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-semantics-") );
+try {
+  const seeded = await commitCathayDomesticDepositSync(semanticDir, syncInput());
+  const semanticDb = openCanonicalDatabase(semanticDir);
+  semanticDb.prepare("UPDATE transaction_revisions SET economic_status = 'refund', administrative_state = 'deleted', semantic_rule_version = ? WHERE revision_number = 1").run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY);
+  semanticDb.close();
+  const semanticQuery = createCathayCanonicalFinancialQuery(semanticDir);
+  const currentSemantic = (await semanticQuery.current({ kind: "current" })).transactions[0]!;
+  assert.equal(currentSemantic.economicStatus, "refund");
+  assert.equal(currentSemantic.administrativeState, "deleted");
+  assert.equal(currentSemantic.assertionSupportState, "supported");
+  const semanticLineage = await semanticQuery.lineage({ kind: "lineage", subject: { kind: "transaction", id: seeded.transactions[0]!.transactionId } });
+  assert.equal(semanticLineage.entries[0]?.revision.economicStatus, "refund");
+  assert.equal(semanticLineage.entries[0]?.revision.administrativeState, "deleted");
+  const emptyRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(/"count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":\[[\s\S]*?\]\}/, '"count":0,"startDate":"2025-08-17","endDate":"2026-08-17","details":[]}');
+  const withdrawnSemantic = await commitCathayDomesticDepositSync(semanticDir, {
+    ...syncInput([syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, emptyRaw)]),
+    observedAt: "2026-08-19T00:00:00+08:00",
+  });
+  const withdrawnSemanticRow = (await semanticQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(withdrawnSemantic.commitSequence) } })).transactions[0]!;
+  assert.equal(withdrawnSemanticRow.assertionSupportState, "withdrawn");
+  assert.equal(withdrawnSemanticRow.economicStatus, "refund");
+  assert.equal(withdrawnSemanticRow.administrativeState, "deleted");
+  await commitCathayDomesticDepositSync(semanticDir, { ...syncInput(), observedAt: "2026-08-20T00:00:00+08:00" });
+  const restoredSemantic = (await semanticQuery.current({ kind: "current" })).transactions[0]!;
+  assert.equal(restoredSemantic.assertionSupportState, "supported");
+  assert.equal(restoredSemantic.economicStatus, "refund");
+  assert.equal(restoredSemantic.administrativeState, "deleted");
+  assert.equal(seeded.transactions.length, 3);
+} finally { await rm(semanticDir, { recursive: true, force: true }); }
 
 const blockStart = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.indexOf('{"queryStatus"');
 const blockEnd = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.lastIndexOf("}]}}") + 1;
@@ -521,7 +612,7 @@ for (const version of [1, 2] as const) {
     const migrated = openCanonicalDatabase(migrationDir);
     try {
       assert.equal(Number(migrated.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION, `v${version} final version`);
-      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 4, `v${version} migration history`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 5, `v${version} migration history`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} source row`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1, `v${version} revision`);
       assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
@@ -596,21 +687,21 @@ const v3MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-
 try {
   await commitCathayDomesticDeposit(v3MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
   const v3Seed = new DatabaseSync(canonicalSqlitePath(v3MigrationDir));
-  v3Seed.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes;");
-  v3Seed.exec("DELETE FROM schema_migrations WHERE version = 4; PRAGMA user_version = 3;");
+  v3Seed.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes;");
+  v3Seed.exec("DELETE FROM schema_migrations WHERE version IN (4, 5); PRAGMA user_version = 3;");
   v3Seed.close();
   const migratedV3 = openCanonicalDatabase(v3MigrationDir);
   try {
     assert.equal(Number(migratedV3.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
     assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
-    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 1);
+    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 2);
     assert.equal(migratedV3.prepare("SELECT 1 FROM sqlite_master WHERE name = 'capture_scopes'").get()?.["1"], 1);
   } finally { migratedV3.close(); }
   const v3RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v3-rollback-"));
   try {
     await commitCathayDomesticDeposit(v3RollbackDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
     const downgrade = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));
-    downgrade.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes; DELETE FROM schema_migrations WHERE version = 4; PRAGMA user_version = 3; CREATE VIEW capture_scopes AS SELECT 1 AS unusable;");
+    downgrade.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE source_record_scopes; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes; DELETE FROM schema_migrations WHERE version IN (4, 5); PRAGMA user_version = 3; CREATE VIEW capture_scopes AS SELECT 1 AS unusable;");
     downgrade.close();
     assert.throws(() => openCanonicalDatabase(v3RollbackDir), /capture_scopes|views may not be indexed/);
     const afterFailure = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -682,7 +682,7 @@ try {
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events WHERE event_kind = 'withdrawn'").get()?.count, 2);
   } finally { db.close(); }
 
-  const user = await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: "User label" });
+  const user = await commitCathayUserAssertion(derivedDir, { transactionId, target: { kind: "transaction", id: transactionId, field: "display_name" }, field: "display_name", value: "User label" });
   const userCurrent = (await query.current({ kind: "current" })).transactions[0]!;
   assert.equal(userCurrent.displayLabel, "User label");
   assert.equal(userCurrent.displayLabelOrigin, "user");
@@ -719,6 +719,40 @@ try {
   const sharedAuthorityLineage = await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } });
   assert.equal(sharedAuthorityLineage.entries[0]?.derivedAssertions.some((assertion) => assertion.value === "Shared authority label"), true);
 
+  const malformedTargetBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const malformedTargetSnapshot = {
+    commits: malformedTargetBefore.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+    userAssertions: malformedTargetBefore.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'user'").get()?.count,
+    transitions: malformedTargetBefore.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+    provenance: malformedTargetBefore.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+    current: malformedTargetBefore.prepare("SELECT value_text, origin, user_assertion_id, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
+    projection: malformedTargetBefore.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+  };
+  malformedTargetBefore.close();
+  const otherTransactionId = source.transactions[1]!.transactionId;
+  for (const [label, target] of [
+    ["string target", "balance"],
+    ["array target", []],
+    ["null target", null],
+    ["missing kind", { id: transactionId, field: "display_name" }],
+    ["forbidden kind", { kind: "balance", id: transactionId, field: "display_name" }],
+    ["missing id", { kind: "transaction", field: "display_name" }],
+    ["conflicting transaction target", { kind: "transaction", id: otherTransactionId, field: "display_name" }],
+  ] as const) {
+    await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, target, field: "display_name", value: "forbidden", userId: "malformed-target-user" } as never), /target|transaction|subject|conflict/i, label);
+    const malformedTargetAfter = openCanonicalDatabase(derivedDir, { readOnly: true });
+    try {
+      assert.deepEqual({
+        commits: malformedTargetAfter.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+        userAssertions: malformedTargetAfter.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'user'").get()?.count,
+        transitions: malformedTargetAfter.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+        provenance: malformedTargetAfter.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count,
+        current: malformedTargetAfter.prepare("SELECT value_text, origin, user_assertion_id, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
+        projection: malformedTargetAfter.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+      }, malformedTargetSnapshot, label);
+    } finally { malformedTargetAfter.close(); }
+  }
+
   const emptyScopeBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
   const emptyScopeSnapshot = {
     commits: emptyScopeBefore.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
@@ -742,7 +776,7 @@ try {
       projection: diagnosticDb.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
     }, emptyScopeSnapshot);
   } finally { diagnosticDb.close(); }
-  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" }), /transaction targets only/);
+  await assert.rejects(() => commitCathayUserAssertion(derivedDir, { target: { kind: "balance", field: "note", id: transactionId }, value: "forbidden" }), /valid transaction target/);
   await assert.rejects(() => commitCathayUserAssertion(derivedDir, { transactionId, field: "amount", value: "999" } as never), /only display_name or note/);
 } finally { await rm(derivedDir, { recursive: true, force: true }); }
 

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -16,6 +16,7 @@ import {
   commitCathayDerivedImportRun,
   runCathayDerivedImportRun,
   commitCathayUserAssertion,
+  rebuildCathayCanonicalProjection,
   canonicalSqlitePath,
   createCathayCanonicalFinancialQuery,
   openCanonicalDatabase,
@@ -810,6 +811,68 @@ try {
   const historicalUser = await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(user.commitSequence) } });
   assert.equal(historicalUser.transactions[0]?.displayLabel, "User label");
   assert.equal(historicalUser.transactions[0]?.displayLabelOrigin, "user");
+  const repeatedDisplayBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const repeatedDisplayCounts = {
+    assertions: repeatedDisplayBefore.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'user'").get()?.count,
+    transitions: repeatedDisplayBefore.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count,
+  };
+  repeatedDisplayBefore.close();
+  const repeatedDisplay = await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: "User label" });
+  const repeatedNoteFirst = await commitCathayUserAssertion(derivedDir, { transactionId, field: "note", value: "User note" });
+  const repeatedNote = await commitCathayUserAssertion(derivedDir, { transactionId, field: "note", value: "User note" });
+  assert.equal(repeatedDisplay.commitSequence > user.commitSequence, true);
+  assert.equal(repeatedNote.commitSequence > repeatedNoteFirst.commitSequence, true);
+  const repeatedUserDb = openCanonicalDatabase(derivedDir, { readOnly: true });
+  try {
+    assert.equal(repeatedUserDb.prepare("SELECT COUNT(*) AS count FROM assertions WHERE origin = 'user'").get()?.count, Number(repeatedDisplayCounts.assertions) + 1);
+    assert.equal(repeatedUserDb.prepare("SELECT COUNT(*) AS count FROM assertion_transitions").get()?.count, Number(repeatedDisplayCounts.transitions) + 1);
+    assert.equal(repeatedUserDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance WHERE commit_id IN (SELECT commit_id FROM canonical_commits WHERE commit_sequence IN (?, ?))").get(repeatedDisplay.commitSequence, repeatedNote.commitSequence)?.count, 2);
+    assert.equal(repeatedUserDb.prepare("SELECT COUNT(*) AS count FROM assertion_transitions WHERE commit_id IN (SELECT commit_id FROM canonical_commits WHERE commit_sequence IN (?, ?))").get(repeatedDisplay.commitSequence, repeatedNote.commitSequence)?.count, 0);
+  } finally { repeatedUserDb.close(); }
+  assert.equal((await query.current({ kind: "current" })).transactions[0]?.note, "User note");
+  assert.equal((await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(repeatedNote.commitSequence) } })).transactions[0]?.note, "User note");
+  assert.equal((await query.lineage({ kind: "lineage", subject: { kind: "transaction", id: transactionId } })).entries.length, 1);
+  assert.equal((await rebuildCathayCanonicalProjection(derivedDir)).status, "switched");
+  const tamperDb = new DatabaseSync(canonicalSqlitePath(derivedDir));
+  const reobservation = tamperDb.prepare(`SELECT provenance.assertion_id, provenance.commit_id
+    FROM assertion_provenance provenance JOIN assertions assertion ON assertion.assertion_id = provenance.assertion_id
+    JOIN canonical_commits commit_row ON commit_row.commit_id = provenance.commit_id
+    WHERE assertion.origin = 'user' AND provenance.source_record_id IS NULL AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL
+      AND NOT EXISTS (SELECT 1 FROM assertion_transitions transition WHERE transition.commit_id = provenance.commit_id)
+      AND assertion.created_commit_id <> provenance.commit_id
+    ORDER BY commit_row.commit_sequence DESC LIMIT 1`).get() as { assertion_id?: Uint8Array; commit_id?: Uint8Array };
+  const sourceAssertionId = Buffer.from((tamperDb.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' LIMIT 1").get() as { assertion_id?: Uint8Array }).assertion_id!);
+  const reobservationAssertionId = Buffer.from(reobservation.assertion_id!);
+  const reobservationCommitId = Buffer.from(reobservation.commit_id!);
+  const originalRoute = (tamperDb.prepare("SELECT authority_route FROM canonical_commits WHERE commit_id = ?").get(reobservationCommitId) as { authority_route?: string }).authority_route!;
+  const originalAssertion = reobservationAssertionId;
+  const assertTamperedRecovery = async (label: string, mutate: () => void, restore: () => void): Promise<void> => {
+    mutate();
+    try {
+      assert.throws(() => openCanonicalDatabase(derivedDir, { readOnly: true }), /provenance|authority|evidence|route|coordinate/i, label);
+      await assert.rejects(() => rebuildCathayCanonicalProjection(derivedDir), /provenance|authority|evidence|route|coordinate/i, label);
+    } finally { restore(); }
+  };
+  await assertTamperedRecovery("provenance-only wrong route", () => {
+    tamperDb.prepare("UPDATE canonical_commits SET authority_route = 'evil/route' WHERE commit_id = ?").run(reobservationCommitId);
+  }, () => {
+    tamperDb.prepare("UPDATE canonical_commits SET authority_route = ? WHERE commit_id = ?").run(originalRoute, reobservationCommitId);
+  });
+  await assertTamperedRecovery("provenance-only wrong assertion", () => {
+    tamperDb.exec("DROP TRIGGER trg_assertion_provenance_integrity_update");
+    tamperDb.prepare("UPDATE assertion_provenance SET assertion_id = ? WHERE assertion_id = ? AND commit_id = ?").run(sourceAssertionId, reobservationAssertionId, reobservationCommitId);
+  }, () => {
+    tamperDb.prepare("UPDATE assertion_provenance SET assertion_id = ? WHERE assertion_id = ? AND commit_id = ?").run(originalAssertion, sourceAssertionId, reobservationCommitId);
+    const repaired = openCanonicalDatabase(derivedDir);
+    repaired.close();
+  });
+  await assertTamperedRecovery("provenance-only orphan commit", () => {
+    const sourceCommit = Buffer.from((tamperDb.prepare("SELECT commit_id FROM source_captures LIMIT 1").get() as { commit_id?: Uint8Array }).commit_id!);
+    tamperDb.prepare("UPDATE assertion_provenance SET commit_id = ? WHERE assertion_id = ? AND commit_id = ?").run(sourceCommit, reobservationAssertionId, reobservationCommitId);
+  }, () => {
+    tamperDb.prepare("UPDATE assertion_provenance SET commit_id = ? WHERE assertion_id = ? AND commit_id = (SELECT commit_id FROM source_captures LIMIT 1)").run(reobservationCommitId, reobservationAssertionId);
+  });
+  tamperDb.close();
   await commitCathayUserAssertion(derivedDir, { transactionId, field: "display_name", value: null });
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
   const authorityDb = openCanonicalDatabase(derivedDir, { readOnly: true });

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -618,6 +618,37 @@ try {
   const producerDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, producerId: "other-producer", scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Other label" }] });
   assert.equal(producerDiagnostic.status, "diagnostic");
   const withdrawn = await commitCathayDerivedImportRun(derivedDir, { ...derivedInput, scope: [{ transactionId, field: "display_name" as const, state: "unsupported" as const }, { transactionId, field: "note" as const, state: "unsupported" as const }] });
+  const historicalLineageBefore = openCanonicalDatabase(derivedDir, { readOnly: true });
+  const historicalLineageSnapshot = {
+    commits: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+    runs: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+    assertions: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
+    provenance: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count,
+    lifecycle: historicalLineageBefore.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events").get()?.count,
+    current: historicalLineageBefore.prepare("SELECT value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
+    projection: historicalLineageBefore.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+  };
+  historicalLineageBefore.close();
+  for (const mismatch of [
+    { ruleLineage: "synthetic-rule-v2" },
+    { producerId: "other-producer" },
+    { origin: "other-origin" },
+  ] as const) {
+    const historicalLineageDiagnostic = await runCathayDerivedImportRun(derivedDir, { ...derivedInput, ...mismatch, scope: [{ transactionId, field: "display_name" as const, state: "supported" as const, value: "Historical mismatch label" }] });
+    assert.equal(historicalLineageDiagnostic.status, "diagnostic");
+    const historicalLineageAfter = openCanonicalDatabase(derivedDir, { readOnly: true });
+    try {
+      assert.deepEqual({
+        commits: historicalLineageAfter.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count,
+        runs: historicalLineageAfter.prepare("SELECT COUNT(*) AS count FROM derived_import_runs").get()?.count,
+        assertions: historicalLineageAfter.prepare("SELECT COUNT(*) AS count FROM derived_assertions").get()?.count,
+        provenance: historicalLineageAfter.prepare("SELECT COUNT(*) AS count FROM derived_assertion_provenance").get()?.count,
+        lifecycle: historicalLineageAfter.prepare("SELECT COUNT(*) AS count FROM derived_assertion_lifecycle_events").get()?.count,
+        current: historicalLineageAfter.prepare("SELECT value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields WHERE transaction_id = ? AND field_name = 'display_name'").get(Buffer.from(transactionId.replaceAll("-", ""), "hex")),
+        projection: historicalLineageAfter.prepare("SELECT generation, commit_id FROM current_projection_state").all(),
+      }, historicalLineageSnapshot);
+    } finally { historicalLineageAfter.close(); }
+  }
   const query = createCathayCanonicalFinancialQuery(derivedDir);
   assert.equal((await query.current({ kind: "current" })).transactions[0]?.displayLabel, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.includes("Synthetic Cathay deposit description") ? "Synthetic Cathay deposit description" : null);
   const historicalChanged = await query.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(changed.commitSequence) } });

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import {
   CANONICAL_SCHEMA_VERSION,
+  CATHAY_POSTING_MAPPING,
   CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
   CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE,
   CATHAY_DOMESTIC_DEPOSIT_PROVENANCE,
   commitCathayDomesticDeposit,
+  canonicalSqlitePath,
   createCathayCanonicalFinancialQuery,
   openCanonicalDatabase,
   parseExactDecimalLexeme,
@@ -56,6 +59,7 @@ try {
     assert.equal((commitRow.commit_id as Uint8Array).byteLength, 16);
     assert.equal(typeof commitRow.recorded_at_utc_us, "number");
     assert.equal(Number.isInteger(commitRow.recorded_at_utc_us), true);
+    assert.equal(db.prepare("SELECT commit_kind FROM canonical_commits").get()?.commit_kind, "source_capture");
     const captureRow = db.prepare("SELECT capture_id, commit_id FROM source_captures").get() as Record<string, unknown>;
     assert.equal(captureRow.capture_id instanceof Uint8Array, true);
     assert.equal(captureRow.commit_id instanceof Uint8Array, true);
@@ -63,6 +67,15 @@ try {
     assert.equal(revisionColumns.some((column) => column.name === "balance_coefficient"), false);
     assert.equal(revisionColumns.some((column) => column.name === "balance_scale"), false);
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM current_transactions WHERE commit_id IS NOT NULL").get()?.count, 3);
+    assert.equal(db.prepare("SELECT COUNT(*) AS count FROM transaction_time_observations").get()?.count, 6);
+    assert.deepEqual((db.prepare("SELECT role, local_value, time_precision, time_origin FROM transaction_time_observations ORDER BY role, local_value LIMIT 2").all() as Array<Record<string, unknown>>).map((row) => ({ ...row })), [
+      { role: "accounting", local_value: "2026-07-01", time_precision: "date", time_origin: "source_reported" },
+      { role: "accounting", local_value: "2026-07-02", time_precision: "date", time_origin: "source_reported" },
+    ]);
+    const indexes = (db.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as Array<{ name?: string }>).map((row) => row.name);
+    for (const index of ["idx_transaction_revisions_financial_time", "idx_transaction_revisions_knowledge_time", "idx_current_transactions_revision", "idx_transaction_revisions_lineage", "idx_assertion_provenance_record"]) {
+      assert.equal(indexes.includes(index), true, index);
+    }
   } finally {
     db.close();
   }
@@ -72,6 +85,11 @@ try {
   assert.equal(current.transactions.length, 3);
   assert.equal(current.transactions[0]?.currency, "TWD");
   assert.equal(current.transactions[0]?.postingStatus, "posted");
+  assert.equal(current.transactions[0]?.postingOrigin, CATHAY_POSTING_MAPPING.origin);
+  assert.equal(current.transactions[0]?.postingBasis, CATHAY_POSTING_MAPPING.basis);
+  assert.equal(current.transactions[0]?.postingRuleVersion, CATHAY_POSTING_MAPPING.ruleVersion);
+  assert.equal(current.transactions[0]?.displayLabel, "Synthetic Cathay deposit description");
+  assert.equal(current.transactions[0]?.effectiveTimeBasis, "accounting");
   assert.equal(current.transactions[0]?.timeZone, "Asia/Taipei");
   assert.equal(current.transactions[0]?.timePrecision, "second");
   assert.equal(current.transactions[0]?.timeOrigin, "source_reported");
@@ -101,6 +119,7 @@ try {
   assert.equal(lineage.entries[0]?.assertion.revisionId, lineage.entries[0]?.revision.id);
   assert.equal(lineage.entries[0]?.sourceRecord.captureId, lineage.entries[0]?.capture.id);
   assert.equal(lineage.entries[0]?.capture.authorityRoute, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.authorityRoute);
+  assert.equal(lineage.entries[0]?.sourceRecord.description, "Synthetic Cathay deposit description");
 
   const repeated = await commitCathayDomesticDeposit(ledgerDir, {
     ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
@@ -160,6 +179,7 @@ try {
   try {
     assert.equal(emptyDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 1);
     assert.equal(emptyDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 1);
+    assert.equal(emptyDb.prepare("SELECT COUNT(*) AS count FROM current_projection_state").get()?.count, 1);
     for (const table of ["source_records", "financial_transactions", "transaction_revisions", "source_assertions", "current_transactions"]) {
       assert.equal(emptyDb.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, 0, table);
     }
@@ -188,6 +208,16 @@ try {
   assert.throws(() => openCanonicalDatabase(newerSchemaDir), /newer than supported/);
 } finally { await rm(newerSchemaDir, { recursive: true, force: true }); }
 
+const corruptDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-corrupt-"));
+try {
+  await commitCathayDomesticDeposit(corruptDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const corruptDb = new DatabaseSync(canonicalSqlitePath(corruptDir));
+  corruptDb.exec("PRAGMA foreign_keys = OFF");
+  corruptDb.prepare("UPDATE current_transactions SET commit_id = ?").run(Buffer.alloc(16, 7));
+  corruptDb.close();
+  assert.throws(() => openCanonicalDatabase(corruptDir, { readOnly: true }), /foreign-key integrity/);
+} finally { await rm(corruptDir, { recursive: true, force: true }); }
+
 for (const [label, capture] of [
   ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],
   ["legacy return code", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"returnCode":"0000"', '"returnCode":"000"') }],
@@ -201,6 +231,9 @@ for (const [label, capture] of [
   ["scope mismatch", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, scope: { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope, endDate: "2026-08-16" } }],
   ["invalid authority", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, authorityRoute: "cathay/domestic-deposit/other" }],
   ["non-exact amount", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"incomeAmt":12500', '"incomeAmt":1.25e4') }],
+  ["unsupported posting fields", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', '"status":"pending","description":"Synthetic Cathay deposit description"') }],
+  ["invalid description type", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', '"description":123') }],
+  ["oversized description", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', `"description":"${"x".repeat(513)}"`) }],
 ] as const) {
   const rejectedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-reject-"));
   try {

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -30,6 +30,148 @@ assert.match(workflowSource, /fetchTransferDetailsRaw/);
 assert.match(workflowSource, /response\.text\(\)/);
 assert.match(workflowSource, /fetchTransferDetailsRaw[\s\S]*JSON\.parse/);
 
+// These fixtures intentionally model the two on-disk shapes that preceded the
+// current schema. Keeping one populated row and its full foreign-key lineage
+// makes migration tests catch accidental target-shape creation and data loss.
+const LEGACY_V1_SCHEMA = `
+CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at_utc_us INTEGER NOT NULL);
+CREATE TABLE canonical_commits (
+  commit_id BLOB PRIMARY KEY CHECK(length(commit_id) = 16), commit_sequence INTEGER NOT NULL UNIQUE,
+  recorded_at_utc_us INTEGER NOT NULL, authority_route TEXT NOT NULL
+);
+CREATE TABLE source_authority_routes (
+  authority_route TEXT PRIMARY KEY, integration_namespace TEXT NOT NULL, stream TEXT NOT NULL,
+  contract_version TEXT NOT NULL, created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+);
+CREATE TABLE source_connections (
+  source_connection_id BLOB PRIMARY KEY CHECK(length(source_connection_id) = 16), integration_namespace TEXT NOT NULL,
+  source_connection_key TEXT NOT NULL, created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(integration_namespace, source_connection_key)
+);
+CREATE TABLE identity_epochs (
+  identity_epoch_id BLOB PRIMARY KEY CHECK(length(identity_epoch_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  epoch_key TEXT NOT NULL, created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(source_connection_id, epoch_key)
+);
+CREATE TABLE source_captures (
+  capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
+  stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
+  completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+);
+CREATE TABLE source_records (
+  source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, payload_json TEXT NOT NULL,
+  UNIQUE(capture_id, sequence_lexeme)
+);
+CREATE TABLE financial_accounts (
+  account_id BLOB PRIMARY KEY CHECK(length(account_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), stream TEXT NOT NULL, account_no TEXT NOT NULL,
+  account_type TEXT NOT NULL CHECK(account_type IN ('depository','credit','loan','investment','other')), currency TEXT NOT NULL,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(source_connection_id, identity_epoch_id, stream, account_no)
+);
+CREATE TABLE financial_transactions (
+  transaction_id BLOB PRIMARY KEY CHECK(length(transaction_id) = 16), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+  source_sequence TEXT NOT NULL, created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(account_id, source_sequence)
+);
+CREATE TABLE transaction_revisions (
+  revision_id BLOB PRIMARY KEY CHECK(length(revision_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), revision_number INTEGER NOT NULL,
+  amount_coefficient TEXT NOT NULL, amount_scale INTEGER NOT NULL CHECK(amount_scale >= 0), currency TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK(direction IN ('inflow','outflow')), posting_status TEXT NOT NULL CHECK(posting_status IN ('pending','posted')),
+  effective_on TEXT NOT NULL, transaction_date_time_local TEXT NOT NULL, time_zone TEXT NOT NULL,
+  time_precision TEXT NOT NULL CHECK(time_precision = 'second'), time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'),
+  utc_instant_utc_us INTEGER NOT NULL, UNIQUE(transaction_id, revision_number)
+);
+CREATE TABLE source_assertions (
+  assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(transaction_id, revision_id)
+);
+CREATE TABLE assertion_provenance (
+  assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), PRIMARY KEY(assertion_id, source_record_id)
+);
+CREATE TABLE source_sync_states (
+  source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+  stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT NOT NULL,
+  last_capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(source_connection_id, account_id, stream)
+);
+CREATE TABLE current_transactions (
+  transaction_id BLOB PRIMARY KEY REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+);
+`;
+
+const legacyId = (value: number): Buffer => Buffer.alloc(16, value);
+
+function seedLegacyDatabase(directory: string, version: 1 | 2): void {
+  const db = new DatabaseSync(canonicalSqlitePath(directory));
+  db.exec("PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;");
+  db.exec(LEGACY_V1_SCHEMA);
+  const commitId = legacyId(1);
+  const route = "cathay/domestic-deposit/v1";
+  const connectionId = legacyId(2);
+  const epochId = legacyId(3);
+  const captureId = legacyId(4);
+  const recordId = legacyId(5);
+  const accountId = legacyId(6);
+  const transactionId = legacyId(7);
+  const revisionId = legacyId(8);
+  const assertionId = legacyId(9);
+  const observedAt = "2026-07-01T00:00:00Z";
+  db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (1, ?)").run(1782864000000000);
+  db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route) VALUES (?, ?, ?, ?)").run(commitId, 1, 1782864000000000, route);
+  db.prepare("INSERT INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(route, "cathay", "domestic-deposit", "v1", commitId);
+  db.prepare("INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_id) VALUES (?, ?, ?, ?)").run(connectionId, "cathay", "synthetic-legacy-connection", commitId);
+  db.prepare("INSERT INTO identity_epochs(identity_epoch_id, source_connection_id, epoch_key, created_commit_id) VALUES (?, ?, ?, ?)").run(epochId, connectionId, "synthetic-legacy-epoch", commitId);
+  db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, connectionId, epochId, route, "domestic-deposit", "SYNTHETIC-LEGACY-001", observedAt, "2026-07-01", "2026-07-01", "complete-range", commitId);
+  db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, payload_json) VALUES (?, ?, ?, ?, ?)").run(recordId, captureId, commitId, "1", '{"synthetic":true}');
+  db.prepare("INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(accountId, connectionId, epochId, "domestic-deposit", "SYNTHETIC-LEGACY-001", "depository", "TWD", commitId);
+  db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, "1", commitId);
+  db.prepare("INSERT INTO transaction_revisions(revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency, direction, posting_status, effective_on, transaction_date_time_local, time_zone, time_precision, time_origin, utc_instant_utc_us) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(revisionId, transactionId, recordId, captureId, commitId, 1, "12500", 0, "TWD", "inflow", "posted", "2026-07-01", "2026-07-01T09:00:00", "Asia/Taipei", "second", "source_reported", 1782867600000000);
+  db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, recordId, commitId);
+  db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, commit_id) VALUES (?, ?, ?)").run(assertionId, recordId, commitId);
+  db.prepare("INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(connectionId, accountId, "domestic-deposit", "2026-07-01", "2026-07-01", "legacy-cursor", captureId, commitId);
+  db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?)").run(transactionId, revisionId, commitId);
+  if (version === 2) {
+    db.exec("ALTER TABLE canonical_commits ADD COLUMN commit_kind TEXT NOT NULL DEFAULT 'source_capture' CHECK(commit_kind = 'source_capture')");
+    db.exec("ALTER TABLE source_records ADD COLUMN description TEXT");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_origin TEXT NOT NULL DEFAULT 'provider_booked_history' CHECK(posting_origin = 'provider_booked_history')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_basis TEXT NOT NULL DEFAULT 'query-status-success-with-accounting-date' CHECK(posting_basis = 'query-status-success-with-accounting-date')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(posting_rule_version = 'cathay/domestic-deposit/v1')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN description TEXT");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_basis TEXT NOT NULL DEFAULT 'accounting' CHECK(effective_time_basis = 'accounting')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(effective_time_rule_version = 'cathay/domestic-deposit/v1')");
+    db.exec(`CREATE TABLE transaction_time_observations (
+      observation_id BLOB PRIMARY KEY CHECK(length(observation_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+      revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+      commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), role TEXT NOT NULL CHECK(role IN ('accounting','occurred')),
+      local_value TEXT NOT NULL, time_zone TEXT NOT NULL CHECK(time_zone = 'Asia/Taipei'), time_precision TEXT NOT NULL CHECK(time_precision IN ('date','second')),
+      time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'), utc_instant_utc_us INTEGER NOT NULL, UNIQUE(revision_id, role)
+    )`);
+    db.exec("CREATE TABLE current_projection_state (generation INTEGER PRIMARY KEY CHECK(generation = 1), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id))");
+    db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?)").run(commitId);
+    db.prepare("INSERT INTO transaction_time_observations(observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(10), transactionId, revisionId, recordId, commitId, "accounting", "2026-07-01", "Asia/Taipei", "date", "source_reported", 1782835200000000);
+    db.prepare("INSERT INTO transaction_time_observations(observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(11), transactionId, revisionId, recordId, commitId, "occurred", "2026-07-01T09:00:00", "Asia/Taipei", "second", "source_reported", 1782867600000000);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (2, ?)").run(1782864000000001);
+  }
+  db.exec(`PRAGMA user_version = ${version}`);
+  db.close();
+}
+
+function restoreLegacySyncState(db: DatabaseSync): void {
+  db.exec(`CREATE TABLE source_sync_states (
+    source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+    stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT NOT NULL,
+    last_capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+    PRIMARY KEY(source_connection_id, account_id, stream)
+  )`);
+  db.prepare("INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(legacyId(2), legacyId(6), "domestic-deposit", "2026-07-01", "2026-07-01", "legacy-cursor", legacyId(4), legacyId(1));
+}
+
 const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-"));
 try {
   const first = await commitCathayDomesticDeposit(ledgerDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
@@ -243,6 +385,84 @@ try {
   schemaDb.close();
   assert.throws(() => openCanonicalDatabase(newerSchemaDir), /newer than supported/);
 } finally { await rm(newerSchemaDir, { recursive: true, force: true }); }
+
+for (const version of [1, 2] as const) {
+  const migrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", `cathay-canonical-migration-v${version}-`));
+  try {
+    seedLegacyDatabase(migrationDir, version);
+    const migrated = openCanonicalDatabase(migrationDir);
+    try {
+      assert.equal(Number(migrated.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION, `v${version} final version`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 3, `v${version} migration history`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} source row`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1, `v${version} revision`);
+      assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
+      assert.equal(migrated.prepare("SELECT cursor FROM source_sync_states").get()?.cursor, "legacy-cursor", `v${version} cursor preservation`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_time_observations").get()?.count, 2, `v${version} time lineage`);
+    } finally { migrated.close(); }
+
+    const reopened = openCanonicalDatabase(migrationDir);
+    try {
+      assert.equal(reopened.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} repeated reopen`);
+    } finally { reopened.close(); }
+    const migratedQuery = createCathayCanonicalFinancialQuery(migrationDir);
+    assert.equal((await migratedQuery.current({ kind: "current" })).transactions.length, 1, `v${version} current query`);
+    assert.equal((await migratedQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: "1" } })).transactions.length, 1, `v${version} historical query`);
+    const migratedLineage = await migratedQuery.lineage({ kind: "lineage", subject: { kind: "transaction", id: "07070707-0707-0707-0707-070707070707" } });
+    assert.equal(migratedLineage.entries.length, 1, `v${version} lineage query`);
+  } finally { await rm(migrationDir, { recursive: true, force: true }); }
+}
+
+// A v1 migration must commit its exact v2 shape before v2->v3 begins. A
+// deliberately broken sync relation forces the second migration to roll back;
+// the v2 metadata and columns must remain, and a repaired relation must retry.
+const v1RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v1-rollback-"));
+try {
+  seedLegacyDatabase(v1RollbackDir, 1);
+  const brokenV1 = new DatabaseSync(canonicalSqlitePath(v1RollbackDir));
+  brokenV1.exec("DROP TABLE source_sync_states");
+  brokenV1.exec("CREATE VIEW source_sync_states AS SELECT 1 AS unusable");
+  brokenV1.close();
+  assert.throws(() => openCanonicalDatabase(v1RollbackDir), /source_sync_states/);
+  const afterV1Failure = new DatabaseSync(canonicalSqlitePath(v1RollbackDir));
+  try {
+    assert.equal(Number(afterV1Failure.prepare("PRAGMA user_version").get()?.user_version), 2);
+    assert.equal(afterV1Failure.prepare("SELECT 1 FROM schema_migrations WHERE version = 2").get()?.["1"], 1);
+    const v2CaptureColumns = afterV1Failure.prepare("PRAGMA table_info(source_captures)").all() as Array<{ name?: string }>;
+    assert.equal(v2CaptureColumns.some((column) => column.name === "completeness_basis"), false);
+    afterV1Failure.exec("DROP VIEW source_sync_states");
+    restoreLegacySyncState(afterV1Failure);
+  } finally { afterV1Failure.close(); }
+  const retriedV1 = openCanonicalDatabase(v1RollbackDir);
+  try {
+    assert.equal(Number(retriedV1.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(retriedV1.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1);
+  } finally { retriedV1.close(); }
+} finally { await rm(v1RollbackDir, { recursive: true, force: true }); }
+
+// The same atomicity guarantee applies when starting from an already committed
+// v2 database: a failed v2->v3 attempt leaves v2 intact and retryable.
+const v2RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v2-rollback-"));
+try {
+  seedLegacyDatabase(v2RollbackDir, 2);
+  const brokenV2 = new DatabaseSync(canonicalSqlitePath(v2RollbackDir));
+  brokenV2.exec("DROP TABLE source_sync_states");
+  brokenV2.close();
+  assert.throws(() => openCanonicalDatabase(v2RollbackDir), /source_sync_states/);
+  const afterV2Failure = new DatabaseSync(canonicalSqlitePath(v2RollbackDir));
+  try {
+    assert.equal(Number(afterV2Failure.prepare("PRAGMA user_version").get()?.user_version), 2);
+    assert.equal(afterV2Failure.prepare("SELECT 1 FROM schema_migrations WHERE version = 2").get()?.["1"], 1);
+    const v2CaptureColumns = afterV2Failure.prepare("PRAGMA table_info(source_captures)").all() as Array<{ name?: string }>;
+    assert.equal(v2CaptureColumns.some((column) => column.name === "completeness_basis"), false);
+    restoreLegacySyncState(afterV2Failure);
+  } finally { afterV2Failure.close(); }
+  const retriedV2 = openCanonicalDatabase(v2RollbackDir);
+  try {
+    assert.equal(Number(retriedV2.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(retriedV2.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1);
+  } finally { retriedV2.close(); }
+} finally { await rm(v2RollbackDir, { recursive: true, force: true }); }
 
 const corruptDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-corrupt-"));
 try {

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import {
+  CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+  CATHAY_DOMESTIC_DEPOSIT_PROVENANCE,
+  commitCathayDomesticDeposit,
+  createCathayCanonicalFinancialQuery,
+  openCanonicalDatabase,
+  parseExactDecimalLexeme,
+} from "./cathay-domestic-deposit.ts";
+import { createCathayCanonicalFinancialQuery as createBoundaryCanonicalQuery } from "../../lib/shared-ledger/server/financial-query.ts";
+
+assert.deepEqual(parseExactDecimalLexeme("123.4500"), {
+  coefficient: 1234500n,
+  scale: 4,
+});
+assert.throws(() => parseExactDecimalLexeme("1e3"), /exact decimal/);
+assert.equal(CATHAY_DOMESTIC_DEPOSIT_PROVENANCE.values, "synthetic");
+assert.equal(CATHAY_DOMESTIC_DEPOSIT_PROVENANCE.liveResponseRetained, false);
+
+const workflowSource = readFileSync(new URL("../../workflows/cathay-statements.ts", import.meta.url), "utf8");
+assert.match(workflowSource, /fetchTransferDetailsRaw/);
+assert.match(workflowSource, /response\.text\(\)/);
+assert.match(workflowSource, /fetchTransferDetailsRaw[\s\S]*JSON\.parse/);
+
+const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-"));
+try {
+  const first = await commitCathayDomesticDeposit(ledgerDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  assert.equal(first.transactions.length, 3);
+  assert.equal(first.transactions[0]?.direction, "inflow");
+  assert.deepEqual(first.transactions[0]?.amount, { coefficient: "12500", scale: 0 });
+
+  const db = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    for (const [table, expected] of [
+      ["canonical_commits", 1],
+      ["source_connections", 1],
+      ["identity_epochs", 1],
+      ["source_captures", 1],
+      ["source_records", 3],
+      ["financial_accounts", 1],
+      ["financial_transactions", 3],
+      ["transaction_revisions", 3],
+      ["source_assertions", 3],
+      ["source_sync_states", 1],
+      ["current_transactions", 3],
+    ] as const) {
+      assert.equal(db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get()?.count, expected, table);
+    }
+  } finally {
+    db.close();
+  }
+
+  const query = createCathayCanonicalFinancialQuery(ledgerDir);
+  const current = await query.current({ kind: "current" });
+  assert.equal(current.transactions.length, 3);
+  assert.equal(current.transactions[0]?.currency, "TWD");
+  assert.equal(current.transactions[0]?.postingStatus, "posted");
+  assert.equal(current.transactions[0]?.timeZone, "Asia/Taipei");
+  assert.equal(current.transactions[0]?.effectiveOn, "2026-07-01");
+  assert.equal(current.transactions[0]?.id, first.transactions[0]?.transactionId);
+
+  const historicalBeforeCommit = await query.historical({
+    kind: "historical",
+    cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(first.commitSequence - 1) },
+  });
+  assert.equal(historicalBeforeCommit.transactions.length, 0);
+  const historical = await query.historical({
+    kind: "historical",
+    cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(first.commitSequence) },
+  });
+  assert.equal(historical.transactions.length, 3);
+  assert.equal(historical.transactions[0]?.id, current.transactions[0]?.id);
+
+  const lineage = await query.lineage({
+    kind: "lineage",
+    subject: { kind: "transaction", id: current.transactions[0]!.id },
+  });
+  assert.equal(lineage.entries.length, 1);
+  assert.equal(lineage.entries[0]?.revision.transactionId, current.transactions[0]?.id);
+  assert.equal(lineage.entries[0]?.assertion.revisionId, lineage.entries[0]?.revision.id);
+  assert.equal(lineage.entries[0]?.sourceRecord.captureId, lineage.entries[0]?.capture.id);
+  assert.equal(lineage.entries[0]?.capture.authorityRoute, CATHAY_DOMESTIC_DEPOSIT_FIXTURE.authorityRoute);
+
+  const repeated = await commitCathayDomesticDeposit(ledgerDir, {
+    ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+    observedAt: "2026-08-18T00:00:00+08:00",
+  });
+  assert.equal(repeated.transactions.filter((transaction) => transaction.revisionCreated).length, 0);
+  const repeatDb = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 2);
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 6);
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM financial_transactions").get()?.count, 3);
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 3);
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM source_assertions").get()?.count, 3);
+    assert.equal(repeatDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 6);
+  } finally {
+    repeatDb.close();
+  }
+
+  const boundaryQuery = createBoundaryCanonicalQuery(ledgerDir);
+  assert.equal((await boundaryQuery.current({ kind: "current" })).transactions.length, 3);
+  assert.equal((await boundaryQuery.historical({
+    kind: "historical",
+    cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(repeated.commitSequence) },
+  })).transactions.length, 3);
+  assert.equal((await boundaryQuery.lineage({
+    kind: "lineage",
+    subject: { kind: "transaction", id: first.transactions[0]!.transactionId },
+  })).entries.length, 1);
+} finally {
+  await rm(ledgerDir, { recursive: true, force: true });
+}
+
+for (const [label, capture] of [
+  ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],
+  ["count mismatch", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"count":3', '"count":2') }],
+  ["query failure", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"queryStatus":"Success"', '"queryStatus":"Failed"') }],
+  ["duplicate sequence", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"sequenceNumber":2', '"sequenceNumber":1') }],
+  ["missing sequence", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"sequenceNumber":1,', '') }],
+  ["ambiguous direction", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"incomeAmt":null', '"incomeAmt":100') }],
+  ["missing date", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"accountDate":"2026-07-01"', '"accountDate":null') }],
+  ["scope mismatch", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, scope: { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope, endDate: "2026-08-16" } }],
+  ["invalid authority", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, authorityRoute: "cathay/domestic-deposit/other" }],
+  ["non-exact amount", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"incomeAmt":12500', '"incomeAmt":1.25e4') }],
+] as const) {
+  const rejectedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-reject-"));
+  try {
+    assert.throws(() => commitCathayDomesticDeposit(rejectedDir, capture), /./, label);
+    const rejectedDb = openCanonicalDatabase(rejectedDir);
+    try {
+      assert.equal(rejectedDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 0, label);
+      assert.equal(rejectedDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 0, label);
+    } finally {
+      rejectedDb.close();
+    }
+  } finally {
+    await rm(rejectedDir, { recursive: true, force: true });
+  }
+}

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -315,8 +315,9 @@ try {
   } finally {
     repeatDb.close();
   }
-
   const boundaryQuery = createBoundaryCanonicalQuery(ledgerDir);
+  assert.equal((await boundaryQuery.current({ kind: "current" })).commitSequence, repeated.commitSequence);
+
   assert.equal((await boundaryQuery.current({ kind: "current" })).transactions.length, 3);
   assert.equal((await boundaryQuery.historical({
     kind: "historical",
@@ -410,6 +411,34 @@ try {
   } finally { provenanceOnlyV4Migrated.close(); }
 } finally { await rm(provenanceOnlyV4MigrationDir, { recursive: true, force: true }); }
 
+const restorationV4MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v4-restoration-"));
+try {
+  await commitCathayDomesticDepositSync(restorationV4MigrationDir, syncInput());
+  const emptyRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(/"count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":\[[\s\S]*?\]\}/, '"count":0,"startDate":"2025-08-17","endDate":"2026-08-17","details":[]}');
+  await commitCathayDomesticDepositSync(restorationV4MigrationDir, { ...syncInput([syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, emptyRaw)]), observedAt: "2026-08-18T00:00:00+08:00" });
+  const restoration = await commitCathayDomesticDepositSync(restorationV4MigrationDir, { ...syncInput(), observedAt: "2026-08-19T00:00:00+08:00" });
+  const restorationV4Seed = openCanonicalDatabase(restorationV4MigrationDir);
+  restorationV4Seed.exec("UPDATE current_transactions SET commit_id = revision_commit_id; DROP TABLE source_record_scopes; DELETE FROM schema_migrations WHERE version = 5; PRAGMA user_version = 4;");
+  restorationV4Seed.close();
+  assert.throws(() => openCanonicalDatabase(restorationV4MigrationDir, { injectMigrationFailure: "v4-v5-after-record-copy" }), /Injected v4-v5 migration failure/);
+  const failedV4 = new DatabaseSync(canonicalSqlitePath(restorationV4MigrationDir));
+  try {
+    assert.equal(Number(failedV4.prepare("PRAGMA user_version").get()?.user_version), 4);
+    assert.equal(failedV4.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 6);
+    assert.equal(failedV4.prepare("SELECT 1 FROM sqlite_master WHERE name = 'source_record_scopes'").get(), undefined);
+  } finally { failedV4.close(); }
+  const restoredMigrationWriter = openCanonicalDatabase(restorationV4MigrationDir);
+  restoredMigrationWriter.close();
+  const restoredMigrationDb = openCanonicalDatabase(restorationV4MigrationDir, { readOnly: true });
+  try {
+    const migratedProjection = restoredMigrationDb.prepare("SELECT commit_id, projection_commit_id, revision_commit_id FROM current_transactions LIMIT 1").get() as Record<string, unknown>;
+    const migratedState = restoredMigrationDb.prepare("SELECT commit_id FROM current_projection_state WHERE generation = 1").get() as Record<string, unknown>;
+    assert.deepEqual(Buffer.from(migratedProjection.projection_commit_id as Uint8Array), Buffer.from(migratedState.commit_id as Uint8Array));
+    assert.notDeepEqual(Buffer.from(migratedProjection.revision_commit_id as Uint8Array), Buffer.from(migratedProjection.projection_commit_id as Uint8Array));
+    assert.equal(restoration.commitSequence, 3);
+  } finally { restoredMigrationDb.close(); }
+} finally { await rm(restorationV4MigrationDir, { recursive: true, force: true }); }
+
 const tombstoneDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-tombstone-") );
 try {
   assert.throws(() => commitCathayDomesticDepositSync(tombstoneDir, syncInput([{
@@ -460,7 +489,9 @@ try {
     observedAt: "2026-08-18T00:00:00+08:00",
   });
   const withdrawnQuery = createCathayCanonicalFinancialQuery(lifecycleDir);
-  assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 0);
+  const withdrawnCurrent = await withdrawnQuery.current({ kind: "current" });
+  assert.equal(withdrawnCurrent.transactions.length, 0);
+  assert.equal(withdrawnCurrent.commitSequence, withdrawn.commitSequence);
   const historicalWithdrawn = await withdrawnQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(withdrawn.commitSequence) } });
   assert.equal(historicalWithdrawn.transactions.length, 3);
   assert.equal(historicalWithdrawn.transactions[0]?.assertionSupportState, "withdrawn");
@@ -469,6 +500,7 @@ try {
     observedAt: "2026-08-19T00:00:00+08:00",
   });
   assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 3);
+  assert.equal((await withdrawnQuery.current({ kind: "current" })).commitSequence, restored.commitSequence);
   const restoredProjectionDb = openCanonicalDatabase(lifecycleDir, { readOnly: true });
   try {
     const projection = restoredProjectionDb.prepare("SELECT commit_id, projection_commit_id, revision_commit_id FROM current_transactions LIMIT 1").get() as Record<string, unknown>;
@@ -742,6 +774,15 @@ try {
   corruptDb.close();
   assert.throws(() => openCanonicalDatabase(corruptDir, { readOnly: true }), /foreign-key integrity/);
 } finally { await rm(corruptDir, { recursive: true, force: true }); }
+
+const malformedV5Dir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-malformed-v5-"));
+try {
+  await commitCathayDomesticDeposit(malformedV5Dir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const malformedV5 = new DatabaseSync(canonicalSqlitePath(malformedV5Dir));
+  malformedV5.exec("DROP INDEX idx_source_record_scopes_scope_sequence");
+  malformedV5.close();
+  assert.throws(() => openCanonicalDatabase(malformedV5Dir, { readOnly: true }), /schema v5 index idx_source_record_scopes_scope_sequence is missing/);
+} finally { await rm(malformedV5Dir, { recursive: true, force: true }); }
 
 for (const [label, capture] of [
   ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -5,17 +5,44 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import {
   CANONICAL_SCHEMA_VERSION,
+  CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  CATHAY_DOMESTIC_DEPOSIT_STREAM,
   CATHAY_POSTING_MAPPING,
   CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
   CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE,
   CATHAY_DOMESTIC_DEPOSIT_PROVENANCE,
   commitCathayDomesticDeposit,
+  commitCathayDomesticDepositSync,
   canonicalSqlitePath,
   createCathayCanonicalFinancialQuery,
   openCanonicalDatabase,
   parseExactDecimalLexeme,
+  type CathayStagedCapturePage,
 } from "./cathay-domestic-deposit.ts";
 import { createCathayCanonicalFinancialQuery as createBoundaryCanonicalQuery } from "../../lib/shared-ledger/server/financial-query.ts";
+
+const syncPage = (accountNo = CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, rawResponse = CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse): CathayStagedCapturePage => ({
+  accountNo,
+  currency: "TWD" as const,
+  scope: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope,
+  pageOrdinal: 0,
+  requestPageToken: null,
+  nextPageToken: null,
+  rawResponse,
+  contractFingerprint: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  preflightFingerprint: "synthetic-preflight-v1",
+  absenceAuthority: "comparable-complete-range" as const,
+});
+
+const syncInput = (pages = [syncPage()]) => ({
+  sourceConnectionId: "synthetic-sync-connection",
+  identityEpoch: "synthetic-sync-epoch",
+  authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
+  observedAt: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.observedAt,
+  syncState: { cursor: null },
+  pages,
+});
 
 assert.deepEqual(parseExactDecimalLexeme("123.4500"), {
   coefficient: 1234500n,
@@ -300,6 +327,107 @@ try {
   await rm(ledgerDir, { recursive: true, force: true });
 }
 
+const multiScopeDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-sync-scopes-"));
+try {
+  const secondAccount = "SYNTHETIC-ACCOUNT-002";
+  const secondRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace("SYNTHETIC-ACCOUNT-001", secondAccount);
+  const firstCommit = await commitCathayDomesticDepositSync(multiScopeDir, syncInput([
+    syncPage(),
+    syncPage(secondAccount, secondRaw),
+  ]));
+  assert.equal(firstCommit.scopes.length, 2);
+  assert.equal(firstCommit.commitSequence, 1);
+  const multiDb = openCanonicalDatabase(multiScopeDir, { readOnly: true });
+  try {
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, 1);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 1);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM capture_scopes").get()?.count, 2);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM capture_scope_pages").get()?.count, 2);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 2);
+    assert.equal(multiDb.prepare("SELECT COUNT(DISTINCT commit_id) AS count FROM source_sync_states").get()?.count, 1);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states WHERE cursor IS NOT NULL").get()?.count, 0);
+    assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM financial_transactions").get()?.count, 6);
+    assert.equal(multiDb.prepare("SELECT 1 FROM sqlite_master WHERE name = 'transport_checkpoints'").get(), undefined);
+  } finally { multiDb.close(); }
+
+  const repeated = await commitCathayDomesticDepositSync(multiScopeDir, {
+    ...syncInput([syncPage(), syncPage(secondAccount, secondRaw)]),
+    observedAt: "2026-08-18T00:00:00+08:00",
+  });
+  assert.equal(repeated.commitSequence, 2);
+  const repeatedDb = openCanonicalDatabase(multiScopeDir, { readOnly: true });
+  try {
+    assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 2);
+    assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 12);
+    assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM financial_transactions").get()?.count, 6);
+    assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 6);
+    assert.equal(repeatedDb.prepare("SELECT COUNT(*) AS count FROM assertion_provenance").get()?.count, 12);
+  } finally { repeatedDb.close(); }
+} finally { await rm(multiScopeDir, { recursive: true, force: true }); }
+
+for (const [label, pages, expected] of [
+  ["duplicate page ordinal", [{ ...syncPage(), pageOrdinal: 0 }, { ...syncPage(), pageOrdinal: 0 }] as const, /duplicate ordinals/],
+  ["missing terminal page", [{ ...syncPage(), nextPageToken: "synthetic-next-token" }] as const, /end before the terminal/],
+  ["contract fingerprint drift", [{ ...syncPage() }, { ...syncPage("SYNTHETIC-ACCOUNT-002", CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace("SYNTHETIC-ACCOUNT-001", "SYNTHETIC-ACCOUNT-002")), contractFingerprint: "synthetic-drift" }] as const, /unsupported|contract or preflight fingerprint drifted across scopes/],
+] as const) {
+  const rejectedSyncDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-sync-reject-"));
+  try {
+    assert.throws(() => commitCathayDomesticDepositSync(rejectedSyncDir, syncInput([...pages])), expected, label);
+    const rejectedSyncDb = openCanonicalDatabase(rejectedSyncDir);
+    try {
+      assert.equal(rejectedSyncDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, 0, label);
+      assert.equal(rejectedSyncDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 0, label);
+    } finally { rejectedSyncDb.close(); }
+  } finally { await rm(rejectedSyncDir, { recursive: true, force: true }); }
+}
+
+const lifecycleDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-lifecycle-"));
+try {
+  const first = await commitCathayDomesticDepositSync(lifecycleDir, syncInput());
+  const emptyRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace(/"count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":\[[\s\S]*?\]\}/, '"count":0,"startDate":"2025-08-17","endDate":"2026-08-17","details":[]}');
+  const withdrawn = await commitCathayDomesticDepositSync(lifecycleDir, {
+    ...syncInput([syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, emptyRaw)]),
+    observedAt: "2026-08-18T00:00:00+08:00",
+  });
+  const withdrawnQuery = createCathayCanonicalFinancialQuery(lifecycleDir);
+  assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 0);
+  const historicalWithdrawn = await withdrawnQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(withdrawn.commitSequence) } });
+  assert.equal(historicalWithdrawn.transactions.length, 3);
+  assert.equal(historicalWithdrawn.transactions[0]?.assertionSupportState, "withdrawn");
+  const restored = await commitCathayDomesticDepositSync(lifecycleDir, {
+    ...syncInput(),
+    observedAt: "2026-08-19T00:00:00+08:00",
+  });
+  assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 3);
+  assert.equal((await withdrawnQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(restored.commitSequence) } })).transactions[0]?.assertionSupportState, "supported");
+  const restoredLineage = await withdrawnQuery.lineage({ kind: "lineage", subject: { kind: "transaction", id: first.transactions[0]!.transactionId } });
+  const lifecycleKinds = restoredLineage.entries.flatMap((entry) => entry.lifecycleEvents.map((event) => event.kind));
+  assert.equal(lifecycleKinds.includes("withdrawn"), true);
+  assert.equal(lifecycleKinds.includes("restored"), true);
+  assert.equal(lifecycleKinds.includes("observed"), true);
+  assert.equal(restoredLineage.entries[0]?.revision.economicStatus, "normal");
+  assert.equal(restoredLineage.entries[0]?.revision.administrativeState, "active");
+
+  const incompleteRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace('"count":3', '"count":2');
+  assert.throws(() => commitCathayDomesticDepositSync(lifecycleDir, {
+    ...syncInput([syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, incompleteRaw)]),
+    observedAt: "2026-08-20T00:00:00+08:00",
+  }), /count does not match/);
+  assert.equal((await withdrawnQuery.current({ kind: "current" })).transactions.length, 3);
+
+  const changedRaw = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.replace('"incomeAmt":12500', '"incomeAmt":13000').replace('"balance":12500', '"balance":13000');
+  const changed = await commitCathayDomesticDepositSync(lifecycleDir, {
+    ...syncInput([syncPage(CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, changedRaw)]),
+    observedAt: "2026-08-21T00:00:00+08:00",
+  });
+  assert.equal(changed.transactions.some((transaction) => transaction.revisionCreated), true);
+  const changedDb = openCanonicalDatabase(lifecycleDir, { readOnly: true });
+  try {
+    assert.equal(changedDb.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 4);
+    assert.equal(changedDb.prepare("SELECT COUNT(*) AS count FROM assertion_lifecycle_events WHERE event_kind = 'superseded'").get()?.count, 1);
+  } finally { changedDb.close(); }
+} finally { await rm(lifecycleDir, { recursive: true, force: true }); }
+
 const blockStart = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.indexOf('{"queryStatus"');
 const blockEnd = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.lastIndexOf("}]}}") + 1;
 const singleResultBlock = CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE.slice(blockStart, blockEnd);
@@ -393,7 +521,7 @@ for (const version of [1, 2] as const) {
     const migrated = openCanonicalDatabase(migrationDir);
     try {
       assert.equal(Number(migrated.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION, `v${version} final version`);
-      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 3, `v${version} migration history`);
+      assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 4, `v${version} migration history`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1, `v${version} source row`);
       assert.equal(migrated.prepare("SELECT COUNT(*) AS count FROM transaction_revisions").get()?.count, 1, `v${version} revision`);
       assert.equal(migrated.prepare("SELECT completeness_basis FROM source_captures").get()?.completeness_basis, "success-status-scope-count-details", `v${version} completeness`);
@@ -463,6 +591,38 @@ try {
     assert.equal(retriedV2.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 1);
   } finally { retriedV2.close(); }
 } finally { await rm(v2RollbackDir, { recursive: true, force: true }); }
+
+const v3MigrationDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v3-"));
+try {
+  await commitCathayDomesticDeposit(v3MigrationDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+  const v3Seed = new DatabaseSync(canonicalSqlitePath(v3MigrationDir));
+  v3Seed.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes;");
+  v3Seed.exec("DELETE FROM schema_migrations WHERE version = 4; PRAGMA user_version = 3;");
+  v3Seed.close();
+  const migratedV3 = openCanonicalDatabase(v3MigrationDir);
+  try {
+    assert.equal(Number(migratedV3.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION);
+    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM source_records").get()?.count, 3);
+    assert.equal(migratedV3.prepare("SELECT COUNT(*) AS count FROM schema_migrations").get()?.count, 1);
+    assert.equal(migratedV3.prepare("SELECT 1 FROM sqlite_master WHERE name = 'capture_scopes'").get()?.["1"], 1);
+  } finally { migratedV3.close(); }
+  const v3RollbackDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-migration-v3-rollback-"));
+  try {
+    await commitCathayDomesticDeposit(v3RollbackDir, CATHAY_DOMESTIC_DEPOSIT_FIXTURE);
+    const downgrade = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));
+    downgrade.exec("DROP TABLE assertion_lifecycle_events; DROP TABLE capture_scope_pages; DROP TABLE capture_scopes; DELETE FROM schema_migrations WHERE version = 4; PRAGMA user_version = 3; CREATE VIEW capture_scopes AS SELECT 1 AS unusable;");
+    downgrade.close();
+    assert.throws(() => openCanonicalDatabase(v3RollbackDir), /capture_scopes|views may not be indexed/);
+    const afterFailure = new DatabaseSync(canonicalSqlitePath(v3RollbackDir));
+    try {
+      assert.equal(Number(afterFailure.prepare("PRAGMA user_version").get()?.user_version), 3);
+      assert.equal(afterFailure.prepare("SELECT 1 FROM schema_migrations WHERE version = 4").get(), undefined);
+      afterFailure.exec("DROP VIEW capture_scopes");
+    } finally { afterFailure.close(); }
+    const retried = openCanonicalDatabase(v3RollbackDir);
+    try { assert.equal(Number(retried.prepare("PRAGMA user_version").get()?.user_version), CANONICAL_SCHEMA_VERSION); } finally { retried.close(); }
+  } finally { await rm(v3RollbackDir, { recursive: true, force: true }); }
+} finally { await rm(v3MigrationDir, { recursive: true, force: true }); }
 
 const corruptDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-corrupt-"));
 try {

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -117,6 +117,7 @@ try {
 
 for (const [label, capture] of [
   ["wrong currency", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, currency: "USD" }],
+  ["legacy return code", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"returnCode":"0000"', '"returnCode":"000"') }],
   ["count mismatch", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"count":3', '"count":2') }],
   ["query failure", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"queryStatus":"Success"', '"queryStatus":"Failed"') }],
   ["duplicate sequence", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"sequenceNumber":2', '"sequenceNumber":1') }],

--- a/src/ledger/canonical/cathay-domestic-deposit.check.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.check.ts
@@ -67,6 +67,12 @@ try {
     assert.equal(revisionColumns.some((column) => column.name === "balance_coefficient"), false);
     assert.equal(revisionColumns.some((column) => column.name === "balance_scale"), false);
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM current_transactions WHERE commit_id IS NOT NULL").get()?.count, 3);
+    assert.equal(db.prepare("SELECT cursor FROM source_sync_states").get()?.cursor, null);
+    assert.deepEqual({ ...(db.prepare("SELECT completeness, completeness_basis, completeness_rule_version FROM source_captures").get() as Record<string, unknown>) }, {
+      completeness: "complete-range",
+      completeness_basis: "success-status-scope-count-details",
+      completeness_rule_version: "cathay/domestic-deposit/v1",
+    });
     assert.equal(db.prepare("SELECT COUNT(*) AS count FROM transaction_time_observations").get()?.count, 6);
     assert.deepEqual((db.prepare("SELECT role, local_value, time_precision, time_origin FROM transaction_time_observations ORDER BY role, local_value LIMIT 2").all() as Array<Record<string, unknown>>).map((row) => ({ ...row })), [
       { role: "accounting", local_value: "2026-07-01", time_precision: "date", time_origin: "source_reported" },
@@ -186,6 +192,36 @@ try {
   } finally { emptyDb.close(); }
 } finally { await rm(emptyDir, { recursive: true, force: true }); }
 
+const completenessDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-completeness-"));
+try {
+  const result = await commitCathayDomesticDeposit(completenessDir, {
+    ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+    scope: { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope, complete: false },
+  });
+  assert.equal(result.transactions.length, 3);
+  const completenessDb = openCanonicalDatabase(completenessDir, { readOnly: true });
+  try {
+    assert.equal(completenessDb.prepare("SELECT completeness FROM source_captures").get()?.completeness, "complete-range");
+  } finally { completenessDb.close(); }
+} finally { await rm(completenessDir, { recursive: true, force: true }); }
+
+const backfillDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-backfill-"));
+try {
+  const backfill = await commitCathayDomesticDeposit(backfillDir, {
+    ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+    observedAt: "2020-01-01T00:00:00Z",
+  }, { clock: () => "2026-08-20T12:00:00.123456Z" });
+  const backfillDb = openCanonicalDatabase(backfillDir, { readOnly: true });
+  try {
+    const knowledge = backfillDb.prepare("SELECT recorded_at_utc_us FROM canonical_commits").get()?.recorded_at_utc_us as number;
+    assert.equal(knowledge > new Date("2020-01-01T00:00:00Z").getTime() * 1000, true);
+    assert.equal(backfillDb.prepare("SELECT recorded_at_utc_us FROM canonical_commits").get()?.recorded_at_utc_us, 1787227200123456);
+  } finally { backfillDb.close(); }
+  const backfillQuery = createCathayCanonicalFinancialQuery(backfillDir);
+  assert.equal((await backfillQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: "0" } })).transactions.length, 0);
+  assert.equal((await backfillQuery.historical({ kind: "historical", cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(backfill.commitSequence) } })).transactions.length, 3);
+} finally { await rm(backfillDir, { recursive: true, force: true }); }
+
 const contendedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-writer-"));
 try {
   await Promise.all([
@@ -234,6 +270,8 @@ for (const [label, capture] of [
   ["unsupported posting fields", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', '"status":"pending","description":"Synthetic Cathay deposit description"') }],
   ["invalid description type", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', '"description":123') }],
   ["oversized description", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, rawResponse: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"description":"Synthetic Cathay deposit description"', `"description":"${"x".repeat(513)}"`) }],
+  ["timezone-less observedAt", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "2026-08-17T12:00:00" }],
+  ["unsafe timestamp microseconds", { ...CATHAY_DOMESTIC_DEPOSIT_FIXTURE, observedAt: "3000-08-17T12:00:00Z" }],
 ] as const) {
   const rejectedDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-canonical-reject-"));
   try {

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -766,7 +766,10 @@ function migrateV3ToV4(db: DatabaseSync): void {
     throw error;
   }
 }
-function migrateV4ToV5(db: DatabaseSync): void {
+export type CanonicalMigrationFailureInjection = "v4-v5-after-record-copy";
+export type CanonicalDatabaseOptions = { readOnly?: boolean; injectMigrationFailure?: CanonicalMigrationFailureInjection };
+
+function migrateV4ToV5(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection): void {
   db.exec("PRAGMA foreign_keys = OFF");
   db.exec("BEGIN IMMEDIATE");
   try {
@@ -797,6 +800,29 @@ function migrateV4ToV5(db: DatabaseSync): void {
     if (recordCount !== mappedCount) throw new Error("v4 source records could not be deterministically mapped to capture scopes.");
     const ambiguous = Number((db.prepare("SELECT COUNT(*) AS count FROM (SELECT source_record_id FROM source_record_scope_migration GROUP BY source_record_id HAVING COUNT(*) <> 1)").get() as { count?: number }).count ?? 0);
     if (ambiguous !== 0) throw new Error("v4 source records have ambiguous capture scope identity.");
+    const projectionState = db.prepare(`SELECT state.commit_id, commit_row.commit_sequence FROM current_projection_state state
+      JOIN canonical_commits commit_row ON commit_row.commit_id = state.commit_id WHERE state.generation = 1`).get() as { commit_id?: unknown; commit_sequence?: number } | undefined;
+    const currentRowCount = Number((db.prepare("SELECT COUNT(*) AS count FROM current_transactions").get() as { count?: number }).count ?? 0);
+    if (currentRowCount > 0 && !projectionState) throw new Error("v4 current projection state is missing; restoration knowledge is ambiguous.");
+    const ambiguousRestorations = Number((db.prepare(`SELECT COUNT(*) AS count FROM (
+      SELECT lifecycle.transaction_id, lifecycle.revision_id, commit_row.commit_sequence
+      FROM assertion_lifecycle_events lifecycle JOIN canonical_commits commit_row ON commit_row.commit_id = lifecycle.commit_id
+      WHERE lifecycle.event_kind = 'restored'
+      GROUP BY lifecycle.transaction_id, lifecycle.revision_id, commit_row.commit_sequence HAVING COUNT(*) > 1
+    )`).get() as { count?: number }).count ?? 0);
+    if (ambiguousRestorations !== 0) throw new Error("v4 restoration projection knowledge is ambiguous.");
+    db.exec(`CREATE TEMP TABLE current_projection_migration AS
+      SELECT current_row.transaction_id, current_row.revision_id,
+        COALESCE((SELECT lifecycle.commit_id FROM assertion_lifecycle_events lifecycle JOIN canonical_commits lifecycle_commit ON lifecycle_commit.commit_id = lifecycle.commit_id
+          WHERE lifecycle.event_kind = 'restored' AND lifecycle.transaction_id = current_row.transaction_id AND lifecycle.revision_id = current_row.revision_id
+          ORDER BY lifecycle_commit.commit_sequence DESC, lifecycle.event_id DESC LIMIT 1), current_row.commit_id) AS projection_commit_id,
+        revision.commit_id AS revision_commit_id
+      FROM current_transactions current_row JOIN transaction_revisions revision ON revision.revision_id = current_row.revision_id`);
+    if (projectionState) {
+      if (projectionState.commit_sequence === undefined) throw new Error("v4 current projection state sequence is missing; restoration knowledge is ambiguous.");
+      const outOfBounds = Number((db.prepare(`SELECT COUNT(*) AS count FROM current_projection_migration migrated JOIN canonical_commits projection_commit ON projection_commit.commit_id = migrated.projection_commit_id WHERE projection_commit.commit_sequence > ?`).get(projectionState.commit_sequence) as { count?: number }).count ?? 0);
+      if (outOfBounds !== 0) throw new Error("v4 restoration projection knowledge exceeds current projection state.");
+    }
 
     db.exec(`CREATE TABLE source_captures_v5 (
       capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
@@ -815,6 +841,7 @@ function migrateV4ToV5(db: DatabaseSync): void {
       UNIQUE(source_record_id, capture_id)
     )`);
     db.exec("INSERT INTO source_records_v5(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) SELECT source_record_id, capture_id, commit_id, provider_sequence, description, payload_json FROM source_record_scope_migration");
+    if (injectMigrationFailure === "v4-v5-after-record-copy") throw new Error("Injected v4-v5 migration failure after record copy.");
     db.exec("DROP TABLE source_records; DROP TABLE source_captures; ALTER TABLE source_captures_v5 RENAME TO source_captures; ALTER TABLE source_records_v5 RENAME TO source_records");
     if (!columnExists(db, "capture_scopes", "scope_kind")) db.exec("ALTER TABLE capture_scopes ADD COLUMN scope_kind TEXT NOT NULL DEFAULT 'bounded-range' CHECK(scope_kind = 'bounded-range')");
     if (!columnExists(db, "transaction_revisions", "economic_status")) db.exec("ALTER TABLE transaction_revisions ADD COLUMN economic_status TEXT NOT NULL DEFAULT 'normal' CHECK(economic_status IN ('normal','canceled','refund','reversal'))");
@@ -822,8 +849,8 @@ function migrateV4ToV5(db: DatabaseSync): void {
     if (!columnExists(db, "transaction_revisions", "semantic_rule_version")) db.exec("ALTER TABLE transaction_revisions ADD COLUMN semantic_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1')");
     if (!columnExists(db, "current_transactions", "projection_commit_id")) db.exec("ALTER TABLE current_transactions ADD COLUMN projection_commit_id BLOB REFERENCES canonical_commits(commit_id)");
     if (!columnExists(db, "current_transactions", "revision_commit_id")) db.exec("ALTER TABLE current_transactions ADD COLUMN revision_commit_id BLOB REFERENCES canonical_commits(commit_id)");
-    db.exec("UPDATE current_transactions SET projection_commit_id = commit_id");
-    db.exec("UPDATE current_transactions SET revision_commit_id = (SELECT revision.commit_id FROM transaction_revisions revision WHERE revision.revision_id = current_transactions.revision_id)");
+    db.exec("UPDATE current_transactions SET projection_commit_id = (SELECT migrated.projection_commit_id FROM current_projection_migration migrated WHERE migrated.transaction_id = current_transactions.transaction_id AND migrated.revision_id = current_transactions.revision_id), revision_commit_id = (SELECT migrated.revision_commit_id FROM current_projection_migration migrated WHERE migrated.transaction_id = current_transactions.transaction_id AND migrated.revision_id = current_transactions.revision_id)");
+    db.exec("UPDATE current_transactions SET commit_id = projection_commit_id");
     db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_capture ON capture_scopes(scope_id, capture_id); CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_account ON capture_scopes(scope_id, account_id)");
     db.exec(SCHEMA_V5_APPEND);
     db.exec("INSERT INTO source_record_scopes(source_record_id, scope_id, capture_id, account_id, sequence_lexeme, commit_id) SELECT source_record_id, scope_id, capture_id, account_id, provider_sequence, commit_id FROM source_record_scope_migration");
@@ -837,7 +864,7 @@ function migrateV4ToV5(db: DatabaseSync): void {
     throw error;
   }
 }
-function applySchemaMigration(db: DatabaseSync): void {
+function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOptions = {}): void {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
   const version = Number(row.user_version ?? 0);
   if (version > CANONICAL_SCHEMA_VERSION) throw new Error(`Canonical SQLite schema ${version} is newer than supported ${CANONICAL_SCHEMA_VERSION}.`);
@@ -846,22 +873,22 @@ function applySchemaMigration(db: DatabaseSync): void {
     migrateV1ToV2(db);
     migrateV2ToV3(db);
     migrateV3ToV4(db);
-    migrateV4ToV5(db);
+    migrateV4ToV5(db, options.injectMigrationFailure);
     return;
   }
   if (version === 2) {
     migrateV2ToV3(db);
     migrateV3ToV4(db);
-    migrateV4ToV5(db);
+    migrateV4ToV5(db, options.injectMigrationFailure);
     return;
   }
   if (version === 3) {
     migrateV3ToV4(db);
-    migrateV4ToV5(db);
+    migrateV4ToV5(db, options.injectMigrationFailure);
     return;
   }
   if (version === 4) {
-    migrateV4ToV5(db);
+    migrateV4ToV5(db, options.injectMigrationFailure);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -883,8 +910,34 @@ function applySchemaMigration(db: DatabaseSync): void {
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  for (const table of ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events"]) {
-    if (!tableExists(db, table)) throw new Error(`Canonical schema v4 table ${table} is missing.`);
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state"];
+  for (const table of requiredTables) {
+    if (!tableExists(db, table)) throw new Error(`Canonical schema v5 table ${table} is missing.`);
+  }
+  const requiredColumns: Record<string, string[]> = {
+    source_captures: ["account_no", "completeness_basis", "completeness_rule_version"],
+    capture_scopes: ["scope_kind", "contract_fingerprint", "preflight_fingerprint", "completeness_rule_version"],
+    source_record_scopes: ["source_record_id", "scope_id", "capture_id", "account_id", "sequence_lexeme"],
+    transaction_revisions: ["economic_status", "administrative_state", "semantic_rule_version"],
+    current_transactions: ["projection_commit_id", "revision_commit_id"],
+  };
+  for (const [table, columns] of Object.entries(requiredColumns)) {
+    const actual = new Set((db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>).map((column) => column.name));
+    for (const column of columns) if (!actual.has(column)) throw new Error(`Canonical schema v5 column ${table}.${column} is missing.`);
+  }
+  const requiredIndexes = [
+    "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof", "idx_assertion_lifecycle_scope",
+    "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
+  ];
+  for (const index of requiredIndexes) {
+    if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v5 index ${index} is missing.`);
+  }
+  const tableSql = (table: string): string => String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) as { sql?: unknown } | undefined)?.sql ?? "");
+  if (!/FOREIGN KEY\s*\(source_record_id,\s*capture_id\)/i.test(tableSql("source_record_scopes")) || !/capture_scopes/i.test(tableSql("source_record_scopes"))) {
+    throw new Error("Canonical schema v5 source-record scope constraints are missing.");
+  }
+  if (!/economic_status.*canceled.*refund.*reversal/i.test(tableSql("transaction_revisions")) || !/administrative_state.*deleted.*purged/i.test(tableSql("transaction_revisions"))) {
+    throw new Error("Canonical schema v5 semantic constraints are missing.");
   }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
@@ -907,7 +960,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
 }
 
-export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: boolean } = {}): DatabaseSync {
+export function openCanonicalDatabase(ledgerDir: string, options: CanonicalDatabaseOptions = {}): DatabaseSync {
   const path = canonicalSqlitePath(ledgerDir);
   if (options.readOnly && !existsSync(path)) throw new Error(`Missing canonical SQLite: ${path}`);
   if (!options.readOnly) mkdirSync(ledgerDir, { recursive: true });
@@ -915,7 +968,7 @@ export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: b
   try {
     db.exec("PRAGMA foreign_keys = ON");
     db.exec("PRAGMA busy_timeout = 30000");
-    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); db.exec("PRAGMA synchronous = FULL"); applySchemaMigration(db); }
+    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); db.exec("PRAGMA synchronous = FULL"); applySchemaMigration(db, options); }
     else {
       const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
       if (Number(row.user_version ?? 0) !== CANONICAL_SCHEMA_VERSION) throw new Error("Canonical SQLite schema is missing or unsupported for read-only access.");
@@ -1235,7 +1288,10 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.projection_commit_id
         ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
-      return { status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow), commitSequence: rows.reduce((max, row) => Math.max(max, Number(row.commit_sequence)), 0) };
+      const projection = db.prepare(`SELECT c.commit_sequence FROM current_projection_state state
+        JOIN canonical_commits c ON c.commit_id = state.commit_id WHERE state.generation = 1`).get() as { commit_sequence?: number } | undefined;
+      if (!projection) throw new Error("Canonical current projection cutoff is missing.");
+      return { status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow), commitSequence: Number(projection.commit_sequence) };
     } finally { db.close(); }
   }
   async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -12,6 +12,7 @@ import {
 export const CATHAY_INTEGRATION_NAMESPACE = "cathay";
 export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
+export const CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION = "v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CATHAY_DERIVED_ORIGIN = "derived/cathay/domestic-deposit/v1" as const;
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
@@ -159,6 +160,29 @@ export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput 
 };
 
 export type ExactDecimal = { coefficient: bigint; scale: number };
+
+/** The physical representation is deliberately stricter than SQLite's TEXT /
+ * INTEGER affinities.  In particular, SQLite's `GLOB '[0-9]*'` means "a
+ * digit followed by anything", so it accepts values such as `12abc`. */
+const MAX_CANONICAL_SCALE = 9007199254740991n;
+function canonicalStoredInteger(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" && Number.isSafeInteger(value)) return value.toString();
+  return null;
+}
+
+function isCanonicalStoredExactAmount(coefficientValue: unknown, scaleValue: unknown): boolean {
+  const coefficient = canonicalStoredInteger(coefficientValue);
+  const scale = canonicalStoredInteger(scaleValue);
+  if (coefficient === null || scale === null
+    || !/^-?(?:0|[1-9]\d*)$/.test(coefficient)
+    || !/^(?:0|[1-9]\d*)$/.test(scale)) return false;
+  try {
+    BigInt(coefficient);
+    return BigInt(scale) <= MAX_CANONICAL_SCALE;
+  } catch { return false; }
+}
 
 export function parseExactDecimalLexeme(lexeme: string): ExactDecimal {
   if (!/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(lexeme)) {
@@ -921,6 +945,22 @@ CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_active ON proj
 CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_revision ON projection_generation_transactions(generation_id, revision_id, projection_commit_id);
 CREATE INDEX IF NOT EXISTS idx_projection_generation_fields_active ON projection_generation_transaction_fields(generation_id, transaction_id, field_name, projection_commit_id);
 CREATE INDEX IF NOT EXISTS idx_projection_generations_status ON projection_generations(status, build_cutoff_commit_sequence, generation_id);
+CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_switch_insert
+BEFORE INSERT ON active_projection_generation
+WHEN (SELECT COUNT(*) FROM canonical_commits) > 0 AND NEW.switched_commit_id IS NULL
+BEGIN SELECT RAISE(ABORT, 'active projection switch commit is required'); END;
+CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_switch_update
+BEFORE UPDATE OF switched_commit_id ON active_projection_generation
+WHEN (SELECT COUNT(*) FROM canonical_commits) > 0 AND NEW.switched_commit_id IS NULL
+BEGIN SELECT RAISE(ABORT, 'active projection switch commit is required'); END;
+CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_commit_insert
+BEFORE INSERT ON active_projection_generation
+WHEN NEW.switched_commit_id IS NOT (SELECT switched_commit_id FROM projection_generations WHERE generation_id = NEW.generation_id)
+BEGIN SELECT RAISE(ABORT, 'active projection switch commit does not match generation'); END;
+CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_commit_update
+BEFORE UPDATE OF generation_id, switched_commit_id ON active_projection_generation
+WHEN NEW.switched_commit_id IS NOT (SELECT switched_commit_id FROM projection_generations WHERE generation_id = NEW.generation_id)
+BEGIN SELECT RAISE(ABORT, 'active projection switch commit does not match generation'); END;
 `;
 
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
@@ -1347,6 +1387,7 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
       commit_kind TEXT NOT NULL CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))
     )`);
     db.exec("INSERT INTO canonical_commits_v6 SELECT * FROM canonical_commits");
+    db.exec("DROP TRIGGER IF EXISTS trg_active_projection_generation_switch_insert; DROP TRIGGER IF EXISTS trg_active_projection_generation_switch_update; DROP TRIGGER IF EXISTS trg_active_projection_generation_commit_insert; DROP TRIGGER IF EXISTS trg_active_projection_generation_commit_update");
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v6 RENAME TO canonical_commits");
     ensureV6SharedAssertionSpine(db);
     db.exec(SCHEMA_V6_APPEND);
@@ -1379,6 +1420,7 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
       commit_kind TEXT NOT NULL CHECK(commit_kind IN ('source_capture','derived_import','user_assertion','projection_rebuild'))
     )`);
     db.exec("INSERT INTO canonical_commits_v7 SELECT * FROM canonical_commits");
+    db.exec("DROP TRIGGER IF EXISTS trg_active_projection_generation_switch_insert; DROP TRIGGER IF EXISTS trg_active_projection_generation_switch_update; DROP TRIGGER IF EXISTS trg_active_projection_generation_commit_insert; DROP TRIGGER IF EXISTS trg_active_projection_generation_commit_update");
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v7 RENAME TO canonical_commits");
     db.exec("CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
     db.exec(SCHEMA_V7_APPEND);
@@ -1389,8 +1431,8 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     let latestSequence = Number(latest?.commit_sequence ?? 0);
     const generationExists = db.prepare("SELECT 1 FROM projection_generations WHERE generation_id = 1").get();
     if (!generationExists) {
-      db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id)
-      VALUES (1, 'active', ?, 'canonical/projection/v1', ?)`).run(latestSequence, latestCommit ?? null);
+      db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
+      VALUES (1, 'active', ?, 'canonical/projection/v1', ?, ?, ?)`).run(latestSequence, latestCommit ?? null, latestCommit ?? null, latestCommit ?? null);
       db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
         SELECT 1, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run();
       db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
@@ -1416,23 +1458,82 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
   }
 }
 
+function validateGenerationExactAmounts(db: DatabaseSync, generationId: number): void {
+  const rows = db.prepare(`SELECT revision.amount_coefficient, CAST(revision.amount_scale AS TEXT) AS amount_scale
+    FROM projection_generation_transactions projected
+    JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    WHERE projected.generation_id = ?`).all(generationId) as Array<{ amount_coefficient?: unknown; amount_scale?: unknown }>;
+  if (rows.some((row) => !isCanonicalStoredExactAmount(row.amount_coefficient, row.amount_scale))) {
+    throw new Error("Canonical v7 projection contains non-exact arithmetic values.");
+  }
+}
+
+function validateCathayAuthorityRoute(db: DatabaseSync, generationId: number): void {
+  const invalid = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions projected
+    WHERE projected.generation_id = ? AND NOT EXISTS (
+      SELECT 1 FROM transaction_revisions revision
+      JOIN source_captures capture ON capture.capture_id = revision.capture_id
+      JOIN assertions source_assertion ON source_assertion.revision_id = revision.revision_id AND source_assertion.origin = 'source'
+      JOIN source_authority_routes registered ON registered.authority_route = capture.authority_route
+      WHERE revision.revision_id = projected.revision_id AND revision.transaction_id = projected.transaction_id
+        AND capture.authority_route = ? AND capture.stream = ?
+        AND capture.completeness_rule_version = ?
+        AND registered.integration_namespace = ? AND registered.stream = ? AND registered.contract_version = ?
+        AND source_assertion.producer_id = ? AND source_assertion.rule_lineage = ?
+    )`).get(generationId, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_STREAM,
+    CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM,
+    CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) as { count?: number }).count ?? 0);
+  if (invalid !== 0) throw new Error("Canonical v7 projection contains an unregistered or invalid Cathay authority route.");
+}
+
+function canonicalIdsEqual(left: unknown, right: unknown): boolean {
+  if (!(left instanceof Uint8Array) || !(right instanceof Uint8Array)) return false;
+  return Buffer.compare(Buffer.from(left), Buffer.from(right)) === 0;
+}
+
+/** Validate the one switch boundary used by both writer and read-only startup.
+ * This is intentionally a row-level gate: SQLite FKs can prove that a pointer
+ * names a row, but cannot prove that the row is the sole active generation or
+ * that all knowledge-state commits agree. */
+function validateActiveProjectionBoundary(db: DatabaseSync): number {
+  const pointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
+  if (!pointer) throw new Error("Canonical v7 active projection pointer is missing.");
+  const activeRows = db.prepare("SELECT generation_id, switched_commit_id, build_cutoff_commit_sequence FROM projection_generations WHERE status = 'active'").all() as Array<{ generation_id?: number; switched_commit_id?: unknown; build_cutoff_commit_sequence?: number }>;
+  if (activeRows.length !== 1) throw new Error("Canonical v7 active projection generation is ambiguous.");
+  const active = activeRows[0]!;
+  const generationId = Number(active.generation_id ?? 0);
+  if (generationId <= 0 || Number(pointer.generation_id ?? 0) !== generationId) throw new Error("Canonical v7 active projection pointer does not target the sole active generation.");
+  const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
+  const stateRows = db.prepare("SELECT generation, commit_id FROM current_projection_state").all() as Array<{ generation?: number; commit_id?: unknown }>;
+  if (commitCount === 0) {
+    if (pointer.switched_commit_id !== null && pointer.switched_commit_id !== undefined) throw new Error("Canonical v7 empty projection has an unexpected switch commit.");
+    if (active.switched_commit_id !== null && active.switched_commit_id !== undefined) throw new Error("Canonical v7 empty generation has an unexpected switch commit.");
+    if (stateRows.length !== 0) throw new Error("Canonical v7 empty projection has an unexpected knowledge state.");
+  } else {
+    if (pointer.switched_commit_id === null || pointer.switched_commit_id === undefined
+      || active.switched_commit_id === null || active.switched_commit_id === undefined) {
+      throw new Error("Canonical v7 active projection switch commit is missing.");
+    }
+    if (!canonicalIdsEqual(pointer.switched_commit_id, active.switched_commit_id)) throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
+    if (!db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id))) throw new Error("Canonical v7 active projection pointer references no commit.");
+    if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1 || !canonicalIdsEqual(stateRows[0]!.commit_id, pointer.switched_commit_id)) {
+      throw new Error("Canonical v7 active projection knowledge state does not match its switch commit.");
+    }
+    const switchSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id)) as { commit_sequence?: number } | undefined)?.commit_sequence ?? -1);
+    if (switchSequence < Number(active.build_cutoff_commit_sequence ?? 0)) throw new Error("Canonical v7 active projection switch precedes its knowledge cutoff.");
+  }
+  validateGenerationExactAmounts(db, generationId);
+  validateCathayAuthorityRoute(db, generationId);
+  return generationId;
+}
+
 function ensureV7ProjectionSchema(db: DatabaseSync): void {
   db.exec(SCHEMA_V7_APPEND);
-  const pointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
-  if (!pointer) throw new Error("Canonical v7 active projection pointer is missing.");
-  const generationId = Number(pointer.generation_id ?? 0);
-  const generation = db.prepare("SELECT generation_id, status FROM projection_generations WHERE generation_id = ?").get(generationId) as { generation_id?: number; status?: string } | undefined;
-  if (!generation || generation.status !== "active") throw new Error("Canonical v7 active projection generation is not active.");
-  const activeCount = Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generations WHERE status = 'active'").get() as { count?: number }).count ?? 0);
-  if (activeCount !== 1) throw new Error("Canonical v7 active projection generation is ambiguous.");
+  const generationId = validateActiveProjectionBoundary(db);
   const mixedRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
     WHERE rows.generation_id = ? AND (rows.revision_id NOT IN (SELECT revision_id FROM transaction_revisions)
       OR rows.transaction_id NOT IN (SELECT transaction_id FROM financial_transactions))`).get(generationId) as { count?: number }).count ?? 0);
   if (mixedRows !== 0) throw new Error("Canonical v7 active projection contains mixed or dangling rows.");
-  const badArithmetic = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
-    JOIN transaction_revisions revision ON revision.revision_id = rows.revision_id
-    WHERE revision.amount_coefficient NOT GLOB '-[0-9]*' AND revision.amount_coefficient NOT GLOB '[0-9]*'`).get() as { count?: number }).count ?? 0);
-  if (badArithmetic !== 0) throw new Error("Canonical v7 projection contains non-exact arithmetic values.");
 }
 function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOptions = {}): void {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
@@ -1628,9 +1729,10 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.revision_commit_id
       AND current_row.commit_id = current_row.projection_commit_id`).get() as { count?: number }).count ?? 0);
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
+  const validatedActiveGenerationId = validateActiveProjectionBoundary(db);
   const activePointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
   if (!activePointer) throw new Error("Canonical v7 active projection pointer is missing.");
-  const activeGenerationId = Number(activePointer.generation_id ?? 0);
+  const activeGenerationId = validatedActiveGenerationId;
   const activeGeneration = db.prepare("SELECT status, build_cutoff_commit_sequence FROM projection_generations WHERE generation_id = ?").get(activeGenerationId) as { status?: string; build_cutoff_commit_sequence?: number } | undefined;
   if (!activeGeneration || activeGeneration.status !== "active") throw new Error("Canonical v7 active projection is not readable.");
   if (activePointer.switched_commit_id !== null && activePointer.switched_commit_id !== undefined
@@ -1779,7 +1881,7 @@ function commitCathayDomesticDepositSyncOnce(
     const maxSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0);
     const commitSequence = maxSequence + 1;
     db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(admissionClock()), input.authorityRoute, "source_capture");
-    db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(input.authorityRoute, CATHAY_INTEGRATION_NAMESPACE, input.stream, "v1", commitId);
+    db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(input.authorityRoute, CATHAY_INTEGRATION_NAMESPACE, input.stream, CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION, commitId);
     const connectionExisting = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
     const sourceConnectionId = connectionExisting ? blob(dbRow<{ source_connection_id: unknown }>(connectionExisting).source_connection_id) : uuidV7();
     if (!connectionExisting) db.prepare("INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_id) VALUES (?, ?, ?, ?)").run(sourceConnectionId, CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId, commitId);
@@ -1966,10 +2068,9 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
       LEFT JOIN financial_transactions transaction_row ON transaction_row.transaction_id = projected.transaction_id
       LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
       WHERE projected.generation_id = ? AND (transaction_row.transaction_id IS NULL OR revision.revision_id IS NULL OR revision.transaction_id <> projected.transaction_id)`).get(generation) as { count?: number }).count ?? 0);
-    const arithmetic = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions projected
-      JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
-      WHERE projected.generation_id = ? AND (revision.amount_coefficient NOT GLOB '[0-9]*' AND revision.amount_coefficient NOT GLOB '-[0-9]*')`).get(generation) as { count?: number }).count ?? 0);
-    if (dangling !== 0 || arithmetic !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
+    if (dangling !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
+    validateGenerationExactAmounts(db, generation);
+    validateCathayAuthorityRoute(db, generation);
     const duplicate = Number((db.prepare(`SELECT COUNT(*) AS count FROM (SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ? GROUP BY transaction_id HAVING COUNT(*) <> 1)`).get(generation) as { count?: number }).count ?? 0);
     if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
     rebuildFailure(options.injectFailure, ["validation", "after-validation"]);

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -7,6 +7,7 @@ export const CATHAY_INTEGRATION_NAMESPACE = "cathay";
 export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
+export const CATHAY_DERIVED_ORIGIN = "derived/cathay/domestic-deposit/v1" as const;
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
 export const CANONICAL_SCHEMA_VERSION = 6;
 export const CATHAY_POSTING_MAPPING = {
@@ -80,20 +81,13 @@ export type CathayDomesticDepositSyncInput = {
  * claims to own.  Unsupported is an explicit output state, not a missing
  * array element, so a partial producer can never withdraw an old claim. */
 export type CathayDerivedField = "display_name" | "note";
+export type CathayDerivedOrigin = typeof CATHAY_DERIVED_ORIGIN;
 export type CathayDerivedOutputState = "supported" | "unsupported";
 export type CathayDerivedImportCoordinate = {
   transactionId: string;
   field: CathayDerivedField;
   state: CathayDerivedOutputState;
   value?: string | null;
-};
-export type CathayDerivedImportSubject = { kind: "transaction"; id: string } | string;
-export type CathayDerivedImportScope = {
-  subjects: CathayDerivedImportSubject[];
-  fields: CathayDerivedField[];
-  producerId?: string;
-  origin?: string;
-  ruleLineage?: string;
 };
 export type CathayDerivedImportRunInput = {
   sourceConnectionId: string;
@@ -105,12 +99,7 @@ export type CathayDerivedImportRunInput = {
   origin?: string;
   observedAt?: string;
   /** Complete subject/field/producer/rule-lineage coordinate matrix. */
-  scope?: CathayDerivedImportCoordinate[] | CathayDerivedImportScope;
-  outputScope?: CathayDerivedImportCoordinate[] | CathayDerivedImportScope;
-  coordinates?: CathayDerivedImportCoordinate[];
-  outputs?: CathayDerivedImportCoordinate[];
-  /** Compatibility spelling for callers that model a complete run explicitly. */
-  complete?: boolean;
+  scope?: CathayDerivedImportCoordinate[];
 };
 export type CathayDerivedImportDiagnostic = {
   kind: "derived-import-diagnostic";
@@ -561,6 +550,54 @@ function blob(value: unknown): CanonicalId { return value instanceof Uint8Array 
 
 export function canonicalSqlitePath(ledgerDir: string): string { return join(ledgerDir, CANONICAL_SQLITE_FILE); }
 
+// One typed assertion metadata/provenance spine is shared by Source, Derived,
+// and User claims. The older source-specific tables remain compatibility
+// projections for #129 callers, while these tables own cross-origin identity,
+// transitions, and provenance for v6 admissions.
+const SCHEMA_SHARED_ASSERTION_SPINE = `
+CREATE TABLE IF NOT EXISTS assertions (
+  assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('transaction_revision','display_name','note')),
+  target_kind TEXT NOT NULL CHECK(target_kind = 'transaction'),
+  origin TEXT NOT NULL CHECK(origin IN ('source','derived','user')),
+  producer_id TEXT NOT NULL,
+  rule_lineage TEXT NOT NULL,
+  revision_id BLOB REFERENCES transaction_revisions(revision_id),
+  value_text TEXT,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  CHECK((origin = 'source' AND field_name = 'transaction_revision' AND revision_id IS NOT NULL AND value_text IS NULL)
+    OR (origin IN ('derived','user') AND field_name IN ('display_name','note') AND revision_id IS NULL AND value_text IS NOT NULL))
+);
+CREATE TABLE IF NOT EXISTS assertion_transitions (
+  event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
+  assertion_id BLOB NOT NULL REFERENCES assertions(assertion_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('transaction_revision','display_name','note')),
+  capture_id BLOB,
+  scope_id BLOB,
+  run_id BLOB REFERENCES derived_import_runs(run_id),
+  coordinate_id BLOB REFERENCES derived_scope_coordinates(coordinate_id),
+  user_id TEXT,
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','restored'))
+);
+CREATE TABLE IF NOT EXISTS assertion_provenance (
+  assertion_id BLOB NOT NULL REFERENCES assertions(assertion_id),
+  source_record_id BLOB REFERENCES source_records(source_record_id),
+  run_id BLOB REFERENCES derived_import_runs(run_id),
+  coordinate_id BLOB REFERENCES derived_scope_coordinates(coordinate_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(assertion_id, source_record_id, run_id, coordinate_id, commit_id)
+);
+`;
+const SCHEMA_SHARED_ASSERTION_SPINE_INDEXES = `
+CREATE INDEX IF NOT EXISTS idx_assertions_lineage ON assertions(transaction_id, field_name, origin, producer_id, rule_lineage, created_commit_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_transitions_knowledge ON assertion_transitions(assertion_id, commit_id, event_kind, event_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_transitions_transaction ON assertion_transitions(transaction_id, field_name, commit_id, event_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_provenance_authority ON assertion_provenance(assertion_id, commit_id, source_record_id, run_id, coordinate_id);
+`;
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at_utc_us INTEGER NOT NULL);
 CREATE TABLE IF NOT EXISTS canonical_commits (
@@ -636,9 +673,7 @@ CREATE TABLE IF NOT EXISTS source_assertions (
   revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(transaction_id, revision_id)
 );
-CREATE TABLE IF NOT EXISTS assertion_provenance (
-  assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), PRIMARY KEY(assertion_id, source_record_id)
-);
+${SCHEMA_SHARED_ASSERTION_SPINE}
 CREATE TABLE IF NOT EXISTS source_sync_states (
   source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
   stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT,
@@ -728,12 +763,14 @@ const SCHEMA_V5 = `${SCHEMA_V4}${SCHEMA_V5_APPEND}`
   .replace("absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range', 'tombstone'))", "absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range'))");
 
 const SCHEMA_V6_APPEND = `
+${SCHEMA_SHARED_ASSERTION_SPINE}
+${SCHEMA_SHARED_ASSERTION_SPINE_INDEXES}
 CREATE TABLE IF NOT EXISTS derived_import_runs (
   run_id BLOB PRIMARY KEY CHECK(length(run_id) = 16),
   source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
   identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id),
   authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
-  stream TEXT NOT NULL, producer_id TEXT NOT NULL, origin TEXT NOT NULL,
+  stream TEXT NOT NULL, producer_id TEXT NOT NULL, origin TEXT NOT NULL CHECK(origin = 'derived/cathay/domestic-deposit/v1'),
   rule_lineage TEXT NOT NULL, observed_at TEXT NOT NULL,
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   status TEXT NOT NULL CHECK(status = 'complete'),
@@ -744,7 +781,7 @@ CREATE TABLE IF NOT EXISTS derived_scope_coordinates (
   run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
   transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
   field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
-  producer_id TEXT NOT NULL, origin TEXT NOT NULL, rule_lineage TEXT NOT NULL,
+  producer_id TEXT NOT NULL, origin TEXT NOT NULL CHECK(origin = 'derived/cathay/domestic-deposit/v1'), rule_lineage TEXT NOT NULL,
   output_state TEXT NOT NULL CHECK(output_state IN ('supported','unsupported')),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   UNIQUE(run_id, transaction_id, field_name, producer_id, origin, rule_lineage)
@@ -753,7 +790,7 @@ CREATE TABLE IF NOT EXISTS derived_assertions (
   assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16),
   transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
   field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
-  producer_id TEXT NOT NULL, origin TEXT NOT NULL, rule_lineage TEXT NOT NULL,
+  producer_id TEXT NOT NULL, origin TEXT NOT NULL CHECK(origin = 'derived/cathay/domestic-deposit/v1'), rule_lineage TEXT NOT NULL,
   value_text TEXT NOT NULL, run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   UNIQUE(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage)
@@ -773,7 +810,7 @@ CREATE TABLE IF NOT EXISTS derived_assertion_lifecycle_events (
   run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
   coordinate_id BLOB REFERENCES derived_scope_coordinates(coordinate_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
-  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','restored','provenance_only'))
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','restored'))
 );
 CREATE TABLE IF NOT EXISTS user_assertions (
   assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16),
@@ -789,7 +826,7 @@ CREATE TABLE IF NOT EXISTS user_assertion_lifecycle_events (
   transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
   field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
   user_id TEXT NOT NULL, commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
-  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','provenance_only'))
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn'))
 );
 CREATE TABLE IF NOT EXISTS user_assertion_provenance (
   assertion_id BLOB NOT NULL REFERENCES user_assertions(assertion_id),
@@ -929,6 +966,27 @@ function migrateV3ToV4(db: DatabaseSync): void {
 export type CanonicalMigrationFailureInjection = "v4-v5-after-record-copy" | "v5-v6-after-derived-schema";
 export type CanonicalDatabaseOptions = { readOnly?: boolean; injectMigrationFailure?: CanonicalMigrationFailureInjection };
 
+function ensureV6SharedAssertionSpine(db: DatabaseSync): void {
+  const provenanceSql = String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'assertion_provenance'").get() as { sql?: unknown } | undefined)?.sql ?? "");
+  const legacyProvenance = /REFERENCES\s+source_assertions/i.test(provenanceSql);
+  if (legacyProvenance) db.exec("ALTER TABLE assertion_provenance RENAME TO assertion_provenance_v5");
+  db.exec(SCHEMA_SHARED_ASSERTION_SPINE);
+  db.exec(`INSERT OR IGNORE INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id)
+    SELECT source_assertion.assertion_id, source_assertion.transaction_id, 'transaction_revision', 'transaction', 'source', capture.authority_route, capture.authority_route,
+      source_assertion.revision_id, NULL, source_assertion.commit_id
+    FROM source_assertions source_assertion JOIN transaction_revisions revision ON revision.revision_id = source_assertion.revision_id
+      JOIN source_captures capture ON capture.capture_id = revision.capture_id`);
+  db.exec(`INSERT OR IGNORE INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind)
+    SELECT event.event_id, event.assertion_id, event.transaction_id, 'transaction_revision', event.capture_id, event.scope_id, NULL, NULL, NULL, event.commit_id, event.event_kind
+    FROM assertion_lifecycle_events event`);
+  if (legacyProvenance) {
+    db.exec(`INSERT OR IGNORE INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id)
+      SELECT assertion_id, source_record_id, NULL, NULL, commit_id FROM assertion_provenance_v5`);
+    db.exec("DROP TABLE assertion_provenance_v5");
+  }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
+}
+
 function migrateV4ToV5(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection): void {
   db.exec("PRAGMA foreign_keys = OFF");
   db.exec("BEGIN IMMEDIATE");
@@ -1039,6 +1097,7 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     )`);
     db.exec("INSERT INTO canonical_commits_v6 SELECT * FROM canonical_commits");
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v6 RENAME TO canonical_commits");
+    ensureV6SharedAssertionSpine(db);
     db.exec(SCHEMA_V6_APPEND);
     if (injectMigrationFailure === "v5-v6-after-derived-schema") throw new Error("Injected v5-v6 migration failure after derived schema.");
     db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(6, currentUtcMicros());
@@ -1090,6 +1149,18 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     if (!tableExists(db, "schema_migrations")) throw new Error("Canonical SQLite schema version metadata is missing.");
     const migration = db.prepare("SELECT 1 FROM schema_migrations WHERE version = ?").get(CANONICAL_SCHEMA_VERSION);
     if (!migration) throw new Error("Canonical SQLite schema migration metadata is incomplete.");
+    db.exec("PRAGMA foreign_keys = OFF");
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      ensureV6SharedAssertionSpine(db);
+      db.exec(SCHEMA_V6_APPEND);
+      db.exec("PRAGMA foreign_keys = ON");
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      db.exec("PRAGMA foreign_keys = ON");
+      throw error;
+    }
     return;
   }
   db.exec("BEGIN IMMEDIATE");
@@ -1105,11 +1176,23 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
   for (const table of requiredTables) {
     if (!tableExists(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
   }
   const requiredColumns: Record<string, string[]> = {
+    assertions: ["assertion_id", "transaction_id", "field_name", "target_kind", "origin", "producer_id", "rule_lineage", "revision_id", "value_text", "created_commit_id"],
+    assertion_transitions: ["event_id", "assertion_id", "transaction_id", "field_name", "capture_id", "scope_id", "run_id", "coordinate_id", "user_id", "commit_id", "event_kind"],
+    assertion_provenance: ["assertion_id", "source_record_id", "run_id", "coordinate_id", "commit_id"],
+    derived_import_runs: ["run_id", "source_connection_id", "identity_epoch_id", "authority_route", "stream", "producer_id", "origin", "rule_lineage", "observed_at", "commit_id", "status"],
+    derived_scope_coordinates: ["coordinate_id", "run_id", "transaction_id", "field_name", "producer_id", "origin", "rule_lineage", "output_state", "commit_id"],
+    derived_assertions: ["assertion_id", "transaction_id", "field_name", "producer_id", "origin", "rule_lineage", "value_text", "run_id", "commit_id"],
+    derived_assertion_provenance: ["assertion_id", "run_id", "coordinate_id", "commit_id"],
+    derived_assertion_lifecycle_events: ["event_id", "assertion_id", "transaction_id", "field_name", "run_id", "coordinate_id", "commit_id", "event_kind"],
+    user_assertions: ["assertion_id", "transaction_id", "field_name", "user_id", "value_text", "commit_id"],
+    user_assertion_lifecycle_events: ["event_id", "assertion_id", "transaction_id", "field_name", "user_id", "commit_id", "event_kind"],
+    user_assertion_provenance: ["assertion_id", "commit_id"],
+    current_transaction_fields: ["transaction_id", "field_name", "value_text", "origin", "derived_assertion_id", "user_assertion_id", "projection_commit_id"],
     source_captures: ["account_no", "completeness_basis", "completeness_rule_version"],
     capture_scopes: ["scope_kind", "contract_fingerprint", "preflight_fingerprint", "completeness_rule_version"],
     source_record_scopes: ["source_record_id", "scope_id", "capture_id", "account_id", "sequence_lexeme"],
@@ -1121,8 +1204,9 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     for (const column of columns) if (!actual.has(column)) throw new Error(`Canonical schema v6 column ${table}.${column} is missing.`);
   }
   const requiredIndexes = [
-    "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof", "idx_assertion_lifecycle_scope",
+    "idx_canonical_commits_sequence", "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof", "idx_assertion_lifecycle_scope",
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
+    "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
     "idx_derived_scope_coordinates_lineage", "idx_derived_assertions_lineage", "idx_derived_assertion_provenance_run",
     "idx_derived_assertion_lifecycle_knowledge", "idx_user_assertion_lifecycle_knowledge", "idx_current_transaction_fields_projection",
     "idx_user_assertion_provenance_commit",
@@ -1136,6 +1220,13 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   }
   if (!/economic_status.*canceled.*refund.*reversal/i.test(tableSql("transaction_revisions")) || !/administrative_state.*deleted.*purged/i.test(tableSql("transaction_revisions"))) {
     throw new Error("Canonical schema v6 semantic constraints are missing.");
+  }
+  if (!/origin\s+TEXT\s+NOT NULL\s+CHECK\s*\(origin\s+IN\s*\('source','derived','user'\)\)/i.test(tableSql("assertions"))) {
+    throw new Error("Canonical schema v6 assertion origin taxonomy is missing.");
+  }
+  const transitionCheck = /event_kind\s+TEXT\s+NOT NULL\s+CHECK\s*\(event_kind\s+IN\s*\('observed','superseded','withdrawn'(?:,'restored')?\)\)/i;
+  if (!transitionCheck.test(tableSql("assertion_transitions")) || !transitionCheck.test(tableSql("derived_assertion_lifecycle_events")) || !transitionCheck.test(tableSql("user_assertion_lifecycle_events"))) {
+    throw new Error("Canonical schema v6 shared assertion transition taxonomy is missing.");
   }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
@@ -1250,10 +1341,12 @@ function insertLifecycleEvent(
   db: DatabaseSync,
   values: { assertionId: CanonicalId; transactionId: CanonicalId; revisionId: CanonicalId; captureId: CanonicalId; scopeId: CanonicalId | null; commitId: CanonicalId; kind: LifecycleEventKind },
 ): void {
-  db.prepare("INSERT INTO assertion_lifecycle_events(event_id, assertion_id, transaction_id, revision_id, capture_id, scope_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.revisionId, values.captureId, values.scopeId, values.commitId, values.kind);
+  const eventId = uuidV7();
+  db.prepare("INSERT INTO assertion_lifecycle_events(event_id, assertion_id, transaction_id, revision_id, capture_id, scope_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(eventId, values.assertionId, values.transactionId, values.revisionId, values.captureId, values.scopeId, values.commitId, values.kind);
+  db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, 'transaction_revision', ?, ?, NULL, NULL, NULL, ?, ?)").run(eventId, values.assertionId, values.transactionId, values.captureId, values.scopeId, values.commitId, values.kind);
 }
 function latestLifecycleEvent(db: DatabaseSync, assertionId: CanonicalId): LifecycleEventKind | null {
-  const row = db.prepare(`SELECT e.event_kind FROM assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+  const row = db.prepare(`SELECT e.event_kind FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
     WHERE e.assertion_id = ? ORDER BY c.commit_sequence DESC, e.event_id DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
   return row?.event_kind as LifecycleEventKind | null;
 }
@@ -1335,6 +1428,7 @@ function commitCathayDomesticDepositSyncOnce(
           observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "occurred", detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", detail.utcInstantUtcUs);
           assertionId = uuidV7();
           db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
+          db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, 'transaction_revision', 'transaction', 'source', ?, ?, ?, NULL, ?)").run(assertionId, transactionId, input.authorityRoute, input.authorityRoute, revisionId, commitId);
           insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: "observed" });
           db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id) VALUES (?, ?, ?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id, projection_commit_id = excluded.projection_commit_id, revision_commit_id = excluded.revision_commit_id").run(transactionId, revisionId, commitId, commitId, commitId);
         } else {
@@ -1342,7 +1436,7 @@ function commitCathayDomesticDepositSyncOnce(
           if (!assertion) throw new Error("Canonical assertion was not created.");
           assertionId = blob(dbRow<{ assertion_id: unknown }>(assertion).assertion_id);
           const wasWithdrawn = latestLifecycleEvent(db, assertionId) === "withdrawn";
-          insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: wasWithdrawn ? "restored" : "observed" });
+          if (wasWithdrawn) insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: "restored" });
           if (wasWithdrawn) {
             const revisionCommit = blob(dbRow<{ commit_id: unknown }>(db.prepare("SELECT commit_id FROM transaction_revisions WHERE revision_id = ?").get(revisionId)).commit_id);
             db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id) VALUES (?, ?, ?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id, projection_commit_id = excluded.projection_commit_id, revision_commit_id = excluded.revision_commit_id").run(transactionId, revisionId, commitId, commitId, revisionCommit);
@@ -1458,30 +1552,8 @@ export function commitCathayDomesticDepositSync(
 }
 
 function importCoordinates(input: CathayDerivedImportRunInput): CathayDerivedImportCoordinate[] {
-  if (input.complete === false) throw new Error("Derived import is partial; no canonical mutation was admitted.");
-  const structuredScope = [input.scope, input.outputScope].find((candidate): candidate is CathayDerivedImportScope => candidate !== undefined && !Array.isArray(candidate));
-  if (structuredScope) {
-    if (!Array.isArray(structuredScope.subjects) || !Array.isArray(structuredScope.fields) || structuredScope.subjects.length === 0 || structuredScope.fields.length === 0) throw new Error("A structured derived import scope requires subjects and fields.");
-    const expected = new Set<string>();
-    for (const subject of structuredScope.subjects) {
-      const transactionId = typeof subject === "string" ? subject : subject.kind === "transaction" ? subject.id : "";
-      if (!transactionId) throw new Error("Derived import scope contains a non-transaction subject.");
-      for (const field of structuredScope.fields) expected.add(`${transactionId}:${field}`);
-    }
-    const outputCandidates = [input.coordinates, input.outputs, input.scope, input.outputScope].filter((candidate): candidate is CathayDerivedImportCoordinate[] => Array.isArray(candidate));
-    const outputs = outputCandidates[0];
-    if (!outputs) throw new Error("A structured derived import scope requires output coordinates.");
-    const actual = new Set(outputs.map((coordinate) => `${coordinate.transactionId}:${coordinate.field}`));
-    if (expected.size !== actual.size || [...expected].some((key) => !actual.has(key))) throw new Error("Derived import output does not cover the complete declared scope.");
-    return normalizeDerivedCoordinates(outputs);
-  }
-  const candidates = [input.coordinates, input.outputs, input.scope, input.outputScope].filter((candidate): candidate is CathayDerivedImportCoordinate[] => Array.isArray(candidate));
-  if (candidates.length === 0) throw new Error("A complete derived import requires an explicit coordinate matrix.");
-  const first = candidates[0]!;
-  for (const candidate of candidates.slice(1)) {
-    if (JSON.stringify(candidate) !== JSON.stringify(first)) throw new Error("Derived import coordinate matrices disagree.");
-  }
-  return normalizeDerivedCoordinates(first);
+  if (!input.scope) throw new Error("A complete derived import requires an explicit coordinate matrix.");
+  return normalizeDerivedCoordinates(input.scope);
 }
 
 function normalizeDerivedCoordinates(first: CathayDerivedImportCoordinate[]): CathayDerivedImportCoordinate[] {
@@ -1501,6 +1573,7 @@ function normalizeDerivedCoordinates(first: CathayDerivedImportCoordinate[]): Ca
     if (seen.has(key)) throw new Error("Derived import coordinate matrix contains a duplicate subject/field.");
     seen.add(key);
   }
+  if (normalized.length === 0) throw new Error("A complete derived import requires a non-empty subject/field coordinate matrix.");
   return normalized;
 }
 
@@ -1508,7 +1581,7 @@ function validateDerivedImportInput(input: CathayDerivedImportRunInput): CathayD
   if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) throw new Error("Derived import Source Connection and Identity Epoch are required.");
   if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY || input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Derived import authority route or stream is not supported.");
   if (!input.producerId.trim() || !input.ruleLineage.trim()) throw new Error("Derived import producer and rule lineage are required.");
-  if (input.origin !== undefined && !input.origin.trim()) throw new Error("Derived import origin is required when supplied.");
+  if (input.origin !== undefined && input.origin !== CATHAY_DERIVED_ORIGIN) throw new Error("Derived import origin is not a registered Derived origin.");
   if (input.observedAt !== undefined) parseRfc3339UtcMicros(input.observedAt, "Derived import observedAt");
   return importCoordinates(input);
 }
@@ -1517,18 +1590,19 @@ function derivedDiagnostic(error: unknown, input: CathayDerivedImportRunInput, s
   return { kind: "derived-import-diagnostic", stage, reason: error instanceof Error ? error.message : String(error), producerId: input.producerId, ruleLineage: input.ruleLineage };
 }
 
-function insertDerivedLifecycleEvent(db: DatabaseSync, values: { assertionId: CanonicalId; transactionId: CanonicalId; field: CathayDerivedField; runId: CanonicalId; coordinateId: CanonicalId | null; commitId: CanonicalId; kind: "observed" | "superseded" | "withdrawn" | "restored" | "provenance_only" }): void {
+function insertDerivedLifecycleEvent(db: DatabaseSync, values: { assertionId: CanonicalId; transactionId: CanonicalId; field: CathayDerivedField; runId: CanonicalId; coordinateId: CanonicalId | null; commitId: CanonicalId; kind: "observed" | "superseded" | "withdrawn" | "restored" }): void {
   db.prepare("INSERT INTO derived_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, run_id, coordinate_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
+  db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, NULL, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
 }
 
 function latestDerivedLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
-  const row = db.prepare(`SELECT event_kind FROM derived_assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+  const row = db.prepare(`SELECT event_kind FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
     WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
   return row?.event_kind ?? null;
 }
 
 function latestUserLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
-  const row = db.prepare(`SELECT event_kind FROM user_assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+  const row = db.prepare(`SELECT event_kind FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
     WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
   return row?.event_kind ?? null;
 }
@@ -1541,9 +1615,9 @@ function insertCurrentDerivedField(db: DatabaseSync, transactionId: CanonicalId,
 }
 
 function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: CanonicalId, field: CathayDerivedField, commitId: CanonicalId): void {
-  const user = db.prepare(`SELECT ua.assertion_id, ua.value_text FROM user_assertions ua
-    JOIN user_assertion_lifecycle_events e ON e.assertion_id = ua.assertion_id
-    WHERE ua.transaction_id = ? AND ua.field_name = ?
+  const user = db.prepare(`SELECT a.assertion_id, a.value_text FROM assertions a
+    JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
+    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'user'
     AND e.event_kind NOT IN ('withdrawn','superseded')
     AND NOT EXISTS (SELECT 1 FROM user_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
       WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id)
@@ -1554,10 +1628,10 @@ function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: Can
       VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, String(user.value_text), blob(user.assertion_id), commitId);
     return;
   }
-  const derived = db.prepare(`SELECT da.assertion_id, da.value_text FROM derived_assertions da
-    JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
-    WHERE da.transaction_id = ? AND da.field_name = ? AND e.event_kind NOT IN ('withdrawn','superseded')
-    AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+  const derived = db.prepare(`SELECT a.assertion_id, a.value_text FROM assertions a
+    JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
+    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'derived' AND e.event_kind NOT IN ('withdrawn','superseded')
+    AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
       WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id)
         OR (nc.commit_sequence = (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) AND newer.rowid > e.rowid)))
     ORDER BY (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) DESC, e.rowid DESC LIMIT 1`).get(transactionId, field) as Record<string, unknown> | undefined;
@@ -1581,7 +1655,7 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
     const commitSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0) + 1;
     db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, 'derived_import')").run(commitId, commitSequence, recordedAtUtcUs(clock()), input.authorityRoute);
     const runId = uuidV7();
-    const origin = input.origin?.trim() || input.authorityRoute;
+    const origin = CATHAY_DERIVED_ORIGIN;
     db.prepare("INSERT INTO derived_import_runs(run_id, source_connection_id, identity_epoch_id, authority_route, stream, producer_id, origin, rule_lineage, observed_at, commit_id, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'complete')").run(runId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, input.producerId, origin, input.ruleLineage, input.observedAt ?? clock(), commitId);
     const assertionIds: string[] = [];
     for (const coordinate of coordinates) {
@@ -1609,17 +1683,19 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       }
       const value = coordinate.value!;
       let assertionId: CanonicalId;
-      let eventKind: "observed" | "superseded" | "restored" | "provenance_only" = "observed";
+      let eventKind: "observed" | "superseded" | "restored" | null = "observed";
       if (latest && String(latest.value_text) === value) {
         assertionId = blob(latest.assertion_id);
-        eventKind = latestDerivedLifecycle(db, assertionId) === "withdrawn" ? "restored" : "provenance_only";
+        eventKind = latestDerivedLifecycle(db, assertionId) === "withdrawn" ? "restored" : null;
       } else {
         assertionId = uuidV7();
         if (latest) insertDerivedLifecycleEvent(db, { assertionId: blob(latest.assertion_id), transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "superseded" });
         db.prepare("INSERT INTO derived_assertions(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage, value_text, run_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, value, runId, commitId);
+        db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'derived', ?, ?, NULL, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, input.ruleLineage, value, commitId);
       }
       db.prepare("INSERT INTO derived_assertion_provenance(assertion_id, run_id, coordinate_id, commit_id) VALUES (?, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
-      insertDerivedLifecycleEvent(db, { assertionId, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: eventKind });
+      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
+      if (eventKind) insertDerivedLifecycleEvent(db, { assertionId, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: eventKind });
       assertionIds.push(idToString(assertionId));
       if (existingCurrent?.origin !== "user") insertCurrentDerivedField(db, transactionId, coordinate.field, assertionId, value, commitId);
     }
@@ -1638,10 +1714,6 @@ export function commitCathayDerivedImportRun(ledgerDir: string, input: CathayDer
   const clock = options.clock ?? (() => new Date().toISOString());
   return withCanonicalWriter(ledgerDir, () => ({ status: "committed", ...commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, clock) }));
 }
-
-export const commitCathayImportRun = commitCathayDerivedImportRun;
-export const commitDerivedImportRun = commitCathayDerivedImportRun;
-export const commitCathayDerivedImport = commitCathayDerivedImportRun;
 
 export async function runCathayDerivedImportRun(ledgerDir: string, input: CathayDerivedImportRunInput, options: CathayDerivedImportOptions = {}): Promise<CathayDerivedImportResult> {
   let coordinates: CathayDerivedImportCoordinate[];
@@ -1690,16 +1762,21 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
         if (!prior) throw new Error("Cannot withdraw a user assertion that does not exist.");
         assertionId = blob(prior.assertion_id);
         db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
+        db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
       } else {
         const value = input.value ?? "";
         if (prior && String(prior.value_text) === value && latestUserLifecycle(db, blob(prior.assertion_id)) !== "withdrawn") {
           assertionId = blob(prior.assertion_id);
-          db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'provenance_only')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
         } else {
           assertionId = uuidV7();
-          if (prior) db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
+          if (prior) {
+            db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
+            db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
+          }
           db.prepare("INSERT INTO user_assertions(assertion_id, transaction_id, field_name, user_id, value_text, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
+          db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'user', ?, 'user/local', NULL, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
           db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
+          db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
         }
       }
       if (withdrawn) {
@@ -1709,6 +1786,7 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
       else db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
         VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, input.value ?? "", assertionId, commitId);
       db.prepare("INSERT OR IGNORE INTO user_assertion_provenance(assertion_id, commit_id) VALUES (?, ?)").run(assertionId, commitId);
+      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, NULL, NULL, ?)").run(assertionId, commitId);
       db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
       db.exec("COMMIT"); inTransaction = false;
       return { status: "committed", assertionId: idToString(assertionId), commitSequence, field, withdrawn };
@@ -1716,10 +1794,6 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
     finally { db.close(); }
   });
 }
-
-export const setCathayUserAssertion = commitCathayUserAssertion;
-export const commitCathayUserTransactionAssertion = commitCathayUserAssertion;
-export const commitCathayUserAssertionAction = commitCathayUserAssertion;
 
 function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }
 function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction {
@@ -1751,17 +1825,17 @@ function selectedCurrentField(db: DatabaseSync, transactionId: unknown, field: C
 }
 
 function selectedHistoricalField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number): { value: string; origin: "derived" | "user"; commitSequence: number } | undefined {
-  const user = db.prepare(`SELECT ua.value_text, c.commit_sequence FROM user_assertions ua JOIN user_assertion_lifecycle_events e ON e.assertion_id = ua.assertion_id
+  const user = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
     JOIN canonical_commits c ON c.commit_id = e.commit_id
-    WHERE ua.transaction_id = ? AND ua.field_name = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
-      AND NOT EXISTS (SELECT 1 FROM user_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'user' AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+      AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
         WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
     ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
   if (user) return { value: String(user.value_text), origin: "user", commitSequence: Number(user.commit_sequence) };
-  const derived = db.prepare(`SELECT da.value_text, c.commit_sequence FROM derived_assertions da JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
+  const derived = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
     JOIN canonical_commits c ON c.commit_id = e.commit_id
-    WHERE da.transaction_id = ? AND da.field_name = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
-      AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'derived' AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+      AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
         WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
     ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
   return derived ? { value: String(derived.value_text), origin: "derived", commitSequence: Number(derived.commit_sequence) } : undefined;
@@ -1805,7 +1879,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence,
-        COALESCE((SELECT CASE WHEN lifecycle.event_kind = 'withdrawn' THEN 'withdrawn' ELSE 'supported' END FROM assertion_lifecycle_events lifecycle
+        COALESCE((SELECT CASE WHEN lifecycle.event_kind = 'withdrawn' THEN 'withdrawn' ELSE 'supported' END FROM assertion_transitions lifecycle
           JOIN canonical_commits lifecycle_commit ON lifecycle_commit.commit_id = lifecycle.commit_id
           WHERE lifecycle.assertion_id = sa.assertion_id AND lifecycle_commit.commit_sequence <= ?
           ORDER BY lifecycle_commit.commit_sequence DESC, lifecycle.event_id DESC LIMIT 1), 'supported') AS assertion_support_state
@@ -1840,7 +1914,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         const provenance = db.prepare(`SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId FROM assertion_provenance p
           JOIN source_records sr ON sr.source_record_id = p.source_record_id WHERE p.assertion_id = ? ORDER BY p.source_record_id`).all(assertionId) as Record<string, unknown>[];
         const lifecycleEvents = db.prepare(`SELECT e.event_id, e.event_kind, c.commit_sequence, cs.scope_id, cs.completeness, cs.absence_authority, cs.contract_fingerprint, cs.page_count
-          FROM assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+          FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
           LEFT JOIN capture_scopes cs ON cs.scope_id = e.scope_id WHERE e.assertion_id = ? ORDER BY c.commit_sequence, e.event_id`).all(assertionId) as Record<string, unknown>[];
         const derivedRows = db.prepare(`SELECT da.assertion_id, da.field_name, da.producer_id, da.origin, da.rule_lineage, da.value_text, da.run_id, c.commit_sequence
           FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
@@ -1862,12 +1936,12 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           })),
           derivedAssertions: derivedRows.map((derived) => {
             const derivedAssertionId = blob(derived.assertion_id);
-            const provenanceRows = db.prepare("SELECT run_id, coordinate_id FROM derived_assertion_provenance WHERE assertion_id = ? ORDER BY run_id, coordinate_id").all(derivedAssertionId) as Record<string, unknown>[];
+            const provenanceRows = db.prepare("SELECT run_id, coordinate_id FROM assertion_provenance WHERE assertion_id = ? AND run_id IS NOT NULL ORDER BY run_id, coordinate_id").all(derivedAssertionId) as Record<string, unknown>[];
             return { id: idToString(derivedAssertionId), field: derived.field_name as CathayDerivedField, producerId: String(derived.producer_id), origin: String(derived.origin), ruleLineage: String(derived.rule_lineage), value: String(derived.value_text), state: latestDerivedLifecycle(db, derivedAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(derived.commit_sequence), runId: idToString(derived.run_id), provenance: provenanceRows.map((provenanceRow) => ({ runId: idToString(provenanceRow.run_id), coordinateId: idToString(provenanceRow.coordinate_id) })) };
           }),
           userAssertions: userRows.map((user) => {
             const userAssertionId = blob(user.assertion_id);
-            const userProvenance = db.prepare(`SELECT c.commit_sequence FROM user_assertion_provenance p JOIN canonical_commits c ON c.commit_id = p.commit_id WHERE p.assertion_id = ? ORDER BY c.commit_sequence`).all(userAssertionId) as Array<Record<string, unknown>>;
+            const userProvenance = db.prepare(`SELECT c.commit_sequence FROM assertion_provenance p JOIN canonical_commits c ON c.commit_id = p.commit_id WHERE p.assertion_id = ? ORDER BY c.commit_sequence`).all(userAssertionId) as Array<Record<string, unknown>>;
             return { id: idToString(userAssertionId), field: user.field_name as CathayUserAssertionField, userId: String(user.user_id), value: String(user.value_text), state: latestUserLifecycle(db, userAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(user.commit_sequence), provenance: userProvenance.map((item) => ({ commitSequence: Number(item.commit_sequence) })) };
           }),
         } satisfies CathayCanonicalLineageEntry;

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1567,7 +1567,7 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     const generationSwitchCommit = existingGeneration?.switched_commit_id
       ? blob(existingGeneration.switched_commit_id)
       : latestCommit;
-    if (!generationExists) {
+    if (!generationExists && latestCommit) {
       db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
       VALUES (1, 'active', ?, 'canonical/projection/v1', ?, ?, ?)`).run(latestSequence, latestCommit ?? null, latestCommit ?? null, latestCommit ?? null);
       db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
@@ -1582,9 +1582,9 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     if (existingGeneration && existingPointer && !canonicalIdsEqual(existingPointer.switched_commit_id, generationSwitchCommit)) {
       throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
     }
-    db.prepare(`INSERT INTO active_projection_generation(singleton_id, generation_id, switched_commit_id)
-      VALUES (1, 1, ?) ON CONFLICT(singleton_id) DO UPDATE SET generation_id = excluded.generation_id, switched_commit_id = excluded.switched_commit_id`).run(generationSwitchCommit ?? null);
     if (generationSwitchCommit) {
+      db.prepare(`INSERT INTO active_projection_generation(singleton_id, generation_id, switched_commit_id)
+        VALUES (1, 1, ?) ON CONFLICT(singleton_id) DO UPDATE SET generation_id = excluded.generation_id, switched_commit_id = excluded.switched_commit_id`).run(generationSwitchCommit);
       recordProjectionGenerationEventIfMissing(db, 1, "created", "migration", generationSwitchCommit);
       recordProjectionGenerationEventIfMissing(db, 1, "validated", "migration", generationSwitchCommit);
       recordProjectionGenerationEventIfMissing(db, 1, "switched", "migration", generationSwitchCommit);
@@ -1664,12 +1664,35 @@ function projectionGenerationEventDigest(values: {
     .digest();
 }
 
-function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): void {
+function ensureProjectionGenerationProvenanceTriggers(db: DatabaseSync): void {
+  db.exec(`DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
+    DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
+    CREATE TRIGGER trg_projection_generation_provenance_no_update
+    BEFORE UPDATE ON projection_generation_provenance
+    BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
+    CREATE TRIGGER trg_projection_generation_provenance_no_delete
+    BEFORE DELETE ON projection_generation_provenance
+    BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;`);
+}
+
+function validateProjectionGenerationProvenanceTriggers(db: DatabaseSync): void {
+  const rows = db.prepare(`SELECT name, sql FROM sqlite_master
+    WHERE type = 'trigger' AND name IN ('trg_projection_generation_provenance_no_update', 'trg_projection_generation_provenance_no_delete')`).all() as Array<{ name?: string; sql?: string }>;
+  if (rows.length !== 2
+    || rows.some((row) => !/projection_generation_provenance/i.test(String(row.sql))
+      || !/BEFORE\s+(UPDATE|DELETE)\s+ON\s+projection_generation_provenance/i.test(String(row.sql))
+      || !/append-only/i.test(String(row.sql)))) {
+    throw new Error("Canonical v7 projection provenance append-only triggers are missing or invalid.");
+  }
+}
+
+function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): boolean {
   const columns = new Set((db.prepare("PRAGMA table_info(projection_generation_provenance)").all() as Array<{ name?: string }>).map((column) => String(column.name)));
   const required = ["ordinal", "previous_event_id", "event_digest"];
   if (!required.some((column) => !columns.has(column))) {
     db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_ordinal ON projection_generation_provenance(generation_id, ordinal); CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_semantic ON projection_generation_provenance(generation_id, event_kind, event_source, commit_id);");
-    return;
+    ensureProjectionGenerationProvenanceTriggers(db);
+    return false;
   }
 
   // v7 databases created before the chain fields are upgraded in the same
@@ -1731,6 +1754,8 @@ function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): void {
   }
   db.exec("DROP TABLE projection_generation_provenance_legacy");
   db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_ordinal ON projection_generation_provenance(generation_id, ordinal); CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_semantic ON projection_generation_provenance(generation_id, event_kind, event_source, commit_id);");
+  ensureProjectionGenerationProvenanceTriggers(db);
+  return true;
 }
 
 function recordProjectionGenerationEvent(
@@ -1762,29 +1787,122 @@ function recordProjectionGenerationEventIfMissing(
   recordProjectionGenerationEvent(db, generationId, eventKind, eventSource, commitId);
 }
 
+/** Complete a legacy chain only while its pre-chain table is being upgraded.
+ * The generation state and immutable canonical commits provide the missing
+ * phases; the resulting ordinals, links, and digests are rebuilt as one
+ * migration operation. Current chains are never repaired on ordinary startup.
+ */
+function rebuildLegacyProjectionProvenanceChains(db: DatabaseSync): void {
+  const generations = db.prepare(`SELECT generation_id, status, build_cutoff_commit_sequence,
+      created_commit_id, validated_commit_id, switched_commit_id
+    FROM projection_generations ORDER BY generation_id`).all() as Array<Record<string, unknown>>;
+  const events = db.prepare(`SELECT rowid AS row_id, event_id, generation_id, event_kind, event_source, commit_id
+    FROM projection_generation_provenance ORDER BY generation_id, rowid`).all() as Array<Record<string, unknown>>;
+  const commitInfo = (commitId: CanonicalId): { sequence: number; kind: string } => {
+    const row = db.prepare("SELECT commit_sequence, commit_kind FROM canonical_commits WHERE commit_id = ?").get(commitId) as { commit_sequence?: number; commit_kind?: string } | undefined;
+    if (!row) throw new Error("Legacy projection provenance references an unknown commit.");
+    return { sequence: Number(row.commit_sequence), kind: String(row.commit_kind) };
+  };
+  const inferSource = (commitId: CanonicalId): ProjectionGenerationEventSource => commitInfo(commitId).kind === "projection_rebuild" ? "rebuild" : "migration";
+  const planned = new Map<number, Array<{ eventId: CanonicalId; eventKind: ProjectionGenerationEventKind; eventSource: ProjectionGenerationEventSource; commitId: CanonicalId; sequence: number }>>();
+  for (const generation of generations) {
+    const generationId = Number(generation.generation_id);
+    const generationEvents = events.filter((event) => Number(event.generation_id) === generationId);
+    const phases = new Map<ProjectionGenerationEventKind, Record<string, unknown>>();
+    for (const event of generationEvents) {
+      const kind = String(event.event_kind) as ProjectionGenerationEventKind;
+      if (!(kind === "created" || kind === "validated" || kind === "switched" || kind === "knowledge")) throw new Error("Legacy projection provenance has an unknown phase.");
+      if (kind !== "knowledge" && phases.has(kind)) throw new Error("Legacy projection provenance has duplicate generation phases.");
+      if (kind !== "knowledge") phases.set(kind, event);
+    }
+    const required = generation.status === "building" ? ["created"]
+      : generation.status === "validated" ? ["created", "validated"] : ["created", "validated", "switched"];
+    const stateCommit: Record<string, unknown> = {
+      created: generation.created_commit_id,
+      validated: generation.validated_commit_id,
+      switched: generation.switched_commit_id,
+    };
+    const rows: Array<{ eventId: CanonicalId; eventKind: ProjectionGenerationEventKind; eventSource: ProjectionGenerationEventSource; commitId: CanonicalId; sequence: number }> = [];
+    const existingPhaseSources = [...phases.values()].map((event) => String(event.event_source) as ProjectionGenerationEventSource);
+    if (new Set(existingPhaseSources).size > 1) throw new Error("Legacy projection phase sources are inconsistent.");
+    let phaseSource: ProjectionGenerationEventSource | undefined = existingPhaseSources[0];
+    let phaseCommit: CanonicalId | undefined;
+    for (const phaseName of required as ProjectionGenerationEventKind[]) {
+      const commitValue = stateCommit[phaseName];
+      if (commitValue === null || commitValue === undefined) throw new Error(`Legacy projection generation ${generationId} is missing its ${phaseName} commit.`);
+      const commitId = blob(commitValue);
+      const existing = phases.get(phaseName);
+      if (existing && !canonicalIdsEqual(existing.commit_id, commitId)) throw new Error(`Legacy projection ${phaseName} phase disagrees with generation state.`);
+      const eventSource: ProjectionGenerationEventSource = existing ? String(existing.event_source) as ProjectionGenerationEventSource : (phaseSource ?? inferSource(commitId));
+      if (!(eventSource === "migration" || eventSource === "rebuild" || eventSource === "routine")) throw new Error("Legacy projection phase source is invalid.");
+      if (phaseSource && phaseSource !== eventSource) throw new Error("Legacy projection phase sources are inconsistent.");
+      if (phaseCommit && !canonicalIdsEqual(phaseCommit, commitId)) throw new Error("Legacy projection phase commits are inconsistent.");
+      phaseSource = eventSource;
+      phaseCommit = commitId;
+      const info = commitInfo(commitId);
+      rows.push({ eventId: existing ? blob(existing.event_id) : uuidV7(), eventKind: phaseName, eventSource, commitId, sequence: info.sequence });
+    }
+    if (generation.status === "building" && generationEvents.some((event) => event.event_kind !== "created")) throw new Error("Legacy building projection generation has unexpected phases.");
+    const switched = rows.find((row) => row.eventKind === "switched");
+    const switchedSequence = switched?.sequence ?? Number.POSITIVE_INFINITY;
+    const cutoff = Number(generation.build_cutoff_commit_sequence ?? -1);
+    const knowledge = generationEvents.filter((event) => event.event_kind === "knowledge").map((event) => {
+      const commitId = blob(event.commit_id);
+      const info = commitInfo(commitId);
+      return { eventId: blob(event.event_id), eventKind: "knowledge" as const, eventSource: String(event.event_source) as ProjectionGenerationEventSource, commitId, sequence: info.sequence };
+    });
+    const knowledgeKeys = new Set<string>();
+    for (const event of knowledge) {
+      const key = event.commitId.toString("hex");
+      if (knowledgeKeys.has(key)) throw new Error("Legacy projection provenance has duplicate knowledge events.");
+      knowledgeKeys.add(key);
+      if (event.sequence <= switchedSequence && event.sequence <= cutoff) throw new Error("Legacy projection knowledge event precedes its switch boundary.");
+      if (event.sequence > cutoff) throw new Error("Legacy projection knowledge event exceeds its generation cutoff.");
+      rows.push(event);
+    }
+    if (switched) {
+      const expected = (db.prepare(`SELECT commit_id, commit_sequence, commit_kind FROM canonical_commits
+        WHERE commit_sequence > ? AND commit_sequence <= ? AND commit_kind <> 'projection_rebuild' ORDER BY commit_sequence`).all(switched.sequence, cutoff) as Array<Record<string, unknown>>)
+        .filter((commit) => canonicalCommitHasEvidence(db, String(commit.commit_kind), blob(commit.commit_id)));
+      for (const commit of expected) {
+        const commitId = blob(commit.commit_id);
+        const key = commitId.toString("hex");
+        if (knowledgeKeys.has(key)) continue;
+        knowledgeKeys.add(key);
+        rows.push({ eventId: uuidV7(), eventKind: "knowledge", eventSource: "routine", commitId, sequence: Number(commit.commit_sequence) });
+      }
+    }
+    rows.sort((left, right) => left.eventKind === "knowledge" && right.eventKind !== "knowledge" ? 1
+      : left.eventKind !== "knowledge" && right.eventKind === "knowledge" ? -1
+        : left.eventKind === "knowledge" && right.eventKind === "knowledge" ? left.sequence - right.sequence : PROJECTION_GENERATION_EVENT_ORDER[left.eventKind] - PROJECTION_GENERATION_EVENT_ORDER[right.eventKind]);
+    planned.set(generationId, rows);
+  }
+  db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; DELETE FROM projection_generation_provenance");
+  const insert = db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
+  for (const [generationId, rows] of planned) {
+    let previous: CanonicalId | null = null;
+    for (let index = 0; index < rows.length; index += 1) {
+      const row = rows[index]!;
+      const ordinal = index + 1;
+      insert.run(row.eventId, generationId, ordinal, previous, row.eventKind, row.eventSource, row.commitId,
+        projectionGenerationEventDigest({ generationId, ordinal, eventKind: row.eventKind, eventSource: row.eventSource, commitId: row.commitId, previousEventId: previous }));
+      previous = row.eventId;
+    }
+  }
+  ensureProjectionGenerationProvenanceTriggers(db);
+}
+
 /** Existing v7 databases predate the typed provenance tables. Backfill only
  * from persisted generation/current rows; no synthetic canonical commit is
  * created, and all future changes use append-only events. */
 function backfillProjectionProvenance(db: DatabaseSync): void {
-  ensureProjectionGenerationProvenanceSchema(db);
+  const upgradedLegacy = ensureProjectionGenerationProvenanceSchema(db);
+  if (upgradedLegacy) rebuildLegacyProjectionProvenanceChains(db);
   const generations = db.prepare(`SELECT generation_id, created_commit_id, validated_commit_id, switched_commit_id
     FROM projection_generations ORDER BY generation_id`).all() as Array<Record<string, unknown>>;
   for (const generation of generations) {
     const generationId = Number(generation.generation_id);
-    const created = generation.created_commit_id ? blob(generation.created_commit_id) : undefined;
-    const validated = generation.validated_commit_id ? blob(generation.validated_commit_id) : undefined;
-    const switched = generation.switched_commit_id ? blob(generation.switched_commit_id) : undefined;
-    const eventSource = (commitId: CanonicalId): ProjectionGenerationEventSource => {
-      const kind = String((db.prepare("SELECT commit_kind FROM canonical_commits WHERE commit_id = ?").get(commitId) as { commit_kind?: unknown } | undefined)?.commit_kind ?? "");
-      return kind === "projection_rebuild" ? "rebuild" : "migration";
-    };
-    const backfillPhase = (eventKind: ProjectionGenerationEventKind, commitId: CanonicalId | undefined): void => {
-      if (!commitId || db.prepare("SELECT 1 FROM projection_generation_provenance WHERE generation_id = ? AND event_kind = ?").get(generationId, eventKind)) return;
-      db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id) VALUES (?, ?, ?, ?, ?)`).run(uuidV7(), generationId, eventKind, eventSource(commitId), commitId);
-    };
-    backfillPhase("created", created);
-    backfillPhase("validated", validated);
-    backfillPhase("switched", switched);
     const selectionCount = Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transaction_selection WHERE generation_id = ?").get(generationId) as { count?: number }).count ?? 0);
     if (selectionCount === 0) {
       db.prepare(`INSERT INTO projection_generation_transaction_selection(generation_id, transaction_id, revision_id, selection_commit_id, selection_kind)
@@ -2020,7 +2138,7 @@ function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: 
   const invalidProvenance = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transaction_fields field
     JOIN projection_generations generation ON generation.generation_id = field.generation_id
     JOIN assertions assertion ON assertion.assertion_id = CASE WHEN field.origin = 'derived' THEN field.derived_assertion_id ELSE field.user_assertion_id END
-    JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
+    LEFT JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
     JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
     WHERE field.generation_id = ? AND provenance_commit.commit_sequence <= generation.build_cutoff_commit_sequence AND (
       (assertion.origin = 'user' AND provenance_commit.authority_route = 'user/local'
@@ -2048,6 +2166,48 @@ function canonicalCommitHasEvidence(db: DatabaseSync, commitKind: string, commit
       WHERE origin = 'user' AND created_commit_id = ?
       UNION ALL SELECT 1 FROM assertion_transitions WHERE user_id IS NOT NULL AND commit_id = ? LIMIT 1`).get(commitId, commitId));
   return false;
+}
+
+function validateUserAssertionProvenanceAuthority(db: DatabaseSync): void {
+  const invalid = Number((db.prepare(`SELECT COUNT(*) AS count
+    FROM assertions assertion
+    JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
+    LEFT JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+    WHERE assertion.origin = 'user' AND (
+      provenance.source_record_id IS NOT NULL OR provenance.run_id IS NOT NULL OR provenance.coordinate_id IS NOT NULL
+      OR provenance.commit_id IS NULL
+      OR provenance_commit.commit_id IS NULL
+      OR provenance_commit.commit_kind <> 'user_assertion'
+      OR provenance_commit.authority_route <> 'user/local'
+      OR EXISTS (SELECT 1 FROM source_captures capture WHERE capture.commit_id = provenance.commit_id)
+      OR EXISTS (SELECT 1 FROM derived_import_runs run WHERE run.commit_id = provenance.commit_id)
+      OR NOT EXISTS (SELECT 1 FROM assertions created
+        WHERE created.assertion_id = assertion.assertion_id AND created.origin = 'user' AND created.created_commit_id = provenance.commit_id)
+      AND NOT EXISTS (SELECT 1 FROM assertion_transitions transition
+        WHERE transition.assertion_id = assertion.assertion_id AND transition.user_id IS NOT NULL AND transition.commit_id = provenance.commit_id)
+    )`).get() as { count?: number }).count ?? 0);
+  if (invalid !== 0) throw new Error("Canonical user assertion provenance authority is invalid.");
+}
+
+const CANONICAL_EMPTY_STORE_TABLES = [
+  "canonical_commits", "source_authority_routes", "source_connections", "identity_epochs",
+  "source_captures", "source_records", "source_record_scopes", "financial_accounts",
+  "financial_transactions", "transaction_revisions", "transaction_time_observations",
+  "assertions", "assertion_transitions", "assertion_provenance", "source_sync_states",
+  "current_transactions", "current_projection_state", "capture_scopes", "capture_scope_pages",
+  "derived_import_runs", "derived_scope_coordinates", "derived_assertion_provenance",
+  "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "user_assertion_provenance",
+  "current_transaction_fields", "projection_generations", "projection_generation_provenance",
+  "active_projection_generation", "projection_generation_transactions",
+  "projection_generation_transaction_selection", "projection_generation_transaction_fields",
+] as const;
+
+/** A fresh store is intentionally queryable before its first canonical commit.
+ * Every evidence and projection relation must be empty together; accepting a
+ * subset would turn a damaged initialization into a silently empty ledger. */
+function validateEmptyCanonicalStore(db: DatabaseSync): void {
+  const nonEmpty = CANONICAL_EMPTY_STORE_TABLES.filter((table) => Number((db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count?: number }).count ?? 0) !== 0);
+  if (nonEmpty.length !== 0) throw new Error(`Canonical empty store is partial: ${nonEmpty.join(", ")}.`);
 }
 
 function validateProjectionGenerationChain(db: DatabaseSync, generationId: number): Array<{ event_kind?: string; event_source?: string; commit_id?: unknown; commit_sequence?: number }> {
@@ -2202,6 +2362,11 @@ function rejectStrayProjectionGenerations(db: DatabaseSync): void {
  * names a row, but cannot prove that the row is the sole active generation or
  * that all knowledge-state commits agree. */
 function validateActiveProjectionBoundary(db: DatabaseSync): number {
+  const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
+  if (commitCount === 0) {
+    validateEmptyCanonicalStore(db);
+    return 0;
+  }
   const pointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
   if (!pointer) throw new Error("Canonical v7 active projection pointer is missing.");
   const activeRows = db.prepare("SELECT generation_id, switched_commit_id, build_cutoff_commit_sequence FROM projection_generations WHERE status = 'active'").all() as Array<{ generation_id?: number; switched_commit_id?: unknown; build_cutoff_commit_sequence?: number }>;
@@ -2209,27 +2374,20 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
   const active = activeRows[0]!;
   const generationId = Number(active.generation_id ?? 0);
   if (generationId <= 0 || Number(pointer.generation_id ?? 0) !== generationId) throw new Error("Canonical v7 active projection pointer does not target the sole active generation.");
-  const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
   const stateRows = db.prepare("SELECT generation, commit_id FROM current_projection_state").all() as Array<{ generation?: number; commit_id?: unknown }>;
-  if (commitCount === 0) {
-    if (pointer.switched_commit_id !== null && pointer.switched_commit_id !== undefined) throw new Error("Canonical v7 empty projection has an unexpected switch commit.");
-    if (active.switched_commit_id !== null && active.switched_commit_id !== undefined) throw new Error("Canonical v7 empty generation has an unexpected switch commit.");
-    if (stateRows.length !== 0) throw new Error("Canonical v7 empty projection has an unexpected knowledge state.");
-  } else {
-    if (pointer.switched_commit_id === null || pointer.switched_commit_id === undefined
-      || active.switched_commit_id === null || active.switched_commit_id === undefined) {
-      throw new Error("Canonical v7 active projection switch commit is missing.");
-    }
-    if (!canonicalIdsEqual(pointer.switched_commit_id, active.switched_commit_id)) throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
-    if (!db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id))) throw new Error("Canonical v7 active projection pointer references no commit.");
-    if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1
-      || stateRows[0]!.commit_id === null || stateRows[0]!.commit_id === undefined
-      || !db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id))) {
-      throw new Error("Canonical v7 active projection knowledge state is missing or invalid.");
-    }
-    const knowledgeSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id)) as { commit_sequence?: number } | undefined)?.commit_sequence ?? -1);
-    if (knowledgeSequence < Number(active.build_cutoff_commit_sequence ?? 0)) throw new Error("Canonical v7 active projection knowledge precedes its cutoff.");
+  if (pointer.switched_commit_id === null || pointer.switched_commit_id === undefined
+    || active.switched_commit_id === null || active.switched_commit_id === undefined) {
+    throw new Error("Canonical v7 active projection switch commit is missing.");
   }
+  if (!canonicalIdsEqual(pointer.switched_commit_id, active.switched_commit_id)) throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
+  if (!db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id))) throw new Error("Canonical v7 active projection pointer references no commit.");
+  if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1
+    || stateRows[0]!.commit_id === null || stateRows[0]!.commit_id === undefined
+    || !db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id))) {
+    throw new Error("Canonical v7 active projection knowledge state is missing or invalid.");
+  }
+  const knowledgeSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id)) as { commit_sequence?: number } | undefined)?.commit_sequence ?? -1);
+  if (knowledgeSequence < Number(active.build_cutoff_commit_sequence ?? 0)) throw new Error("Canonical v7 active projection knowledge precedes its cutoff.");
   validateProjectionGenerationProvenance(db, generationId);
   validateGenerationExactAmounts(db, generationId);
   validateCathayAuthorityRoute(db, generationId);
@@ -2238,6 +2396,7 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
   validateGenerationFieldCompleteness(db, generationId, activeCutoff);
   validateGenerationFieldIntegrity(db, generationId);
   validateGenerationLifecycleCoordinates(db, generationId);
+  validateUserAssertionProvenanceAuthority(db);
   return generationId;
 }
 
@@ -2422,6 +2581,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   }
   const triggerRows = db.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name IN ('trg_current_transaction_fields_origin_insert', 'trg_current_transaction_fields_origin_update')").all() as Array<{ name?: string; sql?: string }>;
   if (triggerRows.length !== 2 || triggerRows.some((row) => !/assertions/i.test(String(row.sql)))) throw new Error("Canonical v6 current projection origin triggers are missing.");
+  validateProjectionGenerationProvenanceTriggers(db);
   const invalidProjectionRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM current_transaction_fields field
     LEFT JOIN assertions derived ON derived.assertion_id = field.derived_assertion_id
     LEFT JOIN assertions user_assertion ON user_assertion.assertion_id = field.user_assertion_id
@@ -2449,6 +2609,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
   rejectStrayProjectionGenerations(db);
   const validatedActiveGenerationId = validateActiveProjectionBoundary(db);
+  if (validatedActiveGenerationId === 0) return;
   const activePointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
   if (!activePointer) throw new Error("Canonical v7 active projection pointer is missing.");
   const activeGenerationId = validatedActiveGenerationId;
@@ -2793,6 +2954,7 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     validateCathayAuthorityRoute(db, generation);
     validateGenerationFieldIntegrity(db, generation);
     validateGenerationLifecycleCoordinates(db, generation);
+    validateUserAssertionProvenanceAuthority(db);
     const duplicate = Number((db.prepare(`SELECT COUNT(*) AS count FROM (SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ? GROUP BY transaction_id HAVING COUNT(*) <> 1)`).get(generation) as { count?: number }).count ?? 0);
     if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
     rebuildFailure(options.injectFailure, ["validation", "after-validation"]);
@@ -2998,8 +3160,18 @@ function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: Can
  * This helper is called before every routine commit's COMMIT, so no reader can
  * observe evidence from one commit with projection rows from another. */
 function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommitId: CanonicalId): void {
-  const pointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
-  if (!pointer) throw new Error("Canonical active projection pointer is missing during routine write.");
+  let pointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
+  const createdGeneration = !pointer;
+  if (!pointer) {
+    const commitSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(projectionCommitId) as { commit_sequence?: number } | undefined)?.commit_sequence ?? 0);
+    db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
+      VALUES (1, 'active', ?, 'canonical/projection/v1', ?, ?, ?)`).run(commitSequence, projectionCommitId, projectionCommitId, projectionCommitId);
+    db.prepare("INSERT INTO active_projection_generation(singleton_id, generation_id, switched_commit_id) VALUES (1, 1, ?)").run(projectionCommitId);
+    recordProjectionGenerationEvent(db, 1, "created", "routine", projectionCommitId);
+    recordProjectionGenerationEvent(db, 1, "validated", "routine", projectionCommitId);
+    recordProjectionGenerationEvent(db, 1, "switched", "routine", projectionCommitId);
+    pointer = { generation_id: 1 };
+  }
   const generationId = Number(pointer.generation_id);
   const generation = db.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(generationId) as { status?: string } | undefined;
   if (!generation || generation.status !== "active") throw new Error("Canonical active projection generation is not writable.");
@@ -3024,7 +3196,7 @@ function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommi
     FROM current_transactions current_row JOIN projection_generations generation ON generation.generation_id = ?`).run(generationId, generationId);
   db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
     SELECT ?, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run(generationId);
-  if (!initializesGeneration) recordProjectionGenerationEvent(db, generationId, "knowledge", "routine", projectionCommitId);
+  if (!initializesGeneration && !createdGeneration) recordProjectionGenerationEvent(db, generationId, "knowledge", "routine", projectionCommitId);
 }
 
 function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock, runtime?: CanonicalRuntimeOptions): { runId: string; commitSequence: number; assertionIds: string[] } {
@@ -3280,6 +3452,9 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     try {
       return withCanonicalSnapshot(db, () => {
       const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
+      if (Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0) === 0) {
+        return { status: "ok", kind: "current", accounts: [], transactions: [], commitSequence: 0 } satisfies CathayCanonicalCurrentQueryResult;
+      }
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -8,7 +8,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 4;
+export const CANONICAL_SCHEMA_VERSION = 5;
 export const CATHAY_POSTING_MAPPING = {
   contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   postingStatus: "posted",
@@ -46,7 +46,7 @@ export type CathayDomesticDepositCaptureInput = {
   absenceAuthority?: CathayAbsenceAuthority;
 };
 
-export type CathayAbsenceAuthority = "comparable-complete-range" | "tombstone";
+export type CathayAbsenceAuthority = "comparable-complete-range";
 export type CathayTransportCheckpoint = {
   kind: "transport-progress";
   ordinal: number;
@@ -428,7 +428,9 @@ function validateSyncInput(input: CathayDomesticDepositSyncInput): ValidatedCath
     const sequences = new Set<string>();
     let expectedRequestToken: string | null = null;
     let absenceAuthority = first.absenceAuthority;
+    if ((first.absenceAuthority as string | undefined) === "tombstone") throw new Error("Cathay tombstone authority is unsupported without a source-validated tombstone record.");
     for (const [index, page] of pages.entries()) {
+      if ((page.absenceAuthority as string | undefined) === "tombstone") throw new Error("Cathay tombstone authority is unsupported without a source-validated tombstone record.");
       if (page.pageOrdinal !== index) throw new Error("Cathay staged pages must have contiguous ordinals starting at zero.");
       if (page.scope.startDate !== startDate || page.scope.endDate !== endDate) throw new Error("Cathay page scope drifted within one account.");
       if (page.contractFingerprint !== first.contractFingerprint || page.preflightFingerprint !== first.preflightFingerprint) throw new Error("Cathay page contract or preflight fingerprint drifted.");
@@ -517,14 +519,14 @@ CREATE TABLE IF NOT EXISTS identity_epochs (
 CREATE TABLE IF NOT EXISTS source_captures (
   capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
   identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
-  stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
+  stream TEXT NOT NULL, account_no TEXT, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
   completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),
   completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 CREATE TABLE IF NOT EXISTS source_records (
   source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, description TEXT,
-  payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)
+  payload_json TEXT NOT NULL, UNIQUE(source_record_id, capture_id)
 );
 CREATE TABLE IF NOT EXISTS financial_accounts (
   account_id BLOB PRIMARY KEY CHECK(length(account_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
@@ -544,6 +546,9 @@ CREATE TABLE IF NOT EXISTS transaction_revisions (
   direction TEXT NOT NULL CHECK(direction IN ('inflow','outflow')), posting_status TEXT NOT NULL CHECK(posting_status IN ('pending','posted')),
   posting_origin TEXT NOT NULL CHECK(posting_origin = 'provider_booked_history'), posting_basis TEXT NOT NULL CHECK(posting_basis = 'query-status-success-with-accounting-date'),
   posting_rule_version TEXT NOT NULL CHECK(posting_rule_version = 'cathay/domestic-deposit/v1'), description TEXT,
+  economic_status TEXT NOT NULL CHECK(economic_status IN ('normal','canceled','refund','reversal')),
+  administrative_state TEXT NOT NULL CHECK(administrative_state IN ('active','deleted','purged')),
+  semantic_rule_version TEXT NOT NULL CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1'),
   effective_on TEXT NOT NULL, transaction_date_time_local TEXT NOT NULL, time_zone TEXT NOT NULL,
   time_precision TEXT NOT NULL CHECK(time_precision = 'second'), time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'),
   effective_time_basis TEXT NOT NULL CHECK(effective_time_basis = 'accounting'), effective_time_rule_version TEXT NOT NULL CHECK(effective_time_rule_version = 'cathay/domestic-deposit/v1'),
@@ -573,7 +578,9 @@ CREATE TABLE IF NOT EXISTS source_sync_states (
 );
 CREATE TABLE IF NOT EXISTS current_transactions (
   transaction_id BLOB PRIMARY KEY REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
-  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 CREATE TABLE IF NOT EXISTS current_projection_state (
   generation INTEGER PRIMARY KEY CHECK(generation = 1), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
@@ -621,12 +628,44 @@ CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_assertion_knowledge ON assert
 CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_transaction_knowledge ON assertion_lifecycle_events(transaction_id, commit_id, event_kind, event_id);
 CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_scope ON assertion_lifecycle_events(scope_id, commit_id, assertion_id);
 `;
-const SCHEMA_V4 = `${SCHEMA}${SCHEMA_V4_APPEND}`;
+const SCHEMA_V4_BASE = SCHEMA
+  .replace("stream TEXT NOT NULL, account_no TEXT, observed_at TEXT NOT NULL", "stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL")
+  .replace("payload_json TEXT NOT NULL, UNIQUE(source_record_id, capture_id)", "payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)")
+  .replace("  economic_status TEXT NOT NULL CHECK(economic_status IN ('normal','canceled','refund','reversal')),\n  administrative_state TEXT NOT NULL CHECK(administrative_state IN ('active','deleted','purged')),\n  semantic_rule_version TEXT NOT NULL CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1'),\n", "")
+  .replace("  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);", "  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);");
+const SCHEMA_V4 = `${SCHEMA_V4_BASE}${SCHEMA_V4_APPEND}`;
+const SCHEMA_V5_APPEND = `
+CREATE TABLE IF NOT EXISTS source_record_scopes (
+  source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16),
+  scope_id BLOB NOT NULL CHECK(length(scope_id) = 16),
+  capture_id BLOB NOT NULL CHECK(length(capture_id) = 16) REFERENCES source_captures(capture_id),
+  account_id BLOB NOT NULL CHECK(length(account_id) = 16) REFERENCES financial_accounts(account_id),
+  sequence_lexeme TEXT NOT NULL, commit_id BLOB NOT NULL CHECK(length(commit_id) = 16) REFERENCES canonical_commits(commit_id),
+  FOREIGN KEY(source_record_id, capture_id) REFERENCES source_records(source_record_id, capture_id),
+  FOREIGN KEY(scope_id, capture_id) REFERENCES capture_scopes(scope_id, capture_id),
+  FOREIGN KEY(scope_id, account_id) REFERENCES capture_scopes(scope_id, account_id),
+  UNIQUE(scope_id, sequence_lexeme)
+);
+CREATE INDEX IF NOT EXISTS idx_source_record_scopes_scope_sequence ON source_record_scopes(scope_id, sequence_lexeme, source_record_id);
+CREATE INDEX IF NOT EXISTS idx_source_record_scopes_account_capture ON source_record_scopes(account_id, capture_id, source_record_id);
+`;
+const SCHEMA_V5 = `${SCHEMA_V4}${SCHEMA_V5_APPEND}`
+  .replace("stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL", "stream TEXT NOT NULL, account_no TEXT, observed_at TEXT NOT NULL")
+  .replace("payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)", "payload_json TEXT NOT NULL, UNIQUE(source_record_id, capture_id)")
+  .replace("  posting_rule_version TEXT NOT NULL CHECK(posting_rule_version = 'cathay/domestic-deposit/v1'), description TEXT,\n", "  posting_rule_version TEXT NOT NULL CHECK(posting_rule_version = 'cathay/domestic-deposit/v1'), description TEXT,\n  economic_status TEXT NOT NULL CHECK(economic_status IN ('normal','canceled','refund','reversal')),\n  administrative_state TEXT NOT NULL CHECK(administrative_state IN ('active','deleted','purged')),\n  semantic_rule_version TEXT NOT NULL CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1'),\n")
+  .replace("  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);\nCREATE TABLE IF NOT EXISTS current_projection_state", "  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);\nCREATE TABLE IF NOT EXISTS current_projection_state")
+  .replace("  scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, completeness TEXT NOT NULL CHECK(completeness = 'complete-range'),", "  scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, scope_kind TEXT NOT NULL CHECK(scope_kind = 'bounded-range'), completeness TEXT NOT NULL CHECK(completeness = 'complete-range'),")
+  .replace("UNIQUE(capture_id, account_id, scope_start, scope_end)", "UNIQUE(scope_id, capture_id), UNIQUE(scope_id, account_id), UNIQUE(capture_id, account_id, scope_start, scope_end)")
+  .replace("absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range', 'tombstone'))", "absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range'))");
 
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
 // Keeping this target schema separate prevents an older database from being created at a
 // partially upgraded shape before its migration transaction reaches the next version.
 const SCHEMA_V2 = SCHEMA
+  .replace("stream TEXT NOT NULL, account_no TEXT, observed_at TEXT NOT NULL", "stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL")
+  .replace("payload_json TEXT NOT NULL, UNIQUE(source_record_id, capture_id)", "payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)")
+  .replace("  economic_status TEXT NOT NULL CHECK(economic_status IN ('normal','canceled','refund','reversal')),\n  administrative_state TEXT NOT NULL CHECK(administrative_state IN ('active','deleted','purged')),\n  semantic_rule_version TEXT NOT NULL CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1'),\n", "")
+  .replace("  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),\n  revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);", "  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)\n);")
   .replace(
     "completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),\n  completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)",
     "completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)",
@@ -638,6 +677,9 @@ if (SCHEMA_V2.includes("completeness_basis") || SCHEMA_V2.includes("completeness
 
 function tableExists(db: DatabaseSync, name: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+function columnExists(db: DatabaseSync, table: string, column: string): boolean {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>).some((row) => row.name === column);
 }
 function migrateV1ToV2(db: DatabaseSync): void {
   db.exec("BEGIN IMMEDIATE");
@@ -697,11 +739,89 @@ function migrateV3ToV4(db: DatabaseSync): void {
   db.exec("BEGIN IMMEDIATE");
   try {
     db.exec(SCHEMA_V4_APPEND);
+    db.exec(`INSERT INTO capture_scopes(
+      scope_id, capture_id, source_connection_id, identity_epoch_id, account_id, account_no, stream, scope_start, scope_end,
+      completeness, completeness_basis, completeness_rule_version, absence_authority, contract_fingerprint, preflight_fingerprint, page_count, terminal, commit_id
+    )
+      SELECT randomblob(16), sc.capture_id, sc.source_connection_id, sc.identity_epoch_id, account_row.account_id, account_row.account_no, sc.stream,
+        sc.scope_start, sc.scope_end, sc.completeness, sc.completeness_basis, sc.completeness_rule_version, NULL,
+        sc.authority_route, 'legacy-migration-v4', 1, 1, sc.commit_id
+      FROM source_captures sc
+      JOIN financial_accounts account_row ON account_row.source_connection_id = sc.source_connection_id
+        AND account_row.identity_epoch_id = sc.identity_epoch_id AND account_row.stream = sc.stream AND account_row.account_no = sc.account_no
+      WHERE NOT EXISTS (SELECT 1 FROM capture_scopes existing WHERE existing.capture_id = sc.capture_id)`);
+    db.exec(`INSERT INTO capture_scope_pages(
+      scope_page_id, scope_id, page_ordinal, terminal, row_count, response_digest, proof_kind, contract_fingerprint, preflight_fingerprint, commit_id
+    )
+      SELECT randomblob(16), cs.scope_id, 0, 1,
+        (SELECT COUNT(*) FROM source_records sr WHERE sr.capture_id = cs.capture_id), 'legacy-migration-v4', cs.completeness_basis,
+        cs.contract_fingerprint, cs.preflight_fingerprint, cs.commit_id
+      FROM capture_scopes cs LEFT JOIN capture_scope_pages existing_page ON existing_page.scope_id = cs.scope_id
+      WHERE existing_page.scope_id IS NULL`);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(4, currentUtcMicros());
     db.exec("PRAGMA user_version = 4");
     db.exec("COMMIT");
   } catch (error) {
     db.exec("ROLLBACK");
+    throw error;
+  }
+}
+function migrateV4ToV5(db: DatabaseSync): void {
+  db.exec("PRAGMA foreign_keys = OFF");
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(`CREATE TEMP TABLE source_record_scope_migration AS
+      SELECT DISTINCT sr.source_record_id, sr.capture_id, sr.commit_id, sr.sequence_lexeme AS old_sequence,
+        sr.description, sr.payload_json, cs.scope_id, cs.account_id, cs.account_no,
+        CASE WHEN sr.sequence_lexeme LIKE cs.account_no || ':%'
+          THEN substr(sr.sequence_lexeme, length(cs.account_no) + 2) ELSE sr.sequence_lexeme END AS provider_sequence
+      FROM source_records sr
+      JOIN transaction_revisions revision ON revision.source_record_id = sr.source_record_id
+      JOIN financial_transactions transaction_row ON transaction_row.transaction_id = revision.transaction_id
+      JOIN financial_accounts account_row ON account_row.account_id = transaction_row.account_id
+      JOIN capture_scopes cs ON cs.capture_id = sr.capture_id AND cs.account_id = account_row.account_id`);
+    const recordCount = Number((db.prepare("SELECT COUNT(*) AS count FROM source_records").get() as { count?: number }).count ?? 0);
+    const mappedCount = Number((db.prepare("SELECT COUNT(*) AS count FROM source_record_scope_migration").get() as { count?: number }).count ?? 0);
+    if (recordCount !== mappedCount) throw new Error("v4 source records could not be deterministically mapped to capture scopes.");
+    const ambiguous = Number((db.prepare("SELECT COUNT(*) AS count FROM (SELECT source_record_id FROM source_record_scope_migration GROUP BY source_record_id HAVING COUNT(*) <> 1)").get() as { count?: number }).count ?? 0);
+    if (ambiguous !== 0) throw new Error("v4 source records have ambiguous capture scope identity.");
+
+    db.exec(`CREATE TABLE source_captures_v5 (
+      capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+      identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
+      stream TEXT NOT NULL, account_no TEXT, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
+      completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),
+      completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+    )`);
+    db.exec(`INSERT INTO source_captures_v5(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id)
+      SELECT capture_id, source_connection_id, identity_epoch_id, authority_route, stream,
+        CASE WHEN account_no = 'multi-scope' THEN NULL ELSE account_no END, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id
+      FROM source_captures`);
+    db.exec(`CREATE TABLE source_records_v5 (
+      source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+      commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, description TEXT, payload_json TEXT NOT NULL,
+      UNIQUE(source_record_id, capture_id)
+    )`);
+    db.exec("INSERT INTO source_records_v5(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) SELECT source_record_id, capture_id, commit_id, provider_sequence, description, payload_json FROM source_record_scope_migration");
+    db.exec("DROP TABLE source_records; DROP TABLE source_captures; ALTER TABLE source_captures_v5 RENAME TO source_captures; ALTER TABLE source_records_v5 RENAME TO source_records");
+    if (!columnExists(db, "capture_scopes", "scope_kind")) db.exec("ALTER TABLE capture_scopes ADD COLUMN scope_kind TEXT NOT NULL DEFAULT 'bounded-range' CHECK(scope_kind = 'bounded-range')");
+    if (!columnExists(db, "transaction_revisions", "economic_status")) db.exec("ALTER TABLE transaction_revisions ADD COLUMN economic_status TEXT NOT NULL DEFAULT 'normal' CHECK(economic_status IN ('normal','canceled','refund','reversal'))");
+    if (!columnExists(db, "transaction_revisions", "administrative_state")) db.exec("ALTER TABLE transaction_revisions ADD COLUMN administrative_state TEXT NOT NULL DEFAULT 'active' CHECK(administrative_state IN ('active','deleted','purged'))");
+    if (!columnExists(db, "transaction_revisions", "semantic_rule_version")) db.exec("ALTER TABLE transaction_revisions ADD COLUMN semantic_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(semantic_rule_version = 'cathay/domestic-deposit/v1')");
+    if (!columnExists(db, "current_transactions", "projection_commit_id")) db.exec("ALTER TABLE current_transactions ADD COLUMN projection_commit_id BLOB REFERENCES canonical_commits(commit_id)");
+    if (!columnExists(db, "current_transactions", "revision_commit_id")) db.exec("ALTER TABLE current_transactions ADD COLUMN revision_commit_id BLOB REFERENCES canonical_commits(commit_id)");
+    db.exec("UPDATE current_transactions SET projection_commit_id = commit_id");
+    db.exec("UPDATE current_transactions SET revision_commit_id = (SELECT revision.commit_id FROM transaction_revisions revision WHERE revision.revision_id = current_transactions.revision_id)");
+    db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_capture ON capture_scopes(scope_id, capture_id); CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_account ON capture_scopes(scope_id, account_id)");
+    db.exec(SCHEMA_V5_APPEND);
+    db.exec("INSERT INTO source_record_scopes(source_record_id, scope_id, capture_id, account_id, sequence_lexeme, commit_id) SELECT source_record_id, scope_id, capture_id, account_id, provider_sequence, commit_id FROM source_record_scope_migration");
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(5, currentUtcMicros());
+    db.exec("PRAGMA user_version = 5");
+    db.exec("COMMIT");
+    db.exec("PRAGMA foreign_keys = ON");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    db.exec("PRAGMA foreign_keys = ON");
     throw error;
   }
 }
@@ -714,15 +834,22 @@ function applySchemaMigration(db: DatabaseSync): void {
     migrateV1ToV2(db);
     migrateV2ToV3(db);
     migrateV3ToV4(db);
+    migrateV4ToV5(db);
     return;
   }
   if (version === 2) {
     migrateV2ToV3(db);
     migrateV3ToV4(db);
+    migrateV4ToV5(db);
     return;
   }
   if (version === 3) {
     migrateV3ToV4(db);
+    migrateV4ToV5(db);
+    return;
+  }
+  if (version === 4) {
+    migrateV4ToV5(db);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -733,7 +860,7 @@ function applySchemaMigration(db: DatabaseSync): void {
   }
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec(SCHEMA_V4);
+    db.exec(SCHEMA_V5);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
@@ -763,7 +890,8 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   const projectionRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM current_transactions current_row
     JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id
     JOIN transaction_revisions r ON r.revision_id = current_row.revision_id
-    WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.commit_id`).get() as { count?: number }).count ?? 0);
+    WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.revision_commit_id
+      AND current_row.commit_id = current_row.projection_commit_id`).get() as { count?: number }).count ?? 0);
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
 }
 
@@ -792,7 +920,7 @@ export type CanonicalAdministrativeState = "active" | "deleted" | "purged";
 export type CanonicalTransaction = {
   id: string; accountId: string; accountNo: string; sourceSequence: string; amount: CanonicalAmount; currency: "TWD";
   direction: "inflow" | "outflow"; postingStatus: "posted"; postingOrigin: "provider_booked_history"; postingBasis: "query-status-success-with-accounting-date"; postingRuleVersion: "cathay/domestic-deposit/v1";
-  assertionSupportState: CanonicalAssertionSupportState; economicStatus: CanonicalEconomicStatus; administrativeState: CanonicalAdministrativeState;
+  assertionSupportState: CanonicalAssertionSupportState; economicStatus: CanonicalEconomicStatus; administrativeState: CanonicalAdministrativeState; semanticRuleVersion: "cathay/domestic-deposit/v1";
   displayLabel: string | null; effectiveOn: string; effectiveTimeBasis: "accounting"; effectiveTimeRuleVersion: "cathay/domestic-deposit/v1"; transactionDateTimeLocal: string;
   timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE; timePrecision: "second"; timeOrigin: "source_reported";
   utcInstantUtcUs: number; revisionId: string; commitSequence: number;
@@ -812,7 +940,7 @@ export type CathayCanonicalLineageEntry = {
   transaction: { id: string; accountId: string; sourceSequence: string };
   revision: CanonicalTransactionRevision;
   assertion: { id: string; revisionId: string; commitSequence: number };
-  sourceRecord: { id: string; captureId: string; sequence: string; description: string | null; payload: string };
+  sourceRecord: { id: string; captureId: string; sequence: string; description: string | null; payload: string; scopeProof: { id: string; accountId: string; accountNo: string; stream: string; scopeStart: string; scopeEnd: string; completeness: "complete-range"; contractFingerprint: string; preflightFingerprint: string } };
   capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
   provenance: Array<{ sourceRecordId: string; captureId: string }>;
   lifecycleEvents: CathayCanonicalLifecycleEvent[];
@@ -826,7 +954,7 @@ export interface CathayCanonicalFinancialQuery {
 }
 export type CathayCommitTransactionResult = { transactionId: string; revisionId: string; sourceSequence: string; direction: "inflow" | "outflow"; amount: CanonicalAmount; revisionCreated: boolean };
 export type CathayCanonicalCommitScopeResult = { scopeId: string; accountId: string; accountNo: string; transactions: CathayCommitTransactionResult[] };
-export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountId: string; transactions: CathayCommitTransactionResult[]; scopes: CathayCanonicalCommitScopeResult[] };
+export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountIds: string[]; transactions: CathayCommitTransactionResult[]; scopes: CathayCanonicalCommitScopeResult[] };
 
 function dbRow<T extends Record<string, unknown>>(value: unknown): T { return value as T; }
 function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow): boolean {
@@ -898,20 +1026,20 @@ function commitCathayDomesticDepositSyncOnce(
     const captureId = uuidV7();
     const captureStart = [...input.scopes].map((scope) => scope.startDate).sort()[0]!;
     const captureEnd = [...input.scopes].map((scope) => scope.endDate).sort().at(-1)!;
-    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, input.scopes.length === 1 ? input.scopes[0]!.accountNo : "multi-scope", input.observedAt, captureStart, captureEnd, CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, commitId);
+    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, input.scopes.length === 1 ? input.scopes[0]!.accountNo : null, input.observedAt, captureStart, captureEnd, CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, commitId);
     const allTransactions: CathayCommitTransactionResult[] = [];
     const scopeResults: CathayCanonicalCommitScopeResult[] = [];
     for (const scope of input.scopes) {
       const accountId = accountIds.get(scope.accountNo)!;
       const scopeId = uuidV7();
-      db.prepare("INSERT INTO capture_scopes(scope_id, capture_id, source_connection_id, identity_epoch_id, account_id, account_no, stream, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, absence_authority, contract_fingerprint, preflight_fingerprint, page_count, terminal, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(scopeId, captureId, sourceConnectionId, identityEpochId, accountId, scope.accountNo, input.stream, scope.startDate, scope.endDate, CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, scope.absenceAuthority ?? null, scope.contractFingerprint, scope.preflightFingerprint, scope.pages.length, 1, commitId);
+      db.prepare("INSERT INTO capture_scopes(scope_id, capture_id, source_connection_id, identity_epoch_id, account_id, account_no, stream, scope_start, scope_end, scope_kind, completeness, completeness_basis, completeness_rule_version, absence_authority, contract_fingerprint, preflight_fingerprint, page_count, terminal, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(scopeId, captureId, sourceConnectionId, identityEpochId, accountId, scope.accountNo, input.stream, scope.startDate, scope.endDate, "bounded-range", CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, scope.absenceAuthority ?? null, scope.contractFingerprint, scope.preflightFingerprint, scope.pages.length, 1, commitId);
       for (const page of scope.pages) db.prepare("INSERT INTO capture_scope_pages(scope_page_id, scope_id, page_ordinal, terminal, row_count, response_digest, proof_kind, contract_fingerprint, preflight_fingerprint, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), scopeId, page.pageOrdinal, page.terminal ? 1 : 0, page.rowCount, page.responseDigest, CATHAY_COMPLETENESS_PROOF.basis, scope.contractFingerprint, scope.preflightFingerprint, commitId);
       const seenSequences = new Set(scope.rows.map((row) => row.sequence));
       const scopeTransactions: CathayCommitTransactionResult[] = [];
       for (const detail of scope.rows) {
         const sourceRecordId = uuidV7();
-        const sourceRecordSequence = input.scopes.length === 1 ? detail.sequence : `${scope.accountNo}:${detail.sequence}`;
-        db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, sourceRecordSequence, detail.description, detail.payload);
+        db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, detail.sequence, detail.description, detail.payload);
+        db.prepare("INSERT INTO source_record_scopes(source_record_id, scope_id, capture_id, account_id, sequence_lexeme, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, scopeId, captureId, accountId, detail.sequence, commitId);
         const existingTransaction = db.prepare("SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?").get(accountId, detail.sequence);
         const transactionId = existingTransaction ? blob(dbRow<{ transaction_id: unknown }>(existingTransaction).transaction_id) : uuidV7();
         if (!existingTransaction) db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, detail.sequence, commitId);
@@ -928,13 +1056,13 @@ function commitCathayDomesticDepositSyncOnce(
           revisionId = uuidV7();
           const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
           db.prepare(`INSERT INTO transaction_revisions(
-            revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
-            direction, posting_status, posting_origin, posting_basis, posting_rule_version, description, effective_on, transaction_date_time_local,
+          revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
+            direction, posting_status, posting_origin, posting_basis, posting_rule_version, description, economic_status, administrative_state, semantic_rule_version, effective_on, transaction_date_time_local,
             time_zone, time_precision, time_origin, effective_time_basis, effective_time_rule_version, utc_instant_utc_us
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
             revisionId, transactionId, sourceRecordId, captureId, commitId, revisionNumber, detail.amount.coefficient.toString(), detail.amount.scale,
             scope.currency, detail.direction, CATHAY_POSTING_MAPPING.postingStatus, CATHAY_POSTING_MAPPING.origin, CATHAY_POSTING_MAPPING.basis, CATHAY_POSTING_MAPPING.ruleVersion,
-            detail.description, detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", "accounting", CATHAY_POSTING_MAPPING.ruleVersion, detail.utcInstantUtcUs,
+            detail.description, "normal", "active", CATHAY_POSTING_MAPPING.ruleVersion, detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", "accounting", CATHAY_POSTING_MAPPING.ruleVersion, detail.utcInstantUtcUs,
           );
           const observation = db.prepare("INSERT INTO transaction_time_observations(observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
           observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "accounting", detail.accountDate, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", detail.accountingUtcInstantUtcUs);
@@ -942,7 +1070,7 @@ function commitCathayDomesticDepositSyncOnce(
           assertionId = uuidV7();
           db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
           insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: "observed" });
-          db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, commitId);
+          db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id) VALUES (?, ?, ?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id, projection_commit_id = excluded.projection_commit_id, revision_commit_id = excluded.revision_commit_id").run(transactionId, revisionId, commitId, commitId, commitId);
         } else {
           const assertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
           if (!assertion) throw new Error("Canonical assertion was not created.");
@@ -951,7 +1079,7 @@ function commitCathayDomesticDepositSyncOnce(
           insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: wasWithdrawn ? "restored" : "observed" });
           if (wasWithdrawn) {
             const revisionCommit = blob(dbRow<{ commit_id: unknown }>(db.prepare("SELECT commit_id FROM transaction_revisions WHERE revision_id = ?").get(revisionId)).commit_id);
-            db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, revisionCommit);
+            db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id) VALUES (?, ?, ?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id, projection_commit_id = excluded.projection_commit_id, revision_commit_id = excluded.revision_commit_id").run(transactionId, revisionId, commitId, commitId, revisionCommit);
           }
         }
         db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, commit_id) VALUES (?, ?, ?)").run(assertionId, sourceRecordId, commitId);
@@ -963,7 +1091,20 @@ function commitCathayDomesticDepositSyncOnce(
         const prior = db.prepare(`SELECT sa.assertion_id, sa.transaction_id, sa.revision_id, t.source_sequence FROM source_assertions sa
           JOIN financial_transactions t ON t.transaction_id = sa.transaction_id JOIN transaction_revisions r ON r.revision_id = sa.revision_id
           JOIN current_transactions current_row ON current_row.transaction_id = t.transaction_id AND current_row.revision_id = r.revision_id
-          WHERE t.account_id = ? AND r.effective_on BETWEEN ? AND ?`).all(accountId, scope.startDate, scope.endDate) as Array<Record<string, unknown>>;
+          JOIN assertion_provenance provenance ON provenance.assertion_id = sa.assertion_id
+          JOIN source_records prior_record ON prior_record.source_record_id = provenance.source_record_id
+          JOIN source_record_scopes prior_record_scope ON prior_record_scope.source_record_id = prior_record.source_record_id
+          JOIN capture_scopes prior_scope ON prior_scope.scope_id = prior_record_scope.scope_id
+          JOIN source_captures prior_capture ON prior_capture.capture_id = prior_scope.capture_id
+          WHERE t.account_id = ? AND r.effective_on BETWEEN ? AND ?
+            AND prior_scope.source_connection_id = ? AND prior_scope.identity_epoch_id = ? AND prior_scope.account_id = ?
+            AND prior_scope.stream = ? AND prior_scope.scope_kind = 'bounded-range'
+            AND prior_scope.completeness = 'complete-range' AND prior_scope.completeness_rule_version = ?
+            AND prior_scope.contract_fingerprint = ? AND prior_scope.preflight_fingerprint = ?
+            AND prior_capture.authority_route = ? AND prior_capture.stream = ?`).all(
+          accountId, scope.startDate, scope.endDate, sourceConnectionId, identityEpochId, accountId, input.stream,
+          CATHAY_COMPLETENESS_PROOF.ruleVersion, scope.contractFingerprint, scope.preflightFingerprint, input.authorityRoute, input.stream,
+        ) as Array<Record<string, unknown>>;
         for (const row of prior) {
           if (seenSequences.has(String(row.source_sequence))) continue;
           const assertionId = blob(row.assertion_id);
@@ -980,7 +1121,7 @@ function commitCathayDomesticDepositSyncOnce(
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
-    return { captureId: idToString(captureId), commitSequence, accountId: idToString(accountIds.get(input.scopes[0]!.accountNo)!), transactions: allTransactions, scopes: scopeResults };
+    return { captureId: idToString(captureId), commitSequence, accountIds: [...accountIds.values()].map(idToString), transactions: allTransactions, scopes: scopeResults };
   } catch (error) {
     if (inTransaction) db.exec("ROLLBACK");
     throw error;
@@ -1056,7 +1197,7 @@ function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction 
     id: idToString(row.transaction_id), accountId: idToString(row.account_id), accountNo: String(row.account_no), sourceSequence: String(row.source_sequence),
     amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: row.posting_status as "posted",
     postingOrigin: row.posting_origin as "provider_booked_history", postingBasis: row.posting_basis as "query-status-success-with-accounting-date", postingRuleVersion: row.posting_rule_version as "cathay/domestic-deposit/v1",
-    assertionSupportState: row.assertion_support_state === "withdrawn" ? "withdrawn" : "supported", economicStatus: row.economic_status as CanonicalEconomicStatus ?? "normal", administrativeState: row.administrative_state as CanonicalAdministrativeState ?? "active",
+    assertionSupportState: row.assertion_support_state === "withdrawn" ? "withdrawn" : "supported", economicStatus: row.economic_status as CanonicalEconomicStatus, administrativeState: row.administrative_state as CanonicalAdministrativeState, semanticRuleVersion: row.semantic_rule_version as "cathay/domestic-deposit/v1",
     displayLabel: typeof row.description === "string" ? row.description : null, effectiveOn: String(row.effective_on), effectiveTimeBasis: row.effective_time_basis as "accounting", effectiveTimeRuleVersion: row.effective_time_rule_version as "cathay/domestic-deposit/v1",
     transactionDateTimeLocal: String(row.transaction_date_time_local), timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, timePrecision: "second", timeOrigin: "source_reported",
     utcInstantUtcUs: Number(row.utc_instant_utc_us), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence),
@@ -1076,11 +1217,11 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     try {
       const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM current_transactions current_row
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
-        JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.commit_id
+        JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.projection_commit_id
         ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
       return { status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow), commitSequence: rows.reduce((max, row) => Math.max(max, Number(row.commit_sequence)), 0) };
     } finally { db.close(); }
@@ -1093,7 +1234,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence,
         COALESCE((SELECT CASE WHEN lifecycle.event_kind = 'withdrawn' THEN 'withdrawn' ELSE 'supported' END FROM assertion_lifecycle_events lifecycle
@@ -1116,12 +1257,15 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
       const revisionRows = db.prepare(`SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence, r.source_record_id, r.capture_id, sr.sequence_lexeme, sr.description, sr.payload_json,
+        source_scope.scope_id, source_scope.account_id AS scope_account_id, source_scope.account_no AS scope_account_no, source_scope.stream AS scope_stream,
+        source_scope.scope_start AS scope_scope_start, source_scope.scope_end AS scope_scope_end, source_scope.contract_fingerprint AS scope_contract_fingerprint, source_scope.preflight_fingerprint AS scope_preflight_fingerprint,
         sc.observed_at, sc.scope_start, sc.scope_end, sc.authority_route, sa.assertion_id FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
-        JOIN source_records sr ON sr.source_record_id = r.source_record_id JOIN source_captures sc ON sc.capture_id = r.capture_id
+        JOIN source_records sr ON sr.source_record_id = r.source_record_id JOIN source_record_scopes record_scope ON record_scope.source_record_id = sr.source_record_id
+        JOIN capture_scopes source_scope ON source_scope.scope_id = record_scope.scope_id JOIN source_captures sc ON sc.capture_id = r.capture_id
         JOIN source_assertions sa ON sa.revision_id = r.revision_id WHERE t.transaction_id = ? ORDER BY r.revision_number`).all(transactionId) as Record<string, unknown>[];
       const entries = revisionRows.map((row) => {
         const assertionId = blob(row.assertion_id);
@@ -1135,7 +1279,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },
           revision,
           assertion: { id: idToString(row.assertion_id), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence) },
-          sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), description: typeof row.description === "string" ? row.description : null, payload: String(row.payload_json) },
+          sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), description: typeof row.description === "string" ? row.description : null, payload: String(row.payload_json), scopeProof: { id: idToString(row.scope_id), accountId: idToString(row.scope_account_id), accountNo: String(row.scope_account_no), stream: String(row.scope_stream), scopeStart: String(row.scope_scope_start), scopeEnd: String(row.scope_scope_end), completeness: "complete-range" as const, contractFingerprint: String(row.scope_contract_fingerprint), preflightFingerprint: String(row.scope_preflight_fingerprint) } },
           capture: { id: idToString(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
           provenance: provenance.map((item) => ({ sourceRecordId: idToString(item.sourceRecordId), captureId: idToString(item.captureId) })),
           lifecycleEvents: lifecycleEvents.map((event) => ({

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1890,11 +1890,24 @@ export async function runCathayDerivedImportRun(ledgerDir: string, input: Cathay
 }
 
 export async function commitCathayUserAssertion(ledgerDir: string, input: CathayUserAssertionInput, options: CathayCanonicalCommitOptions = {}): Promise<CathayUserAssertionResult> {
-  if (typeof input.target === "object" && input.target !== null && input.target.kind !== undefined && input.target.kind !== "transaction") throw new Error("User Assertions support transaction targets only.");
-  const rawField = typeof input.field === "string" ? input.field : typeof input.target === "object" ? input.target.field : undefined;
+  const hasTarget = Object.prototype.hasOwnProperty.call(input, "target");
+  type RuntimeTransactionTarget = { kind?: unknown; field?: unknown; id?: unknown };
+  const targetObject = typeof input.target === "object" && input.target !== null && !Array.isArray(input.target)
+    ? input.target as RuntimeTransactionTarget : undefined;
+  if (hasTarget) {
+    if (!targetObject || targetObject.kind !== "transaction" || typeof targetObject.id !== "string") throw new Error("User Assertions require a valid transaction target object.");
+    const targetId = idFromString(targetObject.id);
+    if (input.transactionId !== undefined && Buffer.compare(targetId, idFromString(input.transactionId)) !== 0) throw new Error("User Assertion target and transactionId conflict.");
+    if (input.subject !== undefined && (input.subject.kind !== "transaction" || Buffer.compare(targetId, idFromString(input.subject.id)) !== 0)) throw new Error("User Assertion target and subject conflict.");
+    if (targetObject.field !== undefined && typeof targetObject.field !== "string") throw new Error("User Assertion target field must be a string.");
+  }
+  const targetField = targetObject?.field;
+  const normalizeField = (value: unknown) => value === "displayName" || value === "displayLabel" ? "display_name" : value;
+  if (targetField !== undefined && input.field !== undefined && normalizeField(targetField) !== normalizeField(input.field)) throw new Error("User Assertion target and field conflict.");
+  const rawField = typeof input.field === "string" ? input.field : typeof targetField === "string" ? targetField : undefined;
   const field = rawField === "displayName" || rawField === "displayLabel" ? "display_name" : rawField;
   if (field !== "display_name" && field !== "note") throw new Error("User Assertions may target only display_name or note.");
-  const transactionIdText = input.transactionId ?? input.subject?.id ?? (typeof input.target === "object" ? input.target.id : undefined);
+  const transactionIdText = input.transactionId ?? input.subject?.id ?? (typeof targetObject?.id === "string" ? targetObject.id : undefined);
   if (!transactionIdText) throw new Error("User Assertion requires a transaction subject.");
   if (input.subject && input.subject.kind !== "transaction") throw new Error("User Assertions support transaction subjects only.");
   const transactionId = idFromString(transactionIdText);

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1594,8 +1594,12 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       const existingCurrent = db.prepare(`SELECT f.origin, f.derived_assertion_id, f.user_assertion_id FROM current_transaction_fields f WHERE f.transaction_id = ? AND f.field_name = ?`).get(transactionId, coordinate.field) as Record<string, unknown> | undefined;
       const conflicting = db.prepare(`SELECT da.assertion_id, da.producer_id, da.origin, da.rule_lineage FROM derived_assertions da
         JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
-        WHERE da.transaction_id = ? AND da.field_name = ? AND (da.producer_id <> ? OR da.origin <> ?)
-        AND e.event_kind NOT IN ('withdrawn','superseded') LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin) as Record<string, unknown> | undefined;
+        JOIN canonical_commits c ON c.commit_id = e.commit_id
+        WHERE da.transaction_id = ? AND da.field_name = ? AND (da.producer_id <> ? OR da.origin <> ? OR da.rule_lineage <> ?)
+        AND e.event_kind NOT IN ('withdrawn','superseded')
+        AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+          WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
+        LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin, input.ruleLineage) as Record<string, unknown> | undefined;
       if (conflicting) throw new Error("A different derived producer or origin cannot supersede the current lineage.");
       const latest = db.prepare(`SELECT da.* FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
         WHERE da.transaction_id = ? AND da.field_name = ? AND da.producer_id = ? AND da.origin = ? AND da.rule_lineage = ?
@@ -1661,6 +1665,7 @@ export async function runCathayDerivedImportRun(ledgerDir: string, input: Cathay
 }
 
 export async function commitCathayUserAssertion(ledgerDir: string, input: CathayUserAssertionInput, options: CathayCanonicalCommitOptions = {}): Promise<CathayUserAssertionResult> {
+  if (typeof input.target === "object" && input.target !== null && input.target.kind !== undefined && input.target.kind !== "transaction") throw new Error("User Assertions support transaction targets only.");
   const rawField = typeof input.field === "string" ? input.field : typeof input.target === "object" ? input.target.field : undefined;
   const field = rawField === "displayName" || rawField === "displayLabel" ? "display_name" : rawField;
   if (field !== "display_name" && field !== "note") throw new Error("User Assertions may target only display_name or note.");

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -8,7 +8,14 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 1;
+export const CANONICAL_SCHEMA_VERSION = 2;
+export const CATHAY_POSTING_MAPPING = {
+  contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  postingStatus: "posted",
+  origin: "provider_booked_history",
+  basis: "query-status-success-with-accounting-date",
+  ruleVersion: "cathay/domestic-deposit/v1",
+} as const;
 
 export const CATHAY_DOMESTIC_DEPOSIT_PROVENANCE = {
   validatedAt: "2026-08-17",
@@ -18,7 +25,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_PROVENANCE = {
   note: "Human-assisted validation covered response shape only; no live values are retained.",
 } as const;
 
-export const CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE = `{"success":true,"returnCode":"0000","content":{"datas":[{"queryStatus":"Success","accountNumber":"SYNTHETIC-ACCOUNT-001","count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":[{"sequenceNumber":1,"txnDateTime":"2026-07-01T09:00:00","accountDate":"2026-07-01","description":"Synthetic deposit","expendAmt":null,"incomeAmt":12500,"balance":12500},{"sequenceNumber":2,"txnDateTime":"2026-07-02T10:15:30","accountDate":"2026-07-02","description":"Synthetic transfer","expendAmt":300,"incomeAmt":null,"balance":12200},{"sequenceNumber":3,"txnDateTime":"2026-07-03T11:45:00","accountDate":"2026-07-03","description":"Synthetic credit","expendAmt":null,"incomeAmt":800,"balance":13000}]}]}}`;
+export const CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE = `{"success":true,"returnCode":"0000","content":{"datas":[{"queryStatus":"Success","accountNumber":"SYNTHETIC-ACCOUNT-001","count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":[{"sequenceNumber":1,"txnDateTime":"2026-07-01T09:00:00","accountDate":"2026-07-01","description":"Synthetic Cathay deposit description","expendAmt":null,"incomeAmt":12500,"balance":12500},{"sequenceNumber":2,"txnDateTime":"2026-07-02T10:15:30","accountDate":"2026-07-02","description":"Synthetic Cathay transfer description","expendAmt":300,"incomeAmt":null,"balance":12200},{"sequenceNumber":3,"txnDateTime":"2026-07-03T11:45:00","accountDate":"2026-07-03","description":"Synthetic Cathay credit description","expendAmt":null,"incomeAmt":800,"balance":13000}]}]}}`;
 
 export type CathayDomesticDepositCaptureInput = {
   rawResponse: string;
@@ -201,18 +208,43 @@ function localDateTimeToUtcMicros(value: string): number {
   if (!Number.isSafeInteger(milliseconds)) throw new Error("Cathay local date-time is outside the supported instant range.");
   return milliseconds * 1000;
 }
+function localDateToUtcMicros(value: string): number {
+  return localDateTimeToUtcMicros(`${value}T00:00:00`);
+}
 
 type ValidatedCathayRow = {
   sequence: string;
   accountDate: string;
   transactionDateTime: string;
+  description: string | null;
+  accountingUtcInstantUtcUs: number;
   utcInstantUtcUs: number;
   amount: ExactDecimal;
   direction: "inflow" | "outflow";
   balance: ExactDecimal;
   payload: string;
 };
-type ValidatedCathayCapture = { accountNo: string; startDate: string; endDate: string; rows: ValidatedCathayRow[] };
+type ValidatedCathayCapture = {
+  accountNo: string;
+  startDate: string;
+  endDate: string;
+  posting: typeof CATHAY_POSTING_MAPPING;
+  rows: ValidatedCathayRow[];
+};
+
+function cathayPostingMapping(
+  statement: { [key: string]: LosslessJsonValue },
+  details: LosslessJsonValue[],
+): typeof CATHAY_POSTING_MAPPING {
+  if (requiredString(statement, "queryStatus") !== "Success") throw new Error("Cathay queryStatus was not Success; posting status is not mappable.");
+  for (const detailValue of details) {
+    const detail = asObject(detailValue, "Cathay transfer detail");
+    if ("status" in detail || "pending" in detail || "postingStatus" in detail) {
+      throw new Error("Cathay posting mapping requires the booked-history response without pending status fields.");
+    }
+  }
+  return CATHAY_POSTING_MAPPING;
+}
 
 function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCathayCapture {
   if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) throw new Error("Source Connection and Identity Epoch are required.");
@@ -234,7 +266,6 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
   const datas = asArray(content.datas, "Cathay response datas");
   if (datas.length !== 1) throw new Error("Cathay response must contain exactly one transfer result.");
   const statement = asObject(datas[0]!, "Cathay transfer result");
-  if (requiredString(statement, "queryStatus") !== "Success") throw new Error("Cathay queryStatus was not Success.");
   const accountNo = requiredString(statement, "accountNumber");
   if (accountNo !== input.accountNo) throw new Error("Cathay account scope does not match the response.");
   if (requiredString(statement, "startDate") !== startDate || requiredString(statement, "endDate") !== endDate) throw new Error("Cathay response date scope does not match the requested scope.");
@@ -242,6 +273,7 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
   if (count.scale !== 0 || count.coefficient < 0n) throw new Error("Cathay count must be a non-negative integer.");
   const details = asArray(statement.details, "Cathay transfer details");
   if (count.coefficient !== BigInt(details.length)) throw new Error("Cathay response count does not match details.");
+  const posting = cathayPostingMapping(statement, details);
 
   const sequences = new Set<string>();
   const rows = details.map((detailValue, index) => {
@@ -260,19 +292,29 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
     const balance = parseExactDecimalLexeme(balanceLexeme);
     const accountDate = requireDate(requiredString(detail, "accountDate"), "accountDate");
     const transactionDateTime = requireDateTime(requiredString(detail, "txnDateTime"), "txnDateTime");
+    const descriptionValue = detail.description;
+    if (descriptionValue !== undefined && descriptionValue !== null && typeof descriptionValue !== "string") {
+      throw new Error("Cathay description must be a string or absent.");
+    }
+    if (typeof descriptionValue === "string" && descriptionValue.length > 512) throw new Error("Cathay description exceeds the supported compact length.");
+    const description = typeof descriptionValue === "string" && descriptionValue.length > 0 ? descriptionValue : null;
     const direction = incomeLexeme === null ? "outflow" : "inflow";
+    const payload: Record<string, string> = { sequenceNumber: sequenceLexeme, accountDate, txnDateTime: transactionDateTime, amount: amountLexeme, amountDirection: direction, balance: balanceLexeme };
+    if (description !== null) payload.description = description;
     return {
       sequence: sequenceLexeme,
       accountDate,
       transactionDateTime,
+      description,
+      accountingUtcInstantUtcUs: localDateToUtcMicros(accountDate),
       utcInstantUtcUs: localDateTimeToUtcMicros(transactionDateTime),
       amount,
       direction,
       balance,
-      payload: JSON.stringify({ sequenceNumber: sequenceLexeme, accountDate, txnDateTime: transactionDateTime, amount: amountLexeme, amountDirection: direction, balance: balanceLexeme }),
+      payload: JSON.stringify(payload),
     } satisfies ValidatedCathayRow;
   });
-  return { accountNo, startDate, endDate, rows };
+  return { accountNo, startDate, endDate, posting, rows };
 }
 
 type CanonicalId = Buffer;
@@ -304,7 +346,8 @@ CREATE TABLE IF NOT EXISTS canonical_commits (
   commit_id BLOB PRIMARY KEY CHECK(length(commit_id) = 16),
   commit_sequence INTEGER NOT NULL UNIQUE,
   recorded_at_utc_us INTEGER NOT NULL,
-  authority_route TEXT NOT NULL
+  authority_route TEXT NOT NULL,
+  commit_kind TEXT NOT NULL CHECK(commit_kind = 'source_capture')
 );
 CREATE TABLE IF NOT EXISTS source_authority_routes (
   authority_route TEXT PRIMARY KEY, integration_namespace TEXT NOT NULL, stream TEXT NOT NULL, contract_version TEXT NOT NULL,
@@ -329,7 +372,8 @@ CREATE TABLE IF NOT EXISTS source_captures (
 );
 CREATE TABLE IF NOT EXISTS source_records (
   source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
-  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, description TEXT,
+  payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)
 );
 CREATE TABLE IF NOT EXISTS financial_accounts (
   account_id BLOB PRIMARY KEY CHECK(length(account_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
@@ -347,9 +391,20 @@ CREATE TABLE IF NOT EXISTS transaction_revisions (
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), revision_number INTEGER NOT NULL,
   amount_coefficient TEXT NOT NULL, amount_scale INTEGER NOT NULL CHECK(amount_scale >= 0), currency TEXT NOT NULL,
   direction TEXT NOT NULL CHECK(direction IN ('inflow','outflow')), posting_status TEXT NOT NULL CHECK(posting_status IN ('pending','posted')),
+  posting_origin TEXT NOT NULL CHECK(posting_origin = 'provider_booked_history'), posting_basis TEXT NOT NULL CHECK(posting_basis = 'query-status-success-with-accounting-date'),
+  posting_rule_version TEXT NOT NULL CHECK(posting_rule_version = 'cathay/domestic-deposit/v1'), description TEXT,
   effective_on TEXT NOT NULL, transaction_date_time_local TEXT NOT NULL, time_zone TEXT NOT NULL,
   time_precision TEXT NOT NULL CHECK(time_precision = 'second'), time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'),
+  effective_time_basis TEXT NOT NULL CHECK(effective_time_basis = 'accounting'), effective_time_rule_version TEXT NOT NULL CHECK(effective_time_rule_version = 'cathay/domestic-deposit/v1'),
   utc_instant_utc_us INTEGER NOT NULL, UNIQUE(transaction_id, revision_number)
+);
+CREATE TABLE IF NOT EXISTS transaction_time_observations (
+  observation_id BLOB PRIMARY KEY CHECK(length(observation_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), role TEXT NOT NULL CHECK(role IN ('accounting','occurred')),
+  local_value TEXT NOT NULL, time_zone TEXT NOT NULL CHECK(time_zone = 'Asia/Taipei'), time_precision TEXT NOT NULL CHECK(time_precision IN ('date','second')),
+  time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'), utc_instant_utc_us INTEGER NOT NULL,
+  UNIQUE(revision_id, role)
 );
 CREATE TABLE IF NOT EXISTS source_assertions (
   assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
@@ -369,16 +424,62 @@ CREATE TABLE IF NOT EXISTS current_transactions (
   transaction_id BLOB PRIMARY KEY REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
+CREATE TABLE IF NOT EXISTS current_projection_state (
+  generation INTEGER PRIMARY KEY CHECK(generation = 1), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+);
+CREATE INDEX IF NOT EXISTS idx_transaction_revisions_financial_time ON transaction_revisions(effective_on, utc_instant_utc_us, transaction_id, commit_id);
+CREATE INDEX IF NOT EXISTS idx_transaction_revisions_knowledge_time ON transaction_revisions(commit_id, transaction_id, revision_number);
+CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id);
+CREATE INDEX IF NOT EXISTS idx_current_transactions_revision ON current_transactions(revision_id, commit_id, transaction_id);
+CREATE INDEX IF NOT EXISTS idx_transaction_revisions_lineage ON transaction_revisions(transaction_id, revision_number, revision_id);
+CREATE INDEX IF NOT EXISTS idx_source_assertions_revision ON source_assertions(revision_id, transaction_id, assertion_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_provenance_record ON assertion_provenance(source_record_id, assertion_id, commit_id);
+CREATE INDEX IF NOT EXISTS idx_source_records_capture ON source_records(capture_id, sequence_lexeme, source_record_id);
+CREATE INDEX IF NOT EXISTS idx_time_observations_revision ON transaction_time_observations(revision_id, role, observation_id);
 `;
 
 function tableExists(db: DatabaseSync, name: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+function migrateV1ToV2(db: DatabaseSync): void {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec("ALTER TABLE canonical_commits ADD COLUMN commit_kind TEXT NOT NULL DEFAULT 'source_capture' CHECK(commit_kind = 'source_capture')");
+    db.exec("ALTER TABLE source_records ADD COLUMN description TEXT");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_origin TEXT NOT NULL DEFAULT 'provider_booked_history' CHECK(posting_origin = 'provider_booked_history')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_basis TEXT NOT NULL DEFAULT 'query-status-success-with-accounting-date' CHECK(posting_basis = 'query-status-success-with-accounting-date')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN posting_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(posting_rule_version = 'cathay/domestic-deposit/v1')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN description TEXT");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_basis TEXT NOT NULL DEFAULT 'accounting' CHECK(effective_time_basis = 'accounting')");
+    db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(effective_time_rule_version = 'cathay/domestic-deposit/v1')");
+    db.exec(SCHEMA);
+    const revisions = db.prepare("SELECT revision_id, transaction_id, source_record_id, commit_id, capture_id, effective_on, transaction_date_time_local, utc_instant_utc_us FROM transaction_revisions").all() as Array<Record<string, unknown>>;
+    const insertObservation = db.prepare(`INSERT INTO transaction_time_observations(
+      observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+    for (const revision of revisions) {
+      insertObservation.run(uuidV7(), blob(revision.transaction_id), blob(revision.revision_id), blob(revision.source_record_id), blob(revision.commit_id), "accounting", String(revision.effective_on), CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", localDateToUtcMicros(String(revision.effective_on)));
+      insertObservation.run(uuidV7(), blob(revision.transaction_id), blob(revision.revision_id), blob(revision.source_record_id), blob(revision.commit_id), "occurred", String(revision.transaction_date_time_local), CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", Number(revision.utc_instant_utc_us));
+    }
+    const latestCommit = db.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as Record<string, unknown> | undefined;
+    if (latestCommit) db.prepare("INSERT OR REPLACE INTO current_projection_state(generation, commit_id) VALUES (1, ?)").run(blob(latestCommit.commit_id));
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, Date.now() * 1000);
+    db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
 }
 function applySchemaMigration(db: DatabaseSync): void {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
   const version = Number(row.user_version ?? 0);
   if (version > CANONICAL_SCHEMA_VERSION) throw new Error(`Canonical SQLite schema ${version} is newer than supported ${CANONICAL_SCHEMA_VERSION}.`);
   if (version === 0 && tableExists(db, "canonical_commits")) throw new Error("Unversioned canonical SQLite schema is not compatible; refusing ad-hoc migration.");
+  if (version === 1) {
+    migrateV1ToV2(db);
+    return;
+  }
   if (version === CANONICAL_SCHEMA_VERSION) {
     if (!tableExists(db, "schema_migrations")) throw new Error("Canonical SQLite schema version metadata is missing.");
     const migration = db.prepare("SELECT 1 FROM schema_migrations WHERE version = ?").get(CANONICAL_SCHEMA_VERSION);
@@ -397,6 +498,27 @@ function applySchemaMigration(db: DatabaseSync): void {
   }
 }
 
+function validateReadOnlyDatabase(db: DatabaseSync): void {
+  const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
+  if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
+  const integrity = String((db.prepare("PRAGMA integrity_check").get() as { integrity_check?: unknown }).integrity_check ?? "");
+  if (integrity !== "ok") throw new Error(`Canonical SQLite integrity check failed: ${integrity}`);
+  const foreignKeys = db.prepare("PRAGMA foreign_key_check").all();
+  if (foreignKeys.length > 0) throw new Error("Canonical SQLite foreign-key integrity check failed.");
+  const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
+  const currentCount = Number((db.prepare("SELECT COUNT(*) AS count FROM current_transactions").get() as { count?: number }).count ?? 0);
+  const stateRows = db.prepare("SELECT generation, commit_id FROM current_projection_state").all() as Array<Record<string, unknown>>;
+  if (commitCount > 0 && stateRows.length !== 1) throw new Error("Canonical current projection generation is missing or ambiguous.");
+  if (stateRows.length === 1) {
+    if (Number(stateRows[0]!.generation) !== 1 || !db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id))) throw new Error("Canonical current projection generation references no commit.");
+  }
+  const projectionRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM current_transactions current_row
+    JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id
+    JOIN transaction_revisions r ON r.revision_id = current_row.revision_id
+    WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.commit_id`).get() as { count?: number }).count ?? 0);
+  if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
+}
+
 export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: boolean } = {}): DatabaseSync {
   const path = canonicalSqlitePath(ledgerDir);
   if (options.readOnly && !existsSync(path)) throw new Error(`Missing canonical SQLite: ${path}`);
@@ -405,10 +527,11 @@ export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: b
   try {
     db.exec("PRAGMA foreign_keys = ON");
     db.exec("PRAGMA busy_timeout = 30000");
-    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); applySchemaMigration(db); }
+    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); db.exec("PRAGMA synchronous = FULL"); applySchemaMigration(db); }
     else {
       const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
       if (Number(row.user_version ?? 0) !== CANONICAL_SCHEMA_VERSION) throw new Error("Canonical SQLite schema is missing or unsupported for read-only access.");
+      validateReadOnlyDatabase(db);
     }
     return db;
   } catch (error) { db.close(); throw error; }
@@ -417,7 +540,8 @@ export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: b
 export type CanonicalAmount = { coefficient: string; scale: number };
 export type CanonicalTransaction = {
   id: string; accountId: string; accountNo: string; sourceSequence: string; amount: CanonicalAmount; currency: "TWD";
-  direction: "inflow" | "outflow"; postingStatus: "posted"; effectiveOn: string; transactionDateTimeLocal: string;
+  direction: "inflow" | "outflow"; postingStatus: "posted"; postingOrigin: "provider_booked_history"; postingBasis: "query-status-success-with-accounting-date"; postingRuleVersion: "cathay/domestic-deposit/v1";
+  displayLabel: string | null; effectiveOn: string; effectiveTimeBasis: "accounting"; effectiveTimeRuleVersion: "cathay/domestic-deposit/v1"; transactionDateTimeLocal: string;
   timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE; timePrecision: "second"; timeOrigin: "source_reported";
   utcInstantUtcUs: number; revisionId: string; commitSequence: number;
 };
@@ -430,7 +554,7 @@ export type CathayCanonicalLineageEntry = {
   transaction: { id: string; accountId: string; sourceSequence: string };
   revision: CanonicalTransactionRevision;
   assertion: { id: string; revisionId: string; commitSequence: number };
-  sourceRecord: { id: string; captureId: string; sequence: string; payload: string };
+  sourceRecord: { id: string; captureId: string; sequence: string; description: string | null; payload: string };
   capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
   provenance: Array<{ sourceRecordId: string; captureId: string }>;
 };
@@ -448,9 +572,13 @@ function dbRow<T extends Record<string, unknown>>(value: unknown): T { return va
 function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow): boolean {
   return row.amount_coefficient === detail.amount.coefficient.toString()
     && row.amount_scale === detail.amount.scale && row.direction === detail.direction
+    && row.posting_status === CATHAY_POSTING_MAPPING.postingStatus && row.posting_origin === CATHAY_POSTING_MAPPING.origin
+    && row.posting_basis === CATHAY_POSTING_MAPPING.basis && row.posting_rule_version === CATHAY_POSTING_MAPPING.ruleVersion
+    && row.description === detail.description
     && row.effective_on === detail.accountDate && row.transaction_date_time_local === detail.transactionDateTime
     && row.time_zone === CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE && row.time_precision === "second"
-    && row.time_origin === "source_reported" && Number(row.utc_instant_utc_us) === detail.utcInstantUtcUs;
+    && row.time_origin === "source_reported" && row.effective_time_basis === "accounting"
+    && row.effective_time_rule_version === CATHAY_POSTING_MAPPING.ruleVersion && Number(row.utc_instant_utc_us) === detail.utcInstantUtcUs;
 }
 function recordedAtUtcUs(value: string): number {
   const milliseconds = Date.parse(value);
@@ -467,7 +595,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
     const commitId = uuidV7();
     const maxSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0);
     const commitSequence = maxSequence + 1;
-    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route) VALUES (?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(input.observedAt), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY);
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(input.observedAt), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, "source_capture");
     db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1", commitId);
     const connectionExisting = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
     const sourceConnectionId = connectionExisting ? blob(dbRow<{ source_connection_id: unknown }>(connectionExisting).source_connection_id) : uuidV7();
@@ -487,7 +615,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
     const transactionResults: CathayCommitTransactionResult[] = [];
     for (const detail of validated.rows) {
       const sourceRecordId = uuidV7();
-      db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, payload_json) VALUES (?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, detail.sequence, detail.payload);
+      db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, detail.sequence, detail.description, detail.payload);
       const transactionExisting = db.prepare("SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?").get(accountId, detail.sequence);
       const transactionId = transactionExisting ? blob(dbRow<{ transaction_id: unknown }>(transactionExisting).transaction_id) : uuidV7();
       if (!transactionExisting) db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, detail.sequence, commitId);
@@ -500,12 +628,19 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
         const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
         db.prepare(`INSERT INTO transaction_revisions(
           revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
-          direction, posting_status, effective_on, transaction_date_time_local, time_zone, time_precision, time_origin, utc_instant_utc_us
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+          direction, posting_status, posting_origin, posting_basis, posting_rule_version, description, effective_on, transaction_date_time_local,
+          time_zone, time_precision, time_origin, effective_time_basis, effective_time_rule_version, utc_instant_utc_us
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
           revisionId, transactionId, sourceRecordId, captureId, commitId, revisionNumber, detail.amount.coefficient.toString(), detail.amount.scale,
-          input.currency, detail.direction, "posted", detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
-          "second", "source_reported", detail.utcInstantUtcUs,
+          input.currency, detail.direction, validated.posting.postingStatus, validated.posting.origin, validated.posting.basis, validated.posting.ruleVersion,
+          detail.description, detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
+          "second", "source_reported", "accounting", validated.posting.ruleVersion, detail.utcInstantUtcUs,
         );
+        const insertObservation = db.prepare(`INSERT INTO transaction_time_observations(
+          observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+        insertObservation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "accounting", detail.accountDate, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", detail.accountingUtcInstantUtcUs);
+        insertObservation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "occurred", detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", detail.utcInstantUtcUs);
         const assertionId = uuidV7();
         db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
         db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, commitId);
@@ -519,6 +654,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
     db.prepare(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET scope_start = excluded.scope_start,
       scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor, captureId, commitId);
+    db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
     return { captureId: idToString(captureId), commitSequence, accountId: idToString(accountId), transactions: transactionResults };
@@ -560,7 +696,9 @@ function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmou
 function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction {
   return {
     id: idToString(row.transaction_id), accountId: idToString(row.account_id), accountNo: String(row.account_no), sourceSequence: String(row.source_sequence),
-    amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: "posted", effectiveOn: String(row.effective_on),
+    amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: row.posting_status as "posted",
+    postingOrigin: row.posting_origin as "provider_booked_history", postingBasis: row.posting_basis as "query-status-success-with-accounting-date", postingRuleVersion: row.posting_rule_version as "cathay/domestic-deposit/v1",
+    displayLabel: typeof row.description === "string" ? row.description : null, effectiveOn: String(row.effective_on), effectiveTimeBasis: row.effective_time_basis as "accounting", effectiveTimeRuleVersion: row.effective_time_rule_version as "cathay/domestic-deposit/v1",
     transactionDateTimeLocal: String(row.transaction_date_time_local), timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, timePrecision: "second", timeOrigin: "source_reported",
     utcInstantUtcUs: Number(row.utc_instant_utc_us), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence),
   };
@@ -579,7 +717,8 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     try {
       const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM current_transactions current_row
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.commit_id
@@ -595,7 +734,8 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
         WHERE r.effective_on <= ? AND c.commit_sequence <= ? AND NOT EXISTS (
@@ -611,8 +751,9 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
       const revisionRows = db.prepare(`SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no, r.amount_coefficient, r.amount_scale, r.currency,
-        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
-        r.utc_instant_utc_us, r.revision_id, c.commit_sequence, r.source_record_id, r.capture_id, sr.sequence_lexeme, sr.payload_json,
+        r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
+        r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence, r.source_record_id, r.capture_id, sr.sequence_lexeme, sr.description, sr.payload_json,
         sc.observed_at, sc.scope_start, sc.scope_end, sc.authority_route, sa.assertion_id FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
         JOIN source_records sr ON sr.source_record_id = r.source_record_id JOIN source_captures sc ON sc.capture_id = r.capture_id
@@ -626,7 +767,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },
           revision,
           assertion: { id: idToString(row.assertion_id), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence) },
-          sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), payload: String(row.payload_json) },
+          sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), description: typeof row.description === "string" ? row.description : null, payload: String(row.payload_json) },
           capture: { id: idToString(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
           provenance: provenance.map((item) => ({ sourceRecordId: idToString(item.sourceRecordId), captureId: idToString(item.captureId) })),
         } satisfies CathayCanonicalLineageEntry;

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1102,10 +1102,12 @@ function convertV6CompatibilityTables(db: DatabaseSync): void {
     {
       name: "source_assertions",
       select: `SELECT assertion.assertion_id, assertion.transaction_id, assertion.revision_id,
-        MIN(provenance.source_record_id) AS source_record_id, assertion.created_commit_id AS commit_id
-        FROM assertions assertion JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
-        WHERE assertion.origin = 'source' AND provenance.source_record_id IS NOT NULL
-        GROUP BY assertion.assertion_id, assertion.transaction_id, assertion.revision_id, assertion.created_commit_id`,
+        revision.source_record_id, assertion.created_commit_id AS commit_id
+        FROM assertions assertion JOIN transaction_revisions revision ON revision.revision_id = assertion.revision_id
+        WHERE assertion.origin = 'source' AND EXISTS (
+          SELECT 1 FROM assertion_provenance provenance
+          WHERE provenance.assertion_id = assertion.assertion_id AND provenance.source_record_id IS NOT NULL
+        )`,
     },
     {
       name: "derived_assertions",
@@ -1161,6 +1163,11 @@ function convertV6CompatibilityTables(db: DatabaseSync): void {
       db.exec(`ALTER TABLE ${compatibility.name} RENAME TO ${legacyName}`);
       db.exec(`CREATE VIEW ${compatibility.name} AS ${compatibility.select}`);
       db.exec(`DROP TABLE ${legacyName}`);
+    } else if (relationType(db, compatibility.name) === "view" && compatibility.name === "source_assertions") {
+      const existingSql = String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'view' AND name = ?").get(compatibility.name) as { sql?: unknown } | undefined)?.sql ?? "");
+      if (!/revision\.source_record_id/i.test(existingSql)) {
+        db.exec(`DROP VIEW ${compatibility.name}; CREATE VIEW ${compatibility.name} AS ${compatibility.select}`);
+      }
     } else if (relationType(db, compatibility.name) === null) {
       db.exec(`CREATE VIEW ${compatibility.name} AS ${compatibility.select}`);
     }
@@ -1442,6 +1449,9 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   };
   for (const [view, authority] of Object.entries(compatibilityAuthority)) {
     if (!authority.test(tableSql(view))) throw new Error(`Canonical schema v6 compatibility view ${view} is not backed by the shared assertion spine.`);
+  }
+  if (!/JOIN\s+transaction_revisions\s+revision\s+ON/i.test(tableSql("source_assertions")) || !/revision\.source_record_id/i.test(tableSql("source_assertions"))) {
+    throw new Error("Canonical schema v6 Source compatibility view does not preserve revision source identity.");
   }
   const triggerRows = db.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name IN ('trg_current_transaction_fields_origin_insert', 'trg_current_transaction_fields_origin_update')").all() as Array<{ name?: string; sql?: string }>;
   if (triggerRows.length !== 2 || triggerRows.some((row) => !/assertions/i.test(String(row.sql)))) throw new Error("Canonical v6 current projection origin triggers are missing.");
@@ -1858,13 +1868,7 @@ function insertDerivedLifecycleEvent(db: DatabaseSync, values: { assertionId: Ca
   db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, NULL, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
 }
 
-function latestDerivedLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
-  const row = db.prepare(`SELECT event_kind FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
-    WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
-  return row?.event_kind ?? null;
-}
-
-function latestUserLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
+function latestAssertionLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
   const row = db.prepare(`SELECT event_kind FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
     WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
   return row?.event_kind ?? null;
@@ -1939,10 +1943,13 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
           AND assertion.producer_id = ? AND assertion.rule_lineage = ?
         ORDER BY c.commit_sequence DESC, assertion.assertion_id DESC LIMIT 1`).get(transactionId, coordinate.field, input.producerId, input.ruleLineage) as Record<string, unknown> | undefined;
       if (coordinate.state === "unsupported") {
-        if (latest && latestDerivedLifecycle(db, blob(latest.assertion_id)) !== "withdrawn") {
+        if (latest) {
           const withdrawnAssertion = blob(latest.assertion_id);
-          insertDerivedLifecycleEvent(db, { assertionId: withdrawnAssertion, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "withdrawn" });
-          if (existingCurrent?.origin === "derived" && existingCurrent.derived_assertion_id && Buffer.compare(blob(existingCurrent.derived_assertion_id), withdrawnAssertion) === 0) refreshCurrentFieldAfterWithdrawal(db, transactionId, coordinate.field, commitId);
+          db.prepare("INSERT OR IGNORE INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, ?, ?, ?)").run(withdrawnAssertion, runId, coordinateId, commitId);
+          if (latestAssertionLifecycle(db, withdrawnAssertion) !== "withdrawn") {
+            insertDerivedLifecycleEvent(db, { assertionId: withdrawnAssertion, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "withdrawn" });
+            if (existingCurrent?.origin === "derived" && existingCurrent.derived_assertion_id && Buffer.compare(blob(existingCurrent.derived_assertion_id), withdrawnAssertion) === 0) refreshCurrentFieldAfterWithdrawal(db, transactionId, coordinate.field, commitId);
+          }
         }
         continue;
       }
@@ -1951,7 +1958,7 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       let eventKind: "observed" | "superseded" | "restored" | null = "observed";
       if (latest && String(latest.value_text) === value) {
         assertionId = blob(latest.assertion_id);
-        eventKind = latestDerivedLifecycle(db, assertionId) === "withdrawn" ? "restored" : null;
+        eventKind = latestAssertionLifecycle(db, assertionId) === "withdrawn" ? "restored" : null;
       } else {
         assertionId = uuidV7();
         if (latest) insertDerivedLifecycleEvent(db, { assertionId: blob(latest.assertion_id), transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "superseded" });
@@ -2047,7 +2054,7 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
         db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
       } else {
         const value = input.value ?? "";
-        if (prior && String(prior.value_text) === value && latestUserLifecycle(db, blob(prior.assertion_id)) !== "withdrawn") {
+        if (prior && String(prior.value_text) === value && latestAssertionLifecycle(db, blob(prior.assertion_id)) !== "withdrawn") {
           assertionId = blob(prior.assertion_id);
         } else {
           assertionId = uuidV7();
@@ -2221,12 +2228,12 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           derivedAssertions: derivedRows.map((derived) => {
             const derivedAssertionId = blob(derived.assertion_id);
             const provenanceRows = db.prepare("SELECT run_id, coordinate_id FROM assertion_provenance WHERE assertion_id = ? AND run_id IS NOT NULL ORDER BY run_id, coordinate_id").all(derivedAssertionId) as Record<string, unknown>[];
-            return { id: idToString(derivedAssertionId), field: derived.field_name as CathayDerivedField, producerId: String(derived.producer_id), origin: String(derived.origin), ruleLineage: String(derived.rule_lineage), value: String(derived.value_text), state: latestDerivedLifecycle(db, derivedAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(derived.commit_sequence), runId: idToString(derived.run_id), provenance: provenanceRows.map((provenanceRow) => ({ runId: idToString(provenanceRow.run_id), coordinateId: idToString(provenanceRow.coordinate_id) })) };
+            return { id: idToString(derivedAssertionId), field: derived.field_name as CathayDerivedField, producerId: String(derived.producer_id), origin: String(derived.origin), ruleLineage: String(derived.rule_lineage), value: String(derived.value_text), state: latestAssertionLifecycle(db, derivedAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(derived.commit_sequence), runId: idToString(derived.run_id), provenance: provenanceRows.map((provenanceRow) => ({ runId: idToString(provenanceRow.run_id), coordinateId: idToString(provenanceRow.coordinate_id) })) };
           }),
           userAssertions: userRows.map((user) => {
             const userAssertionId = blob(user.assertion_id);
             const userProvenance = db.prepare(`SELECT c.commit_sequence FROM assertion_provenance p JOIN canonical_commits c ON c.commit_id = p.commit_id WHERE p.assertion_id = ? ORDER BY c.commit_sequence`).all(userAssertionId) as Array<Record<string, unknown>>;
-            return { id: idToString(userAssertionId), field: user.field_name as CathayUserAssertionField, userId: String(user.user_id), value: String(user.value_text), state: latestUserLifecycle(db, userAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(user.commit_sequence), provenance: userProvenance.map((item) => ({ commitSequence: Number(item.commit_sequence) })) };
+            return { id: idToString(userAssertionId), field: user.field_name as CathayUserAssertionField, userId: String(user.user_id), value: String(user.value_text), state: latestAssertionLifecycle(db, userAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(user.commit_sequence), provenance: userProvenance.map((item) => ({ commitSequence: Number(item.commit_sequence) })) };
           }),
         } satisfies CathayCanonicalLineageEntry;
       });

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -847,10 +847,6 @@ CREATE TABLE IF NOT EXISTS current_transaction_fields (
 );
 CREATE INDEX IF NOT EXISTS idx_derived_scope_coordinates_lineage ON derived_scope_coordinates(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
 CREATE INDEX IF NOT EXISTS idx_derived_assertions_lineage ON derived_assertions(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
-CREATE INDEX IF NOT EXISTS idx_derived_assertion_provenance_run ON derived_assertion_provenance(run_id, coordinate_id, assertion_id);
-CREATE INDEX IF NOT EXISTS idx_derived_assertion_lifecycle_knowledge ON derived_assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id);
-CREATE INDEX IF NOT EXISTS idx_user_assertion_lifecycle_knowledge ON user_assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id);
-CREATE INDEX IF NOT EXISTS idx_user_assertion_provenance_commit ON user_assertion_provenance(commit_id, assertion_id);
 CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id);
 `;
 const SCHEMA_V6 = `${SCHEMA_V5.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
@@ -874,6 +870,10 @@ if (SCHEMA_V2.includes("completeness_basis") || SCHEMA_V2.includes("completeness
 
 function tableExists(db: DatabaseSync, name: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+function relationType(db: DatabaseSync, name: string): "table" | "view" | null {
+  const row = db.prepare("SELECT type FROM sqlite_master WHERE name = ?").get(name) as { type?: string } | undefined;
+  return row?.type === "table" || row?.type === "view" ? row.type : null;
 }
 function columnExists(db: DatabaseSync, table: string, column: string): boolean {
   return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>).some((row) => row.name === column);
@@ -985,6 +985,102 @@ function ensureV6SharedAssertionSpine(db: DatabaseSync): void {
     db.exec("DROP TABLE assertion_provenance_v5");
   }
   db.exec("CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
+}
+
+function backfillV6DerivedAndUserAssertions(db: DatabaseSync): void {
+  if (tableExists(db, "derived_assertions")) {
+    db.exec(`INSERT OR IGNORE INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id)
+      SELECT assertion_id, transaction_id, field_name, 'transaction', 'derived', producer_id, rule_lineage, NULL, value_text, commit_id FROM derived_assertions`);
+  }
+  if (tableExists(db, "user_assertions")) {
+    db.exec(`INSERT OR IGNORE INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id)
+      SELECT assertion_id, transaction_id, field_name, 'transaction', 'user', user_id, 'user/local', NULL, value_text, commit_id FROM user_assertions`);
+  }
+  if (tableExists(db, "derived_assertion_lifecycle_events")) {
+    db.exec(`INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind)
+      SELECT event.event_id, event.assertion_id, event.transaction_id, event.field_name, NULL, NULL, event.run_id, event.coordinate_id, NULL, event.commit_id, event.event_kind
+      FROM derived_assertion_lifecycle_events event
+      WHERE NOT EXISTS (SELECT 1 FROM assertion_transitions existing
+        WHERE existing.assertion_id = event.assertion_id AND existing.transaction_id = event.transaction_id
+          AND existing.field_name = event.field_name AND existing.run_id = event.run_id
+          AND existing.coordinate_id IS event.coordinate_id AND existing.commit_id = event.commit_id
+          AND existing.event_kind = event.event_kind)`);
+  }
+  if (tableExists(db, "user_assertion_lifecycle_events")) {
+    db.exec(`INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind)
+      SELECT event.event_id, event.assertion_id, event.transaction_id, event.field_name, NULL, NULL, NULL, NULL, event.user_id, event.commit_id, event.event_kind
+      FROM user_assertion_lifecycle_events event
+      WHERE NOT EXISTS (SELECT 1 FROM assertion_transitions existing
+        WHERE existing.assertion_id = event.assertion_id AND existing.transaction_id = event.transaction_id
+          AND existing.field_name = event.field_name AND existing.user_id IS event.user_id
+          AND existing.commit_id = event.commit_id AND existing.event_kind = event.event_kind)`);
+  }
+  if (tableExists(db, "derived_assertion_provenance")) {
+    db.exec(`INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id)
+      SELECT provenance.assertion_id, NULL, provenance.run_id, provenance.coordinate_id, provenance.commit_id
+      FROM derived_assertion_provenance provenance
+      WHERE NOT EXISTS (SELECT 1 FROM assertion_provenance existing
+        WHERE existing.assertion_id = provenance.assertion_id AND existing.source_record_id IS NULL
+          AND existing.run_id = provenance.run_id AND existing.coordinate_id = provenance.coordinate_id
+          AND existing.commit_id = provenance.commit_id)`);
+  }
+  if (tableExists(db, "user_assertion_provenance")) {
+    db.exec(`INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id)
+      SELECT provenance.assertion_id, NULL, NULL, NULL, provenance.commit_id
+      FROM user_assertion_provenance provenance
+      WHERE NOT EXISTS (SELECT 1 FROM assertion_provenance existing
+        WHERE existing.assertion_id = provenance.assertion_id AND existing.source_record_id IS NULL
+          AND existing.run_id IS NULL AND existing.coordinate_id IS NULL AND existing.commit_id = provenance.commit_id)`);
+  }
+}
+
+function convertV6CompatibilityTables(db: DatabaseSync): void {
+  backfillV6DerivedAndUserAssertions(db);
+  const compatibilityViews: Array<{ name: string; select: string }> = [
+    {
+      name: "assertion_lifecycle_events",
+      select: `SELECT transition.event_id, transition.assertion_id, transition.transaction_id, assertion.revision_id,
+        transition.capture_id, transition.scope_id, transition.commit_id, transition.event_kind
+        FROM assertion_transitions transition JOIN assertions assertion ON assertion.assertion_id = transition.assertion_id
+        WHERE assertion.origin = 'source'`,
+    },
+    {
+      name: "derived_assertion_lifecycle_events",
+      select: `SELECT transition.event_id, transition.assertion_id, transition.transaction_id, transition.field_name,
+        transition.run_id, transition.coordinate_id, transition.commit_id, transition.event_kind
+        FROM assertion_transitions transition JOIN assertions assertion ON assertion.assertion_id = transition.assertion_id
+        WHERE assertion.origin = 'derived'`,
+    },
+    {
+      name: "user_assertion_lifecycle_events",
+      select: `SELECT transition.event_id, transition.assertion_id, transition.transaction_id, transition.field_name,
+        transition.user_id, transition.commit_id, transition.event_kind
+        FROM assertion_transitions transition JOIN assertions assertion ON assertion.assertion_id = transition.assertion_id
+        WHERE assertion.origin = 'user'`,
+    },
+    {
+      name: "derived_assertion_provenance",
+      select: `SELECT provenance.assertion_id, provenance.run_id, provenance.coordinate_id, provenance.commit_id
+        FROM assertion_provenance provenance JOIN assertions assertion ON assertion.assertion_id = provenance.assertion_id
+        WHERE assertion.origin = 'derived' AND provenance.run_id IS NOT NULL`,
+    },
+    {
+      name: "user_assertion_provenance",
+      select: `SELECT provenance.assertion_id, provenance.commit_id
+        FROM assertion_provenance provenance JOIN assertions assertion ON assertion.assertion_id = provenance.assertion_id
+        WHERE assertion.origin = 'user' AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL`,
+    },
+  ];
+  for (const compatibility of compatibilityViews) {
+    if (relationType(db, compatibility.name) === "table") {
+      const legacyName = `${compatibility.name}_compat_legacy`;
+      db.exec(`ALTER TABLE ${compatibility.name} RENAME TO ${legacyName}`);
+      db.exec(`CREATE VIEW ${compatibility.name} AS ${compatibility.select}`);
+      db.exec(`DROP TABLE ${legacyName}`);
+    } else if (relationType(db, compatibility.name) === null) {
+      db.exec(`CREATE VIEW ${compatibility.name} AS ${compatibility.select}`);
+    }
+  }
 }
 
 function migrateV4ToV5(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection): void {
@@ -1099,6 +1195,7 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v6 RENAME TO canonical_commits");
     ensureV6SharedAssertionSpine(db);
     db.exec(SCHEMA_V6_APPEND);
+    convertV6CompatibilityTables(db);
     if (injectMigrationFailure === "v5-v6-after-derived-schema") throw new Error("Injected v5-v6 migration failure after derived schema.");
     db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(6, currentUtcMicros());
     db.exec("PRAGMA user_version = 6");
@@ -1153,7 +1250,8 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     db.exec("BEGIN IMMEDIATE");
     try {
       ensureV6SharedAssertionSpine(db);
-      db.exec(SCHEMA_V6_APPEND);
+      if (relationType(db, "assertion_lifecycle_events") !== "view") db.exec(SCHEMA_V6_APPEND);
+      convertV6CompatibilityTables(db);
       db.exec("PRAGMA foreign_keys = ON");
       db.exec("COMMIT");
     } catch (error) {
@@ -1166,6 +1264,8 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
   db.exec("BEGIN IMMEDIATE");
   try {
     db.exec(SCHEMA_V6);
+    ensureV6SharedAssertionSpine(db);
+    convertV6CompatibilityTables(db);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
@@ -1178,7 +1278,10 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 function validateReadOnlyDatabase(db: DatabaseSync): void {
   const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
   for (const table of requiredTables) {
-    if (!tableExists(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
+    if (!relationType(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
+  }
+  for (const table of ["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+    if (relationType(db, table) !== "view") throw new Error(`Canonical schema v6 compatibility relation ${table} is not a read-only view.`);
   }
   const requiredColumns: Record<string, string[]> = {
     assertions: ["assertion_id", "transaction_id", "field_name", "target_kind", "origin", "producer_id", "rule_lineage", "revision_id", "value_text", "created_commit_id"],
@@ -1204,17 +1307,16 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     for (const column of columns) if (!actual.has(column)) throw new Error(`Canonical schema v6 column ${table}.${column} is missing.`);
   }
   const requiredIndexes = [
-    "idx_canonical_commits_sequence", "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof", "idx_assertion_lifecycle_scope",
+    "idx_canonical_commits_sequence", "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof",
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
     "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
-    "idx_derived_scope_coordinates_lineage", "idx_derived_assertions_lineage", "idx_derived_assertion_provenance_run",
-    "idx_derived_assertion_lifecycle_knowledge", "idx_user_assertion_lifecycle_knowledge", "idx_current_transaction_fields_projection",
-    "idx_user_assertion_provenance_commit",
+    "idx_derived_scope_coordinates_lineage", "idx_derived_assertions_lineage",
+    "idx_current_transaction_fields_projection",
   ];
   for (const index of requiredIndexes) {
     if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v6 index ${index} is missing.`);
   }
-  const tableSql = (table: string): string => String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) as { sql?: unknown } | undefined)?.sql ?? "");
+  const tableSql = (table: string): string => String((db.prepare("SELECT sql FROM sqlite_master WHERE (type = 'table' OR type = 'view') AND name = ?").get(table) as { sql?: unknown } | undefined)?.sql ?? "");
   if (!/FOREIGN KEY\s*\(source_record_id,\s*capture_id\)/i.test(tableSql("source_record_scopes")) || !/capture_scopes/i.test(tableSql("source_record_scopes"))) {
     throw new Error("Canonical schema v6 source-record scope constraints are missing.");
   }
@@ -1225,8 +1327,11 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     throw new Error("Canonical schema v6 assertion origin taxonomy is missing.");
   }
   const transitionCheck = /event_kind\s+TEXT\s+NOT NULL\s+CHECK\s*\(event_kind\s+IN\s*\('observed','superseded','withdrawn'(?:,'restored')?\)\)/i;
-  if (!transitionCheck.test(tableSql("assertion_transitions")) || !transitionCheck.test(tableSql("derived_assertion_lifecycle_events")) || !transitionCheck.test(tableSql("user_assertion_lifecycle_events"))) {
+  if (!transitionCheck.test(tableSql("assertion_transitions"))) {
     throw new Error("Canonical schema v6 shared assertion transition taxonomy is missing.");
+  }
+  if (!["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"].every((view) => /assertion_(?:transitions|provenance)/i.test(tableSql(view)))) {
+    throw new Error("Canonical schema v6 compatibility views are not backed by the shared assertion spine.");
   }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
@@ -1342,7 +1447,6 @@ function insertLifecycleEvent(
   values: { assertionId: CanonicalId; transactionId: CanonicalId; revisionId: CanonicalId; captureId: CanonicalId; scopeId: CanonicalId | null; commitId: CanonicalId; kind: LifecycleEventKind },
 ): void {
   const eventId = uuidV7();
-  db.prepare("INSERT INTO assertion_lifecycle_events(event_id, assertion_id, transaction_id, revision_id, capture_id, scope_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(eventId, values.assertionId, values.transactionId, values.revisionId, values.captureId, values.scopeId, values.commitId, values.kind);
   db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, 'transaction_revision', ?, ?, NULL, NULL, NULL, ?, ?)").run(eventId, values.assertionId, values.transactionId, values.captureId, values.scopeId, values.commitId, values.kind);
 }
 function latestLifecycleEvent(db: DatabaseSync, assertionId: CanonicalId): LifecycleEventKind | null {
@@ -1591,7 +1695,6 @@ function derivedDiagnostic(error: unknown, input: CathayDerivedImportRunInput, s
 }
 
 function insertDerivedLifecycleEvent(db: DatabaseSync, values: { assertionId: CanonicalId; transactionId: CanonicalId; field: CathayDerivedField; runId: CanonicalId; coordinateId: CanonicalId | null; commitId: CanonicalId; kind: "observed" | "superseded" | "withdrawn" | "restored" }): void {
-  db.prepare("INSERT INTO derived_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, run_id, coordinate_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
   db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, NULL, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
 }
 
@@ -1619,7 +1722,7 @@ function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: Can
     JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
     WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'user'
     AND e.event_kind NOT IN ('withdrawn','superseded')
-    AND NOT EXISTS (SELECT 1 FROM user_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+    AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
       WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id)
         OR (nc.commit_sequence = (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) AND newer.rowid > e.rowid)))
     ORDER BY (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) DESC, e.rowid DESC LIMIT 1`).get(transactionId, field) as Record<string, unknown> | undefined;
@@ -1693,7 +1796,6 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
         db.prepare("INSERT INTO derived_assertions(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage, value_text, run_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, value, runId, commitId);
         db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'derived', ?, ?, NULL, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, input.ruleLineage, value, commitId);
       }
-      db.prepare("INSERT INTO derived_assertion_provenance(assertion_id, run_id, coordinate_id, commit_id) VALUES (?, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
       db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
       if (eventKind) insertDerivedLifecycleEvent(db, { assertionId, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: eventKind });
       assertionIds.push(idToString(assertionId));
@@ -1761,7 +1863,6 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
       if (withdrawn) {
         if (!prior) throw new Error("Cannot withdraw a user assertion that does not exist.");
         assertionId = blob(prior.assertion_id);
-        db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
         db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
       } else {
         const value = input.value ?? "";
@@ -1770,12 +1871,10 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
         } else {
           assertionId = uuidV7();
           if (prior) {
-            db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
             db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
           }
           db.prepare("INSERT INTO user_assertions(assertion_id, transaction_id, field_name, user_id, value_text, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
           db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'user', ?, 'user/local', NULL, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
-          db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
           db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
         }
       }
@@ -1785,7 +1884,6 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
       }
       else db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
         VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, input.value ?? "", assertionId, commitId);
-      db.prepare("INSERT OR IGNORE INTO user_assertion_provenance(assertion_id, commit_id) VALUES (?, ?)").run(assertionId, commitId);
       db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, NULL, NULL, ?)").run(assertionId, commitId);
       db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
       db.exec("COMMIT"); inTransaction = false;

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -8,12 +8,17 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 2;
+export const CANONICAL_SCHEMA_VERSION = 3;
 export const CATHAY_POSTING_MAPPING = {
   contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   postingStatus: "posted",
   origin: "provider_booked_history",
   basis: "query-status-success-with-accounting-date",
+  ruleVersion: "cathay/domestic-deposit/v1",
+} as const;
+export const CATHAY_COMPLETENESS_PROOF = {
+  kind: "complete-range",
+  basis: "success-status-scope-count-details",
   ruleVersion: "cathay/domestic-deposit/v1",
 } as const;
 
@@ -35,8 +40,8 @@ export type CathayDomesticDepositCaptureInput = {
   currency: string;
   authorityRoute: string;
   stream: string;
-  scope: { startDate: string; endDate: string; complete: boolean };
-  syncState: { cursor: string };
+  scope: { startDate: string; endDate: string; complete?: boolean };
+  syncState: { cursor?: string | null };
   observedAt: string;
 };
 
@@ -48,8 +53,8 @@ export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput 
   currency: "TWD",
   authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
-  scope: { startDate: "2025-08-17", endDate: "2026-08-17", complete: true },
-  syncState: { cursor: "2026-08-17" },
+  scope: { startDate: "2025-08-17", endDate: "2026-08-17" },
+  syncState: { cursor: null },
   observedAt: "2026-08-17T12:00:00+08:00",
 };
 
@@ -203,10 +208,26 @@ function requireDateTime(value: string, label: string): string {
   if (Number.isNaN(calendarShape.getTime()) || calendarShape.toISOString().slice(0, 19) !== value) throw new Error(`${label} must be a valid local date-time.`);
   return value;
 }
+function parseRfc3339UtcMicros(value: string, label: string): number {
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/);
+  if (!match) throw new Error(`${label} must be RFC3339 with an explicit UTC designator or numeric offset.`);
+  const civil = `${match[1]}T${match[2]}`;
+  if ((match[3]?.length ?? 0) > 6) throw new Error(`${label} exceeds integer microsecond precision.`);
+  const calendarShape = new Date(`${civil}Z`);
+  if (Number.isNaN(calendarShape.getTime()) || calendarShape.toISOString().slice(0, 19) !== civil) throw new Error(`${label} must be a valid RFC3339 timestamp.`);
+  if (match[4] !== "Z") {
+    const [hours, minutes] = match[4].slice(1).split(":").map(Number);
+    if (hours > 23 || minutes > 59) throw new Error(`${label} has an invalid numeric offset.`);
+  }
+  const epochMilliseconds = Date.parse(`${civil}${match[4]}`);
+  if (!Number.isSafeInteger(epochMilliseconds)) throw new Error(`${label} is outside the supported instant range.`);
+  const fractionMicros = BigInt((match[3] ?? "").slice(0, 6).padEnd(6, "0"));
+  const micros = BigInt(epochMilliseconds) * 1000n + fractionMicros;
+  if (micros > BigInt(Number.MAX_SAFE_INTEGER) || micros < BigInt(Number.MIN_SAFE_INTEGER)) throw new Error(`${label} microseconds exceed the safe SQLite binding range.`);
+  return Number(micros);
+}
 function localDateTimeToUtcMicros(value: string): number {
-  const milliseconds = new Date(`${value}+08:00`).getTime();
-  if (!Number.isSafeInteger(milliseconds)) throw new Error("Cathay local date-time is outside the supported instant range.");
-  return milliseconds * 1000;
+  return parseRfc3339UtcMicros(`${value}+08:00`, "Cathay local date-time");
 }
 function localDateToUtcMicros(value: string): number {
   return localDateTimeToUtcMicros(`${value}T00:00:00`);
@@ -229,6 +250,7 @@ type ValidatedCathayCapture = {
   startDate: string;
   endDate: string;
   posting: typeof CATHAY_POSTING_MAPPING;
+  completeness: typeof CATHAY_COMPLETENESS_PROOF;
   rows: ValidatedCathayRow[];
 };
 
@@ -251,13 +273,10 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
   if (input.currency !== "TWD") throw new Error("Cathay domestic deposit currency must be TWD.");
   if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) throw new Error("Invalid authority route.");
   if (input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Invalid Cathay product stream.");
-  if (!input.scope.complete) throw new Error("Cathay transfer scope must be complete.");
-  if (!input.syncState.cursor.trim()) throw new Error("Cathay sync state cursor is required.");
   const startDate = requireDate(input.scope.startDate, "scope.startDate");
   const endDate = requireDate(input.scope.endDate, "scope.endDate");
   if (startDate > endDate) throw new Error("Cathay scope startDate must not be after endDate.");
-  const observedAtMs = Date.parse(input.observedAt);
-  if (!Number.isSafeInteger(observedAtMs)) throw new Error("Invalid observation time.");
+  parseRfc3339UtcMicros(input.observedAt, "Capture observedAt");
 
   const root = asObject(new LosslessJsonParser(input.rawResponse).parse(), "Cathay response");
   if (root.success !== true) throw new Error("Cathay response was not successful.");
@@ -314,7 +333,7 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
       payload: JSON.stringify(payload),
     } satisfies ValidatedCathayRow;
   });
-  return { accountNo, startDate, endDate, posting, rows };
+  return { accountNo, startDate, endDate, posting, completeness: CATHAY_COMPLETENESS_PROOF, rows };
 }
 
 type CanonicalId = Buffer;
@@ -368,7 +387,8 @@ CREATE TABLE IF NOT EXISTS source_captures (
   capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
   identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
   stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
-  completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
+  completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),
+  completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 CREATE TABLE IF NOT EXISTS source_records (
   source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
@@ -416,7 +436,7 @@ CREATE TABLE IF NOT EXISTS assertion_provenance (
 );
 CREATE TABLE IF NOT EXISTS source_sync_states (
   source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
-  stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT NOT NULL,
+  stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT,
   last_capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   PRIMARY KEY(source_connection_id, account_id, stream)
 );
@@ -463,8 +483,32 @@ function migrateV1ToV2(db: DatabaseSync): void {
     }
     const latestCommit = db.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as Record<string, unknown> | undefined;
     if (latestCommit) db.prepare("INSERT OR REPLACE INTO current_projection_state(generation, commit_id) VALUES (1, ?)").run(blob(latestCommit.commit_id));
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, Date.now() * 1000);
-    db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(2, currentUtcMicros());
+    db.exec("PRAGMA user_version = 2");
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+function migrateV2ToV3(db: DatabaseSync): void {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec("ALTER TABLE source_captures ADD COLUMN completeness_basis TEXT NOT NULL DEFAULT 'success-status-scope-count-details' CHECK(completeness_basis = 'success-status-scope-count-details')");
+    db.exec("ALTER TABLE source_captures ADD COLUMN completeness_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1')");
+    db.exec("ALTER TABLE source_sync_states RENAME TO source_sync_states_v2");
+    db.exec(`CREATE TABLE source_sync_states (
+      source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+      stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT,
+      last_capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+      PRIMARY KEY(source_connection_id, account_id, stream)
+    )`);
+    db.exec(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
+      SELECT source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id FROM source_sync_states_v2`);
+    db.exec("DROP TABLE source_sync_states_v2");
+    db.exec(SCHEMA);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(3, currentUtcMicros());
+    db.exec("PRAGMA user_version = 3");
     db.exec("COMMIT");
   } catch (error) {
     db.exec("ROLLBACK");
@@ -478,6 +522,11 @@ function applySchemaMigration(db: DatabaseSync): void {
   if (version === 0 && tableExists(db, "canonical_commits")) throw new Error("Unversioned canonical SQLite schema is not compatible; refusing ad-hoc migration.");
   if (version === 1) {
     migrateV1ToV2(db);
+    migrateV2ToV3(db);
+    return;
+  }
+  if (version === 2) {
+    migrateV2ToV3(db);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -489,7 +538,7 @@ function applySchemaMigration(db: DatabaseSync): void {
   db.exec("BEGIN IMMEDIATE");
   try {
     db.exec(SCHEMA);
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, Date.now() * 1000);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
   } catch (error) {
@@ -581,12 +630,22 @@ function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow):
     && row.effective_time_rule_version === CATHAY_POSTING_MAPPING.ruleVersion && Number(row.utc_instant_utc_us) === detail.utcInstantUtcUs;
 }
 function recordedAtUtcUs(value: string): number {
-  const milliseconds = Date.parse(value);
-  if (!Number.isSafeInteger(milliseconds)) throw new Error("Invalid observation time.");
-  return milliseconds * 1000;
+  return parseRfc3339UtcMicros(value, "Canonical admission clock");
 }
 
-function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesticDepositCaptureInput, validated: ValidatedCathayCapture): CathayCanonicalCommitResult {
+function currentUtcMicros(): number {
+  return parseRfc3339UtcMicros(new Date().toISOString(), "Canonical migration clock");
+}
+
+export type CanonicalAdmissionClock = () => string;
+export type CathayCanonicalCommitOptions = { clock?: CanonicalAdmissionClock };
+
+function commitCathayDomesticDepositOnce(
+  ledgerDir: string,
+  input: CathayDomesticDepositCaptureInput,
+  validated: ValidatedCathayCapture,
+  admissionClock: CanonicalAdmissionClock,
+): CathayCanonicalCommitResult {
   const db = openCanonicalDatabase(ledgerDir);
   let inTransaction = false;
   try {
@@ -595,7 +654,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
     const commitId = uuidV7();
     const maxSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0);
     const commitSequence = maxSequence + 1;
-    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(input.observedAt), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, "source_capture");
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(admissionClock()), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, "source_capture");
     db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1", commitId);
     const connectionExisting = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
     const sourceConnectionId = connectionExisting ? blob(dbRow<{ source_connection_id: unknown }>(connectionExisting).source_connection_id) : uuidV7();
@@ -610,7 +669,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
       if (account.currency !== input.currency || account.account_type !== "depository") throw new Error("Cathay account identity has conflicting required classification.");
     } else db.prepare("INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(accountId, sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo, "depository", input.currency, commitId);
     const captureId = uuidV7();
-    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, "complete-range", commitId);
+    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, validated.completeness.kind, validated.completeness.basis, validated.completeness.ruleVersion, commitId);
 
     const transactionResults: CathayCommitTransactionResult[] = [];
     for (const detail of validated.rows) {
@@ -653,7 +712,7 @@ function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesti
     }
     db.prepare(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET scope_start = excluded.scope_start,
-      scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor, captureId, commitId);
+      scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor ?? null, captureId, commitId);
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
@@ -687,9 +746,14 @@ async function withCanonicalWriter<T>(ledgerDir: string, operation: () => T): Pr
   }
 }
 
-export function commitCathayDomesticDeposit(ledgerDir: string, input: CathayDomesticDepositCaptureInput): Promise<CathayCanonicalCommitResult> {
+export function commitCathayDomesticDeposit(
+  ledgerDir: string,
+  input: CathayDomesticDepositCaptureInput,
+  options: CathayCanonicalCommitOptions = {},
+): Promise<CathayCanonicalCommitResult> {
   const validated = validateCapture(input);
-  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositOnce(ledgerDir, input, validated));
+  const admissionClock = options.clock ?? (() => new Date().toISOString());
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositOnce(ledgerDir, input, validated, admissionClock));
 }
 
 function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import {
   configureCanonicalRuntime,
   verifyCanonicalRuntime,
+  withCanonicalSnapshot,
   withCanonicalWriterQueue,
   type CanonicalRuntimeOptions,
 } from "./canonical-runtime.ts";
@@ -961,6 +962,24 @@ CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_commit_update
 BEFORE UPDATE OF generation_id, switched_commit_id ON active_projection_generation
 WHEN NEW.switched_commit_id IS NOT (SELECT switched_commit_id FROM projection_generations WHERE generation_id = NEW.generation_id)
 BEGIN SELECT RAISE(ABORT, 'active projection switch commit does not match generation'); END;
+CREATE TRIGGER IF NOT EXISTS trg_projection_generation_fields_integrity_insert
+BEFORE INSERT ON projection_generation_transaction_fields
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion JOIN projection_generations generation ON generation.generation_id = NEW.generation_id
+  WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
+    AND assertion.origin = NEW.origin AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
+    AND NEW.projection_commit_id IS COALESCE(generation.switched_commit_id, generation.created_commit_id)
+)
+BEGIN SELECT RAISE(ABORT, 'projection generation field assertion integrity mismatch'); END;
+CREATE TRIGGER IF NOT EXISTS trg_projection_generation_fields_integrity_update
+BEFORE UPDATE OF generation_id, transaction_id, field_name, origin, derived_assertion_id, user_assertion_id, projection_commit_id ON projection_generation_transaction_fields
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion JOIN projection_generations generation ON generation.generation_id = NEW.generation_id
+  WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
+    AND assertion.origin = NEW.origin AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
+    AND NEW.projection_commit_id IS COALESCE(generation.switched_commit_id, generation.created_commit_id)
+)
+BEGIN SELECT RAISE(ABORT, 'projection generation field assertion integrity mismatch'); END;
 `;
 
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
@@ -1491,6 +1510,103 @@ function canonicalIdsEqual(left: unknown, right: unknown): boolean {
   return Buffer.compare(Buffer.from(left), Buffer.from(right)) === 0;
 }
 
+function projectionIdentityKey(row: { transaction_id?: unknown; revision_id?: unknown }): string {
+  return `${blob(row.transaction_id).toString("hex")}:${blob(row.revision_id).toString("hex")}`;
+}
+
+/** Rebuild population is intentionally allowed to omit malformed evidence;
+ * this equality check makes that omission observable before a shadow can be
+ * validated. The expected set is derived from immutable revision/scope rows,
+ * not from the Source Assertion join used by the population query. */
+function validateGenerationTransactionCompleteness(db: DatabaseSync, generationId: number, cutoff: number): void {
+  const expected = db.prepare(`SELECT transaction_row.transaction_id, revision.revision_id
+    FROM financial_transactions transaction_row
+    JOIN transaction_revisions revision ON revision.transaction_id = transaction_row.transaction_id
+    JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
+    JOIN source_captures capture ON capture.capture_id = revision.capture_id
+    JOIN source_records source_record ON source_record.source_record_id = revision.source_record_id AND source_record.capture_id = revision.capture_id
+    JOIN source_record_scopes source_scope ON source_scope.source_record_id = source_record.source_record_id AND source_scope.capture_id = source_record.capture_id AND source_scope.sequence_lexeme = source_record.sequence_lexeme
+    JOIN capture_scopes scope ON scope.scope_id = source_scope.scope_id AND scope.capture_id = source_scope.capture_id AND scope.account_id = transaction_row.account_id
+    WHERE revision_commit.commit_sequence <= ?
+      AND NOT EXISTS (SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
+        WHERE newer.transaction_id = revision.transaction_id AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > revision_commit.commit_sequence)
+      AND COALESCE((SELECT transition.event_kind FROM assertions source_assertion
+        JOIN assertion_transitions transition ON transition.assertion_id = source_assertion.assertion_id
+        JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
+        WHERE source_assertion.origin = 'source' AND source_assertion.revision_id = revision.revision_id
+          AND transition_commit.commit_sequence <= ?
+        ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1), 'observed') <> 'withdrawn'`).all(cutoff, cutoff, cutoff) as Array<{ transaction_id?: unknown; revision_id?: unknown }>;
+  const actual = db.prepare("SELECT transaction_id, revision_id FROM projection_generation_transactions WHERE generation_id = ?").all(generationId) as Array<{ transaction_id?: unknown; revision_id?: unknown }>;
+  const expectedKeys = new Set(expected.map(projectionIdentityKey));
+  const actualKeys = new Set(actual.map(projectionIdentityKey));
+  const missing = [...expectedKeys].filter((key) => !actualKeys.has(key));
+  const extra = [...actualKeys].filter((key) => !expectedKeys.has(key));
+  if (missing.length !== 0 || extra.length !== 0 || expectedKeys.size !== actualKeys.size) {
+    throw new Error(`Projection rebuild completeness mismatch: missing=${missing.length}, extra=${extra.length}.`);
+  }
+}
+
+function validateGenerationFieldIntegrity(db: DatabaseSync, generationId: number): void {
+  const rows = db.prepare(`SELECT field.generation_id, field.transaction_id, field.field_name, field.value_text, field.origin,
+      field.derived_assertion_id, field.user_assertion_id, field.projection_commit_id,
+      generation.build_cutoff_commit_sequence, generation.created_commit_id AS generation_created_commit_id,
+      generation.switched_commit_id AS generation_switched_commit_id,
+      assertion.assertion_id, assertion.transaction_id AS assertion_transaction_id, assertion.field_name AS assertion_field_name,
+      assertion.origin AS assertion_origin, assertion.producer_id AS assertion_producer_id, assertion.rule_lineage AS assertion_rule_lineage,
+      assertion.value_text AS assertion_value_text, assertion.created_commit_id AS assertion_created_commit_id,
+      assertion_commit.commit_sequence AS assertion_commit_sequence, assertion_commit.authority_route AS assertion_authority_route,
+      projected.transaction_id AS projected_transaction_id, projected.revision_id AS projected_revision_id,
+      projected.projection_commit_id AS projected_projection_commit_id, projected.revision_commit_id AS projected_revision_commit_id,
+      revision.transaction_id AS revision_transaction_id, revision.commit_id AS revision_commit_id,
+      projection_commit.commit_sequence AS projection_commit_sequence,
+      (SELECT transition.event_kind FROM assertion_transitions transition JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
+        WHERE transition.assertion_id = assertion.assertion_id AND transition_commit.commit_sequence <= generation.build_cutoff_commit_sequence
+        ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1) AS lifecycle_event,
+      run.run_id, run.authority_route AS run_authority_route, run.stream AS run_stream, run.producer_id AS run_producer_id,
+      run.origin AS run_origin, run.rule_lineage AS run_rule_lineage, run.status AS run_status,
+      registered.integration_namespace AS registered_namespace, registered.stream AS registered_stream,
+      registered.contract_version AS registered_contract_version
+    FROM projection_generation_transaction_fields field
+    JOIN projection_generations generation ON generation.generation_id = field.generation_id
+    LEFT JOIN assertions assertion ON assertion.assertion_id = CASE WHEN field.origin = 'derived' THEN field.derived_assertion_id ELSE field.user_assertion_id END
+    LEFT JOIN canonical_commits assertion_commit ON assertion_commit.commit_id = assertion.created_commit_id
+    LEFT JOIN projection_generation_transactions projected ON projected.generation_id = field.generation_id AND projected.transaction_id = field.transaction_id
+    LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    LEFT JOIN canonical_commits projection_commit ON projection_commit.commit_id = field.projection_commit_id
+    LEFT JOIN derived_import_runs run ON run.commit_id = assertion.created_commit_id AND run.producer_id = assertion.producer_id AND run.rule_lineage = assertion.rule_lineage
+    LEFT JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+    WHERE field.generation_id = ?`).all(generationId) as Array<Record<string, unknown>>;
+  for (const row of rows) {
+    const expectedProjectionCommit = row.generation_switched_commit_id ?? row.generation_created_commit_id;
+    const validLifecycle = row.lifecycle_event === "observed" || row.lifecycle_event === "restored";
+    const assertionMatches = row.assertion_id !== undefined && row.assertion_id !== null
+      && canonicalIdsEqual(row.assertion_transaction_id, row.transaction_id)
+      && row.assertion_field_name === row.field_name && row.assertion_origin === row.origin
+      && row.assertion_value_text === row.value_text;
+    const projectionMatches = canonicalIdsEqual(row.projection_commit_id, expectedProjectionCommit)
+      && row.projected_projection_commit_id !== undefined && row.projected_projection_commit_id !== null
+      && canonicalIdsEqual(row.projected_projection_commit_id, row.projection_commit_id)
+      && canonicalIdsEqual(row.projected_revision_commit_id, row.revision_commit_id)
+      && canonicalIdsEqual(row.revision_transaction_id, row.transaction_id)
+      && row.projected_transaction_id !== undefined && row.projected_transaction_id !== null
+      && row.projection_commit_sequence !== undefined && row.projection_commit_sequence !== null;
+    const assertionAsOfCutoff = row.assertion_commit_sequence !== undefined && row.assertion_commit_sequence !== null
+      && Number(row.assertion_commit_sequence) <= Number(row.build_cutoff_commit_sequence);
+    const authorityValid = row.origin === "user"
+      ? row.assertion_rule_lineage === "user/local" && row.assertion_authority_route === "user/local" && typeof row.assertion_producer_id === "string" && String(row.assertion_producer_id).length > 0
+      : row.origin === "derived"
+        && row.assertion_authority_route === CATHAY_DOMESTIC_DEPOSIT_AUTHORITY
+        && row.assertion_producer_id === row.run_producer_id && row.assertion_rule_lineage === row.run_rule_lineage
+        && row.run_authority_route === CATHAY_DOMESTIC_DEPOSIT_AUTHORITY && row.run_stream === CATHAY_DOMESTIC_DEPOSIT_STREAM
+        && row.run_origin === CATHAY_DERIVED_ORIGIN && row.run_status === "complete"
+        && row.registered_namespace === CATHAY_INTEGRATION_NAMESPACE && row.registered_stream === CATHAY_DOMESTIC_DEPOSIT_STREAM
+        && row.registered_contract_version === CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION;
+    if (!assertionMatches || !projectionMatches || !validLifecycle || !assertionAsOfCutoff || !authorityValid) {
+      throw new Error("Canonical v7 projection field assertion integrity is invalid.");
+    }
+  }
+}
+
 /** Validate the one switch boundary used by both writer and read-only startup.
  * This is intentionally a row-level gate: SQLite FKs can prove that a pointer
  * names a row, but cannot prove that the row is the sole active generation or
@@ -1524,6 +1640,7 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
   }
   validateGenerationExactAmounts(db, generationId);
   validateCathayAuthorityRoute(db, generationId);
+  validateGenerationFieldIntegrity(db, generationId);
   return generationId;
 }
 
@@ -2049,17 +2166,11 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     let fieldCount = 0;
     for (const transaction of generationTransactions) {
       for (const field of ["display_name", "note"] as const) {
-        const selectAsOf = (origin: "user" | "derived") => db.prepare(`SELECT a.assertion_id, a.value_text FROM assertions a
-          JOIN assertion_transitions e ON e.assertion_id = a.assertion_id JOIN canonical_commits c ON c.commit_id = e.commit_id
-          WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
-            AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
-              WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ?
-                AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
-          ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(blob(transaction.transaction_id), field, origin, cutoff, cutoff) as { assertion_id?: unknown; value_text?: unknown } | undefined;
-        const selected = selectAsOf("user") ?? selectAsOf("derived");
+        const selected = selectAssertionAsOf(db, blob(transaction.transaction_id), field, cutoff, "user")
+          ?? selectAssertionAsOf(db, blob(transaction.transaction_id), field, cutoff, "derived");
         if (!selected) continue;
         const assertion = blob(selected.assertion_id);
-        insertField.run(generation, blob(transaction.transaction_id), field, String(selected.value_text), (selectAsOf("user") ? "user" : "derived"), (selectAsOf("user") ? null : assertion), (selectAsOf("user") ? assertion : null), commitId);
+        insertField.run(generation, blob(transaction.transaction_id), field, selected.value_text, selected.origin, selected.origin === "derived" ? assertion : null, selected.origin === "user" ? assertion : null, commitId);
         fieldCount += 1;
       }
     }
@@ -2069,8 +2180,10 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
       LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
       WHERE projected.generation_id = ? AND (transaction_row.transaction_id IS NULL OR revision.revision_id IS NULL OR revision.transaction_id <> projected.transaction_id)`).get(generation) as { count?: number }).count ?? 0);
     if (dangling !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
+    validateGenerationTransactionCompleteness(db, generation, cutoff);
     validateGenerationExactAmounts(db, generation);
     validateCathayAuthorityRoute(db, generation);
+    validateGenerationFieldIntegrity(db, generation);
     const duplicate = Number((db.prepare(`SELECT COUNT(*) AS count FROM (SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ? GROUP BY transaction_id HAVING COUNT(*) <> 1)`).get(generation) as { count?: number }).count ?? 0);
     if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
     rebuildFailure(options.injectFailure, ["validation", "after-validation"]);
@@ -2275,13 +2388,14 @@ function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommi
   const generationId = Number(pointer.generation_id);
   const generation = db.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(generationId) as { status?: string } | undefined;
   if (!generation || generation.status !== "active") throw new Error("Canonical active projection generation is not writable.");
+  db.prepare("UPDATE projection_generations SET build_cutoff_commit_sequence = (SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?), switched_commit_id = ?, validated_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
+  db.prepare("UPDATE current_transactions SET commit_id = ?, projection_commit_id = ?").run(projectionCommitId, projectionCommitId);
   db.prepare("DELETE FROM projection_generation_transaction_fields WHERE generation_id = ?").run(generationId);
   db.prepare("DELETE FROM projection_generation_transactions WHERE generation_id = ?").run(generationId);
   db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
     SELECT ?, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run(generationId);
   db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
     SELECT ?, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run(generationId);
-  db.prepare("UPDATE projection_generations SET build_cutoff_commit_sequence = (SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?), switched_commit_id = ?, validated_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
   db.prepare("UPDATE active_projection_generation SET switched_commit_id = ? WHERE singleton_id = 1").run(projectionCommitId);
 }
 
@@ -2495,15 +2609,25 @@ function selectedCurrentField(db: DatabaseSync, transactionId: unknown, field: C
 
 type HistoricalAssertionOrigin = "derived" | "user";
 type SelectedHistoricalField = { value: string; origin: HistoricalAssertionOrigin; commitSequence: number };
+type SelectedAssertionAsOf = { assertion_id: unknown; value_text: string; origin: HistoricalAssertionOrigin; commitSequence: number };
 
-function selectHistoricalFieldByOrigin(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number, origin: HistoricalAssertionOrigin): SelectedHistoricalField | undefined {
-  const row = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
+/** One as-of assertion selector is shared by historical reads and rebuilds so
+ * lifecycle ordering and cutoff semantics cannot drift between the two paths. */
+function selectAssertionAsOf(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number, origin: HistoricalAssertionOrigin): SelectedAssertionAsOf | undefined {
+  const row = db.prepare(`SELECT a.assertion_id, a.value_text, c.commit_sequence
+    FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
     JOIN canonical_commits c ON c.commit_id = e.commit_id
     WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
       AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
-        WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
-    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, origin, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
-  return row ? { value: String(row.value_text), origin, commitSequence: Number(row.commit_sequence) } : undefined;
+        WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ?
+          AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
+    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, origin, knowledgeAt, knowledgeAt) as { assertion_id?: unknown; value_text?: unknown; commit_sequence?: number } | undefined;
+  return row ? { assertion_id: row.assertion_id, value_text: String(row.value_text), origin, commitSequence: Number(row.commit_sequence) } : undefined;
+}
+
+function selectHistoricalFieldByOrigin(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number, origin: HistoricalAssertionOrigin): SelectedHistoricalField | undefined {
+  const selected = selectAssertionAsOf(db, transactionId, field, knowledgeAt, origin);
+  return selected ? { value: selected.value_text, origin, commitSequence: selected.commitSequence } : undefined;
 }
 
 function selectedHistoricalField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number): SelectedHistoricalField | undefined {
@@ -2524,7 +2648,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
   async current(_request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult> {
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      db.exec("BEGIN");
+      return withCanonicalSnapshot(db, () => {
       const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
@@ -2538,8 +2662,8 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         JOIN canonical_commits c ON c.commit_id = pointer.switched_commit_id WHERE pointer.singleton_id = 1`).get() as { commit_sequence?: number } | undefined;
       if (!projection) throw new Error("Canonical current projection cutoff is missing.");
       const result = { status: "ok", kind: "current", accounts, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row))), commitSequence: Number(projection.commit_sequence) } satisfies CathayCanonicalCurrentQueryResult;
-      db.exec("COMMIT");
       return result;
+      });
     } finally { db.close(); }
   }
   async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {
@@ -2549,7 +2673,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     if (!Number.isSafeInteger(knowledgeAt)) throw new Error("Canonical historical knowledgeAt is outside the supported sequence range.");
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      db.exec("BEGIN");
+      return withCanonicalSnapshot(db, () => {
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
@@ -2566,8 +2690,8 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
         ) ORDER BY a.account_no, t.source_sequence`).all(knowledgeAt, request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
       const result = { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row, knowledgeAt))) } satisfies CathayCanonicalHistoricalQueryResult;
-      db.exec("COMMIT");
       return result;
+      });
     } finally { db.close(); }
   }
   async lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult> {
@@ -2575,7 +2699,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const transactionId = idFromString(request.subject.id);
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      db.exec("BEGIN");
+      return withCanonicalSnapshot(db, () => {
       const revisionRows = db.prepare(`SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
@@ -2631,8 +2755,8 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         } satisfies CathayCanonicalLineageEntry;
       });
       const result = { status: "ok", kind: "lineage", subject: request.subject, entries } satisfies CathayCanonicalLineageQueryResult;
-      db.exec("COMMIT");
       return result;
+      });
     } finally { db.close(); }
   }
 }

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -2109,21 +2109,22 @@ function selectedCurrentField(db: DatabaseSync, transactionId: unknown, field: C
   return { value: String(row.value_text), origin: row.origin, commitSequence: Number(row.commit_sequence) };
 }
 
-function selectedHistoricalField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number): { value: string; origin: "derived" | "user"; commitSequence: number } | undefined {
-  const user = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
+type HistoricalAssertionOrigin = "derived" | "user";
+type SelectedHistoricalField = { value: string; origin: HistoricalAssertionOrigin; commitSequence: number };
+
+function selectHistoricalFieldByOrigin(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number, origin: HistoricalAssertionOrigin): SelectedHistoricalField | undefined {
+  const row = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
     JOIN canonical_commits c ON c.commit_id = e.commit_id
-    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'user' AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
       AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
         WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
-    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
-  if (user) return { value: String(user.value_text), origin: "user", commitSequence: Number(user.commit_sequence) };
-  const derived = db.prepare(`SELECT a.value_text, c.commit_sequence FROM assertions a JOIN assertion_transitions e ON e.assertion_id = a.assertion_id
-    JOIN canonical_commits c ON c.commit_id = e.commit_id
-    WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = 'derived' AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
-      AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
-        WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
-    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
-  return derived ? { value: String(derived.value_text), origin: "derived", commitSequence: Number(derived.commit_sequence) } : undefined;
+    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, origin, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
+  return row ? { value: String(row.value_text), origin, commitSequence: Number(row.commit_sequence) } : undefined;
+}
+
+function selectedHistoricalField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number): SelectedHistoricalField | undefined {
+  return selectHistoricalFieldByOrigin(db, transactionId, field, knowledgeAt, "user")
+    ?? selectHistoricalFieldByOrigin(db, transactionId, field, knowledgeAt, "derived");
 }
 
 function addSelectedFields(db: DatabaseSync, row: Record<string, unknown>, knowledgeAt?: number): Record<string, unknown> {

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1,0 +1,861 @@
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export const CATHAY_INTEGRATION_NAMESPACE = "cathay";
+export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
+export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
+export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
+export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
+
+export const CATHAY_DOMESTIC_DEPOSIT_PROVENANCE = {
+  validatedAt: "2026-08-17",
+  source: "Cathay domestic deposit",
+  values: "synthetic",
+  liveResponseRetained: false,
+  note: "Human-assisted validation covered response shape only; no live values are retained.",
+} as const;
+
+export const CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE = `{"success":true,"returnCode":"000","content":{"datas":[{"queryStatus":"Success","accountNumber":"SYNTHETIC-ACCOUNT-001","count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":[{"sequenceNumber":1,"txnDateTime":"2026-07-01T09:00:00","accountDate":"2026-07-01","description":"Synthetic deposit","expendAmt":null,"incomeAmt":12500,"balance":12500},{"sequenceNumber":2,"txnDateTime":"2026-07-02T10:15:30","accountDate":"2026-07-02","description":"Synthetic transfer","expendAmt":300,"incomeAmt":null,"balance":12200},{"sequenceNumber":3,"txnDateTime":"2026-07-03T11:45:00","accountDate":"2026-07-03","description":"Synthetic credit","expendAmt":null,"incomeAmt":800,"balance":13000}]}]}}`;
+
+export type CathayDomesticDepositCaptureInput = {
+  rawResponse: string;
+  sourceConnectionId: string;
+  identityEpoch: string;
+  accountNo: string;
+  currency: string;
+  authorityRoute: string;
+  stream: string;
+  scope: {
+    startDate: string;
+    endDate: string;
+    complete: boolean;
+  };
+  observedAt: string;
+};
+
+export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput = {
+  rawResponse: CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE,
+  sourceConnectionId: "synthetic-cathay-connection",
+  identityEpoch: "cathay-domestic-deposit-v1",
+  accountNo: "SYNTHETIC-ACCOUNT-001",
+  currency: "TWD",
+  authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
+  scope: { startDate: "2025-08-17", endDate: "2026-08-17", complete: true },
+  observedAt: "2026-08-17T12:00:00+08:00",
+};
+
+export type ExactDecimal = {
+  coefficient: bigint;
+  scale: number;
+};
+
+export function parseExactDecimalLexeme(lexeme: string): ExactDecimal {
+  if (!/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(lexeme)) {
+    throw new Error(`Invalid exact decimal lexeme: ${lexeme}`);
+  }
+  const negative = lexeme.startsWith("-");
+  const unsigned = negative ? lexeme.slice(1) : lexeme;
+  const [whole, fraction = ""] = unsigned.split(".");
+  const coefficient = BigInt(`${negative ? "-" : ""}${whole}${fraction}`);
+  return { coefficient, scale: fraction.length };
+}
+
+type LosslessJsonNumber = { kind: "number"; lexeme: string };
+type LosslessJsonValue =
+  | null
+  | boolean
+  | string
+  | LosslessJsonNumber
+  | LosslessJsonValue[]
+  | { [key: string]: LosslessJsonValue };
+
+class LosslessJsonParser {
+  private position = 0;
+  private readonly source: string;
+
+  constructor(source: string) {
+    this.source = source;
+  }
+
+  parse(): LosslessJsonValue {
+    const value = this.value();
+    this.whitespace();
+    if (this.position !== this.source.length) throw new Error("Invalid JSON trailing data.");
+    return value;
+  }
+
+  private value(): LosslessJsonValue {
+    this.whitespace();
+    const char = this.source[this.position];
+    if (char === "{") return this.object();
+    if (char === "[") return this.array();
+    if (char === '"') return this.string();
+    if (this.source.startsWith("true", this.position)) {
+      this.position += 4;
+      return true;
+    }
+    if (this.source.startsWith("false", this.position)) {
+      this.position += 5;
+      return false;
+    }
+    if (this.source.startsWith("null", this.position)) {
+      this.position += 4;
+      return null;
+    }
+    return { kind: "number", lexeme: this.number() };
+  }
+
+  private object(): { [key: string]: LosslessJsonValue } {
+    this.position += 1;
+    const output: { [key: string]: LosslessJsonValue } = {};
+    this.whitespace();
+    if (this.source[this.position] === "}") {
+      this.position += 1;
+      return output;
+    }
+    while (true) {
+      this.whitespace();
+      if (this.source[this.position] !== '"') throw new Error("Invalid JSON object key.");
+      const key = this.string();
+      this.whitespace();
+      if (this.source[this.position] !== ":") throw new Error("Invalid JSON object separator.");
+      this.position += 1;
+      if (key in output) throw new Error(`Duplicate JSON object key: ${key}`);
+      output[key] = this.value();
+      this.whitespace();
+      if (this.source[this.position] === "}") {
+        this.position += 1;
+        return output;
+      }
+      if (this.source[this.position] !== ",") throw new Error("Invalid JSON object delimiter.");
+      this.position += 1;
+    }
+  }
+
+  private array(): LosslessJsonValue[] {
+    this.position += 1;
+    const output: LosslessJsonValue[] = [];
+    this.whitespace();
+    if (this.source[this.position] === "]") {
+      this.position += 1;
+      return output;
+    }
+    while (true) {
+      output.push(this.value());
+      this.whitespace();
+      if (this.source[this.position] === "]") {
+        this.position += 1;
+        return output;
+      }
+      if (this.source[this.position] !== ",") throw new Error("Invalid JSON array delimiter.");
+      this.position += 1;
+    }
+  }
+
+  private string(): string {
+    const start = this.position;
+    this.position += 1;
+    while (this.position < this.source.length) {
+      const char = this.source[this.position];
+      if (char === "\\") {
+        this.position += 2;
+        continue;
+      }
+      if (char === '"') {
+        this.position += 1;
+        return JSON.parse(this.source.slice(start, this.position)) as string;
+      }
+      this.position += 1;
+    }
+    throw new Error("Unterminated JSON string.");
+  }
+
+  private number(): string {
+    const match = this.source.slice(this.position).match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+    if (!match) throw new Error(`Invalid JSON value at position ${this.position}.`);
+    this.position += match[0].length;
+    return match[0];
+  }
+
+  private whitespace() {
+    while (/\s/.test(this.source[this.position] ?? "")) this.position += 1;
+  }
+}
+
+function asObject(value: LosslessJsonValue, label: string): { [key: string]: LosslessJsonValue } {
+  if (!value || typeof value !== "object" || Array.isArray(value) || "kind" in value) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value as { [key: string]: LosslessJsonValue };
+}
+
+function asArray(value: LosslessJsonValue | undefined, label: string): LosslessJsonValue[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array.`);
+  return value;
+}
+
+function requiredString(object: { [key: string]: LosslessJsonValue }, key: string): string {
+  const value = object[key];
+  if (typeof value !== "string" || !value) throw new Error(`Missing required string ${key}.`);
+  return value;
+}
+
+function isLosslessJsonNumber(value: LosslessJsonValue | undefined): value is LosslessJsonNumber {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value) && value.kind === "number");
+}
+
+function requiredNumber(object: { [key: string]: LosslessJsonValue }, key: string): string {
+  const value = object[key];
+  if (!isLosslessJsonNumber(value)) {
+    throw new Error(`Missing required JSON number ${key}.`);
+  }
+  return value.lexeme;
+}
+
+function nullableNumber(object: { [key: string]: LosslessJsonValue }, key: string): string | null {
+  const value = object[key];
+  if (value === null) return null;
+  if (!isLosslessJsonNumber(value)) {
+    throw new Error(`${key} must be a JSON number or null.`);
+  }
+  return value.lexeme;
+}
+
+function requireDate(value: string, label: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`${label} must be YYYY-MM-DD.`);
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+    throw new Error(`${label} must be a valid calendar date.`);
+  }
+  return value;
+}
+
+function requireDateTime(value: string, label: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+    throw new Error(`${label} must be YYYY-MM-DDTHH:mm:ss.`);
+  }
+  const date = new Date(`${value}Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 19) !== value) {
+    throw new Error(`${label} must be a valid local date-time.`);
+  }
+  return value;
+}
+
+type ValidatedCathayRow = {
+  sequence: string;
+  accountDate: string;
+  transactionDateTime: string;
+  amount: ExactDecimal;
+  direction: "inflow" | "outflow";
+  balance: ExactDecimal;
+  payload: string;
+};
+
+type ValidatedCathayCapture = {
+  accountNo: string;
+  startDate: string;
+  endDate: string;
+  rows: ValidatedCathayRow[];
+};
+
+function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCathayCapture {
+  if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) {
+    throw new Error("Source Connection and Identity Epoch are required.");
+  }
+  if (input.currency !== "TWD") throw new Error("Cathay domestic deposit currency must be TWD.");
+  if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) throw new Error("Invalid authority route.");
+  if (input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Invalid Cathay product stream.");
+  if (!input.scope.complete) throw new Error("Cathay transfer scope must be complete.");
+  const startDate = requireDate(input.scope.startDate, "scope.startDate");
+  const endDate = requireDate(input.scope.endDate, "scope.endDate");
+  if (startDate > endDate) throw new Error("Cathay scope startDate must not be after endDate.");
+  if (Number.isNaN(Date.parse(input.observedAt))) throw new Error("Invalid observation time.");
+
+  const root = asObject(new LosslessJsonParser(input.rawResponse).parse(), "Cathay response");
+  if (root.success !== true) throw new Error("Cathay response was not successful.");
+  if (root.returnCode !== "000") throw new Error("Cathay response returnCode was not 000.");
+  const content = asObject(root.content, "Cathay response content");
+  const statement = asObject(asArray(content.datas, "Cathay response datas")[0], "Cathay transfer result");
+  if (requiredString(statement, "queryStatus") !== "Success") throw new Error("Cathay queryStatus was not Success.");
+  const accountNo = requiredString(statement, "accountNumber");
+  if (accountNo !== input.accountNo) throw new Error("Cathay account scope does not match the response.");
+  if (requiredString(statement, "startDate") !== startDate || requiredString(statement, "endDate") !== endDate) {
+    throw new Error("Cathay response date scope does not match the requested scope.");
+  }
+  const count = parseExactDecimalLexeme(requiredNumber(statement, "count"));
+  if (count.scale !== 0 || count.coefficient < 0n) throw new Error("Cathay count must be a non-negative integer.");
+  const details = asArray(statement.details, "Cathay transfer details");
+  if (count.coefficient !== BigInt(details.length)) throw new Error("Cathay response count does not match details.");
+
+  const sequences = new Set<string>();
+  const rows = details.map((detailValue, index) => {
+    const detail = asObject(detailValue, `Cathay detail ${index}`);
+    const sequenceLexeme = requiredNumber(detail, "sequenceNumber");
+    const sequence = parseExactDecimalLexeme(sequenceLexeme);
+    if (sequence.scale !== 0 || sequence.coefficient < 0n || sequences.has(sequenceLexeme)) {
+      throw new Error("Cathay sequenceNumber must be a unique exact integer.");
+    }
+    sequences.add(sequenceLexeme);
+    const expendLexeme = nullableNumber(detail, "expendAmt");
+    const incomeLexeme = nullableNumber(detail, "incomeAmt");
+    if ((expendLexeme === null) === (incomeLexeme === null)) {
+      throw new Error("Cathay detail must have exactly one direction amount.");
+    }
+    const amountLexeme = incomeLexeme ?? expendLexeme!;
+    const amount = parseExactDecimalLexeme(amountLexeme);
+    if (amount.coefficient < 0n) throw new Error("Cathay amount must be non-negative.");
+    const balance = parseExactDecimalLexeme(requiredNumber(detail, "balance"));
+    const accountDate = requireDate(requiredString(detail, "accountDate"), "accountDate");
+    const transactionDateTime = requireDateTime(requiredString(detail, "txnDateTime"), "txnDateTime");
+    const direction = incomeLexeme === null ? "outflow" : "inflow";
+    return {
+      sequence: sequenceLexeme,
+      accountDate,
+      transactionDateTime,
+      amount,
+      direction,
+      balance,
+      payload: JSON.stringify({
+        sequenceNumber: sequenceLexeme,
+        accountDate,
+        txnDateTime: transactionDateTime,
+        amount: amountLexeme,
+        amountDirection: direction,
+        balance: requiredNumber(detail, "balance"),
+      }),
+    } satisfies ValidatedCathayRow;
+  });
+  return { accountNo, startDate, endDate, rows };
+}
+
+function uuidV7(): string {
+  const bytes = randomBytes(16);
+  const timestamp = BigInt(Date.now());
+  for (let index = 0; index < 6; index += 1) {
+    bytes[index] = Number((timestamp >> BigInt(40 - index * 8)) & 0xffn);
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function canonicalSqlitePath(ledgerDir: string): string {
+  return join(ledgerDir, CANONICAL_SQLITE_FILE);
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS canonical_commits (
+  commit_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+  commit_id TEXT NOT NULL UNIQUE,
+  recorded_at TEXT NOT NULL,
+  authority_route TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS source_authority_routes (
+  authority_route TEXT PRIMARY KEY,
+  integration_namespace TEXT NOT NULL,
+  stream TEXT NOT NULL,
+  contract_version TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS source_connections (
+  source_connection_id TEXT PRIMARY KEY,
+  integration_namespace TEXT NOT NULL,
+  source_connection_key TEXT NOT NULL,
+  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  UNIQUE(integration_namespace, source_connection_key)
+);
+CREATE TABLE IF NOT EXISTS identity_epochs (
+  identity_epoch_id TEXT PRIMARY KEY,
+  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
+  epoch_key TEXT NOT NULL,
+  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  UNIQUE(source_connection_id, epoch_key)
+);
+CREATE TABLE IF NOT EXISTS source_captures (
+  capture_id TEXT PRIMARY KEY,
+  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id TEXT NOT NULL REFERENCES identity_epochs(identity_epoch_id),
+  authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
+  stream TEXT NOT NULL,
+  account_no TEXT NOT NULL,
+  observed_at TEXT NOT NULL,
+  scope_start TEXT NOT NULL,
+  scope_end TEXT NOT NULL,
+  completeness TEXT NOT NULL CHECK (completeness = 'complete-range'),
+  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence)
+);
+CREATE TABLE IF NOT EXISTS source_records (
+  source_record_id TEXT PRIMARY KEY,
+  capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
+  sequence_lexeme TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  UNIQUE(capture_id, sequence_lexeme)
+);
+CREATE TABLE IF NOT EXISTS financial_accounts (
+  account_id TEXT PRIMARY KEY,
+  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id TEXT NOT NULL REFERENCES identity_epochs(identity_epoch_id),
+  stream TEXT NOT NULL,
+  account_no TEXT NOT NULL,
+  account_type TEXT NOT NULL CHECK (account_type IN ('depository', 'credit', 'loan', 'investment', 'other')),
+  currency TEXT NOT NULL,
+  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  UNIQUE(source_connection_id, identity_epoch_id, stream, account_no)
+);
+CREATE TABLE IF NOT EXISTS financial_transactions (
+  transaction_id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES financial_accounts(account_id),
+  source_sequence TEXT NOT NULL,
+  UNIQUE(account_id, source_sequence)
+);
+CREATE TABLE IF NOT EXISTS transaction_revisions (
+  revision_id TEXT PRIMARY KEY,
+  transaction_id TEXT NOT NULL REFERENCES financial_transactions(transaction_id),
+  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
+  capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
+  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  revision_number INTEGER NOT NULL,
+  amount_coefficient TEXT NOT NULL,
+  amount_scale INTEGER NOT NULL CHECK (amount_scale >= 0),
+  currency TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('inflow', 'outflow')),
+  posting_status TEXT NOT NULL CHECK (posting_status IN ('pending', 'posted')),
+  effective_on TEXT NOT NULL,
+  transaction_date_time_local TEXT NOT NULL,
+  time_zone TEXT NOT NULL,
+  time_precision TEXT NOT NULL CHECK (time_precision = 'second'),
+  balance_coefficient TEXT NOT NULL,
+  balance_scale INTEGER NOT NULL CHECK (balance_scale >= 0),
+  UNIQUE(transaction_id, revision_number)
+);
+CREATE TABLE IF NOT EXISTS source_assertions (
+  assertion_id TEXT PRIMARY KEY,
+  transaction_id TEXT NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id TEXT NOT NULL REFERENCES transaction_revisions(revision_id),
+  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
+  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  UNIQUE(transaction_id, revision_id)
+);
+CREATE TABLE IF NOT EXISTS assertion_provenance (
+  assertion_id TEXT NOT NULL REFERENCES source_assertions(assertion_id),
+  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
+  PRIMARY KEY(assertion_id, source_record_id)
+);
+CREATE TABLE IF NOT EXISTS source_sync_states (
+  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
+  account_id TEXT NOT NULL REFERENCES financial_accounts(account_id),
+  stream TEXT NOT NULL,
+  scope_start TEXT NOT NULL,
+  scope_end TEXT NOT NULL,
+  last_capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
+  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  PRIMARY KEY(source_connection_id, account_id, stream)
+);
+CREATE TABLE IF NOT EXISTS current_transactions (
+  transaction_id TEXT PRIMARY KEY REFERENCES financial_transactions(transaction_id),
+  revision_id TEXT NOT NULL REFERENCES transaction_revisions(revision_id),
+  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence)
+);
+`;
+
+export function openCanonicalDatabase(
+  ledgerDir: string,
+  options: { readOnly?: boolean } = {},
+): DatabaseSync {
+  const path = canonicalSqlitePath(ledgerDir);
+  if (options.readOnly && !existsSync(path)) throw new Error(`Missing canonical SQLite: ${path}`);
+  if (!options.readOnly) mkdirSync(ledgerDir, { recursive: true });
+  const db = new DatabaseSync(path, options.readOnly ? { readOnly: true } : {});
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec("PRAGMA busy_timeout = 30000");
+  if (!options.readOnly) {
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec(SCHEMA);
+  }
+  return db;
+}
+
+export type CanonicalAmount = { coefficient: string; scale: number };
+export type CanonicalTransaction = {
+  id: string;
+  accountId: string;
+  accountNo: string;
+  sourceSequence: string;
+  amount: CanonicalAmount;
+  currency: "TWD";
+  direction: "inflow" | "outflow";
+  postingStatus: "posted";
+  effectiveOn: string;
+  transactionDateTimeLocal: string;
+  timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE;
+  balance: CanonicalAmount;
+  revisionId: string;
+  commitSequence: number;
+};
+
+export type CathayCanonicalCurrentQueryRequest = { kind: "current" };
+export type CathayCanonicalCurrentQueryResult = {
+  status: "ok";
+  kind: "current";
+  accounts: Array<{ id: string; accountNo: string; currency: "TWD"; accountType: "depository" }>;
+  transactions: CanonicalTransaction[];
+  commitSequence: number;
+};
+export type CathayCanonicalHistoricalQueryRequest = {
+  kind: "historical";
+  cutoff: { kind: "both"; financialAt: string; knowledgeAt: string };
+};
+export type CathayCanonicalHistoricalQueryResult = {
+  status: "ok";
+  kind: "historical";
+  cutoff: CathayCanonicalHistoricalQueryRequest["cutoff"];
+  transactions: CanonicalTransaction[];
+};
+export type CathayCanonicalLineageQueryRequest = {
+  kind: "lineage";
+  subject: { kind: "transaction"; id: string };
+};
+export type CathayCanonicalLineageEntry = {
+  transaction: { id: string; accountId: string; sourceSequence: string };
+  revision: CanonicalTransactionRevision;
+  assertion: { id: string; revisionId: string; commitSequence: number };
+  sourceRecord: { id: string; captureId: string; sequence: string; payload: string };
+  capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
+  provenance: Array<{ sourceRecordId: string; captureId: string }>;
+};
+export type CathayCanonicalLineageQueryResult = {
+  status: "ok";
+  kind: "lineage";
+  subject: CathayCanonicalLineageQueryRequest["subject"];
+  entries: CathayCanonicalLineageEntry[];
+};
+export type CanonicalTransactionRevision = CanonicalTransaction & { transactionId: string };
+
+export interface CathayCanonicalFinancialQuery {
+  current(request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult>;
+  historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult>;
+  lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult>;
+}
+
+export type CathayCommitTransactionResult = {
+  transactionId: string;
+  revisionId: string;
+  sourceSequence: string;
+  direction: "inflow" | "outflow";
+  amount: CanonicalAmount;
+  revisionCreated: boolean;
+};
+export type CathayCanonicalCommitResult = {
+  captureId: string;
+  commitSequence: number;
+  accountId: string;
+  transactions: CathayCommitTransactionResult[];
+};
+
+function dbRow<T extends Record<string, unknown>>(value: unknown): T {
+  return value as T;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sameRevision(
+  row: Record<string, unknown>,
+  detail: ValidatedCathayRow,
+): boolean {
+  return row.amount_coefficient === detail.amount.coefficient.toString()
+    && row.amount_scale === detail.amount.scale
+    && row.direction === detail.direction
+    && row.effective_on === detail.accountDate
+    && row.transaction_date_time_local === detail.transactionDateTime
+    && row.balance_coefficient === detail.balance.coefficient.toString()
+    && row.balance_scale === detail.balance.scale;
+}
+
+export function commitCathayDomesticDeposit(
+  ledgerDir: string,
+  input: CathayDomesticDepositCaptureInput,
+): CathayCanonicalCommitResult {
+  const validated = validateCapture(input);
+  const db = openCanonicalDatabase(ledgerDir);
+  let inTransaction = false;
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    inTransaction = true;
+    db.prepare(
+      "INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version) VALUES (?, ?, ?, ?)",
+    ).run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1");
+    const commitInsert = db.prepare(
+      "INSERT INTO canonical_commits(commit_id, recorded_at, authority_route) VALUES (?, ?, ?)",
+    ).run(uuidV7(), nowIso(), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY);
+    const commitSequence = Number(commitInsert.lastInsertRowid);
+    const connectionExisting = db.prepare(
+      "SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?",
+    ).get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
+    const sourceConnectionId = connectionExisting
+      ? String(dbRow<{ source_connection_id: string }>(connectionExisting).source_connection_id)
+      : uuidV7();
+    if (!connectionExisting) {
+      db.prepare(
+        "INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_sequence) VALUES (?, ?, ?, ?)",
+      ).run(sourceConnectionId, CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId, commitSequence);
+    }
+    const epochExisting = db.prepare(
+      "SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?",
+    ).get(sourceConnectionId, input.identityEpoch);
+    const identityEpochId = epochExisting
+      ? String(dbRow<{ identity_epoch_id: string }>(epochExisting).identity_epoch_id)
+      : uuidV7();
+    if (!epochExisting) {
+      db.prepare(
+        "INSERT INTO identity_epochs(identity_epoch_id, source_connection_id, epoch_key, created_commit_sequence) VALUES (?, ?, ?, ?)",
+      ).run(identityEpochId, sourceConnectionId, input.identityEpoch, commitSequence);
+    }
+    const accountExisting = db.prepare(
+      "SELECT account_id, currency, account_type FROM financial_accounts WHERE source_connection_id = ? AND identity_epoch_id = ? AND stream = ? AND account_no = ?",
+    ).get(sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo);
+    const accountId = accountExisting
+      ? String(dbRow<{ account_id: string }>(accountExisting).account_id)
+      : uuidV7();
+    if (accountExisting) {
+      const account = dbRow<{ currency: string; account_type: string }>(accountExisting);
+      if (account.currency !== input.currency || account.account_type !== "depository") {
+        throw new Error("Cathay account identity has conflicting required classification.");
+      }
+    } else {
+      db.prepare(
+        "INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_sequence) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(accountId, sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo, "depository", input.currency, commitSequence);
+    }
+    const captureId = uuidV7();
+    db.prepare(
+      "INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, commit_sequence) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, "complete-range", commitSequence);
+
+    const transactionResults: CathayCommitTransactionResult[] = [];
+    for (const detail of validated.rows) {
+      const sourceRecordId = uuidV7();
+      db.prepare(
+        "INSERT INTO source_records(source_record_id, capture_id, sequence_lexeme, payload_json) VALUES (?, ?, ?, ?)",
+      ).run(sourceRecordId, captureId, detail.sequence, detail.payload);
+      const transactionExisting = db.prepare(
+        "SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?",
+      ).get(accountId, detail.sequence);
+      const transactionId = transactionExisting
+        ? String(dbRow<{ transaction_id: string }>(transactionExisting).transaction_id)
+        : uuidV7();
+      if (!transactionExisting) {
+        db.prepare(
+          "INSERT INTO financial_transactions(transaction_id, account_id, source_sequence) VALUES (?, ?, ?)",
+        ).run(transactionId, accountId, detail.sequence);
+      }
+      const latest = db.prepare(
+        "SELECT * FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number DESC LIMIT 1",
+      ).get(transactionId);
+      const latestRow = latest ? dbRow<Record<string, unknown>>(latest) : undefined;
+      const revisionCreated = !latestRow || !sameRevision(latestRow, detail);
+      let revisionId = latestRow ? String(latestRow.revision_id) : uuidV7();
+      if (revisionCreated) {
+        revisionId = uuidV7();
+        const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
+        db.prepare(
+          `INSERT INTO transaction_revisions(
+            revision_id, transaction_id, source_record_id, capture_id, commit_sequence, revision_number,
+            amount_coefficient, amount_scale, currency, direction, posting_status, effective_on,
+            transaction_date_time_local, time_zone, time_precision, balance_coefficient, balance_scale
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(revisionId, transactionId, sourceRecordId, captureId, commitSequence, revisionNumber,
+          detail.amount.coefficient.toString(), detail.amount.scale, input.currency, detail.direction, "posted",
+          detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second",
+          detail.balance.coefficient.toString(), detail.balance.scale);
+        db.prepare(
+          "INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_sequence) VALUES (?, ?, ?, ?, ?)",
+        ).run(uuidV7(), transactionId, revisionId, sourceRecordId, commitSequence);
+        db.prepare(
+          "INSERT INTO current_transactions(transaction_id, revision_id, commit_sequence) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_sequence = excluded.commit_sequence",
+        ).run(transactionId, revisionId, commitSequence);
+      }
+      const assertion = db.prepare(
+        "SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?",
+      ).get(transactionId, revisionId);
+      if (!assertion) throw new Error("Canonical assertion was not created.");
+      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id) VALUES (?, ?)")
+        .run(String(dbRow<{ assertion_id: string }>(assertion).assertion_id), sourceRecordId);
+      transactionResults.push({
+        transactionId,
+        revisionId,
+        sourceSequence: detail.sequence,
+        direction: detail.direction,
+        amount: { coefficient: detail.amount.coefficient.toString(), scale: detail.amount.scale },
+        revisionCreated,
+      });
+    }
+    db.prepare(
+      `INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, last_capture_id, commit_sequence)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET
+         scope_start = excluded.scope_start, scope_end = excluded.scope_end,
+         last_capture_id = excluded.last_capture_id, commit_sequence = excluded.commit_sequence`,
+    ).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, captureId, commitSequence);
+    db.exec("COMMIT");
+    inTransaction = false;
+    return { captureId, commitSequence, accountId, transactions: transactionResults };
+  } catch (error) {
+    if (inTransaction) db.exec("ROLLBACK");
+    throw error;
+  } finally {
+    db.close();
+  }
+}
+
+function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount {
+  return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) };
+}
+
+function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction {
+  return {
+    id: String(row.transaction_id),
+    accountId: String(row.account_id),
+    accountNo: String(row.account_no),
+    sourceSequence: String(row.source_sequence),
+    amount: amountFromRow(row),
+    currency: "TWD",
+    direction: row.direction as "inflow" | "outflow",
+    postingStatus: "posted",
+    effectiveOn: String(row.effective_on),
+    transactionDateTimeLocal: String(row.transaction_date_time_local),
+    timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
+    balance: { coefficient: String(row.balance_coefficient), scale: Number(row.balance_scale) },
+    revisionId: String(row.revision_id),
+    commitSequence: Number(row.commit_sequence),
+  };
+}
+
+function transactionRevisionFromRow(row: Record<string, unknown>): CanonicalTransactionRevision {
+  const transaction = transactionFromRow(row);
+  return {
+    ...transaction,
+    id: String(row.revision_id),
+    transactionId: transaction.id,
+  };
+}
+
+class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQuery {
+  private readonly ledgerDir: string;
+
+  constructor(ledgerDir: string) {
+    this.ledgerDir = ledgerDir;
+  }
+
+  async current(_request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult> {
+    const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
+    try {
+      const accounts = (db.prepare(
+        "SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no",
+      ).all() as Record<string, unknown>[]).map((row) => ({
+        id: String(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const,
+      }));
+      const rows = db.prepare(
+        `SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence,
+          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
+          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
+          r.revision_id, r.commit_sequence
+         FROM current_transactions c
+         JOIN financial_transactions t ON t.transaction_id = c.transaction_id
+         JOIN financial_accounts a ON a.account_id = t.account_id
+         JOIN transaction_revisions r ON r.revision_id = c.revision_id
+         ORDER BY a.account_no, t.source_sequence`,
+      ).all() as Record<string, unknown>[];
+      return {
+        status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow),
+        commitSequence: rows.reduce((max, row) => Math.max(max, Number(row.commit_sequence)), 0),
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {
+    if (request.cutoff.kind !== "both" || !/^\d+$/.test(request.cutoff.knowledgeAt)) {
+      throw new Error("Canonical historical queries require financial-time and knowledge-time cutoffs.");
+    }
+    const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
+    try {
+      const rows = db.prepare(
+        `SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence,
+          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
+          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
+          r.revision_id, r.commit_sequence
+         FROM financial_transactions t
+         JOIN financial_accounts a ON a.account_id = t.account_id
+         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id
+         JOIN canonical_commits c ON c.commit_sequence = r.commit_sequence
+         WHERE r.effective_on <= ? AND c.commit_sequence <= ?
+           AND NOT EXISTS (
+             SELECT 1 FROM transaction_revisions newer
+             JOIN canonical_commits newer_commit ON newer_commit.commit_sequence = newer.commit_sequence
+             WHERE newer.transaction_id = r.transaction_id
+               AND newer.effective_on <= ?
+               AND newer_commit.commit_sequence <= ?
+               AND newer_commit.commit_sequence > c.commit_sequence
+           )
+         ORDER BY a.account_no, t.source_sequence`,
+      ).all(request.cutoff.financialAt, Number(request.cutoff.knowledgeAt), request.cutoff.financialAt, Number(request.cutoff.knowledgeAt)) as Record<string, unknown>[];
+      return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map(transactionFromRow) };
+    } finally {
+      db.close();
+    }
+  }
+
+  async lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult> {
+    if (request.subject.kind !== "transaction" || !request.subject.id) {
+      throw new Error("Cathay lineage queries require a transaction subject.");
+    }
+    const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
+    try {
+      const revisionRows = db.prepare(
+        `SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no,
+          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
+          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
+          r.revision_id, r.commit_sequence, r.source_record_id, r.capture_id,
+          sr.sequence_lexeme, sr.payload_json, sc.observed_at, sc.scope_start, sc.scope_end, sc.authority_route,
+          sa.assertion_id
+         FROM financial_transactions t
+         JOIN financial_accounts a ON a.account_id = t.account_id
+         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id
+         JOIN source_records sr ON sr.source_record_id = r.source_record_id
+         JOIN source_captures sc ON sc.capture_id = r.capture_id
+         JOIN source_assertions sa ON sa.revision_id = r.revision_id
+         WHERE t.transaction_id = ?
+         ORDER BY r.revision_number`,
+      ).all(request.subject.id) as Record<string, unknown>[];
+      const entries = revisionRows.map((row) => {
+        const provenance = db.prepare(
+          `SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId
+           FROM assertion_provenance p JOIN source_records sr ON sr.source_record_id = p.source_record_id
+           WHERE p.assertion_id = ? ORDER BY p.source_record_id`,
+        ).all(String(row.assertion_id)) as Record<string, unknown>[];
+        const revision = transactionRevisionFromRow(row);
+        return {
+          transaction: { id: String(row.transaction_id), accountId: String(row.account_id), sourceSequence: String(row.source_sequence) },
+          revision,
+          assertion: { id: String(row.assertion_id), revisionId: String(row.revision_id), commitSequence: Number(row.commit_sequence) },
+          sourceRecord: { id: String(row.source_record_id), captureId: String(row.capture_id), sequence: String(row.sequence_lexeme), payload: String(row.payload_json) },
+          capture: { id: String(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
+          provenance: provenance.map((item) => ({ sourceRecordId: String(item.sourceRecordId), captureId: String(item.captureId) })),
+        } satisfies CathayCanonicalLineageEntry;
+      });
+      return { status: "ok", kind: "lineage", subject: request.subject, entries };
+    } finally {
+      db.close();
+    }
+  }
+}
+
+export function createCathayCanonicalFinancialQuery(ledgerDir: string): CathayCanonicalFinancialQuery {
+  return new CathayCanonicalFinancialQueryAdapter(ledgerDir);
+}

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -8,7 +8,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 5;
+export const CANONICAL_SCHEMA_VERSION = 6;
 export const CATHAY_POSTING_MAPPING = {
   contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   postingStatus: "posted",
@@ -73,6 +73,75 @@ export type CathayDomesticDepositSyncInput = {
   syncState: { cursor?: string | null };
   observedAt: string;
   pages: CathayStagedCapturePage[];
+};
+
+/** The first derived import contract is deliberately transaction-scoped.  A
+ * complete run supplies one coordinate for every transaction/field pair it
+ * claims to own.  Unsupported is an explicit output state, not a missing
+ * array element, so a partial producer can never withdraw an old claim. */
+export type CathayDerivedField = "display_name" | "note";
+export type CathayDerivedOutputState = "supported" | "unsupported";
+export type CathayDerivedImportCoordinate = {
+  transactionId: string;
+  field: CathayDerivedField;
+  state: CathayDerivedOutputState;
+  value?: string | null;
+};
+export type CathayDerivedImportSubject = { kind: "transaction"; id: string } | string;
+export type CathayDerivedImportScope = {
+  subjects: CathayDerivedImportSubject[];
+  fields: CathayDerivedField[];
+  producerId?: string;
+  origin?: string;
+  ruleLineage?: string;
+};
+export type CathayDerivedImportRunInput = {
+  sourceConnectionId: string;
+  identityEpoch: string;
+  authorityRoute: string;
+  stream: string;
+  producerId: string;
+  ruleLineage: string;
+  origin?: string;
+  observedAt?: string;
+  /** Complete subject/field/producer/rule-lineage coordinate matrix. */
+  scope?: CathayDerivedImportCoordinate[] | CathayDerivedImportScope;
+  outputScope?: CathayDerivedImportCoordinate[] | CathayDerivedImportScope;
+  coordinates?: CathayDerivedImportCoordinate[];
+  outputs?: CathayDerivedImportCoordinate[];
+  /** Compatibility spelling for callers that model a complete run explicitly. */
+  complete?: boolean;
+};
+export type CathayDerivedImportDiagnostic = {
+  kind: "derived-import-diagnostic";
+  stage: "preflight" | "scope" | "commit";
+  reason: string;
+  producerId?: string;
+  ruleLineage?: string;
+};
+export type CathayDerivedImportResult =
+  | { status: "committed"; runId: string; commitSequence: number; assertionIds: string[] }
+  | { status: "diagnostic"; diagnostic: CathayDerivedImportDiagnostic };
+export type CathayDerivedImportOptions = CathayCanonicalCommitOptions & {
+  onDiagnostic?: (diagnostic: CathayDerivedImportDiagnostic) => void;
+};
+
+export type CathayUserAssertionField = "display_name" | "note";
+export type CathayUserAssertionInput = {
+  transactionId?: string;
+  subject?: { kind: "transaction"; id: string };
+  field?: CathayUserAssertionField | string;
+  target?: { kind?: string; field?: string; id?: string } | string;
+  value?: string | null;
+  userId?: string;
+  observedAt?: string;
+};
+export type CathayUserAssertionResult = {
+  status: "committed";
+  assertionId: string;
+  commitSequence: number;
+  field: CathayUserAssertionField;
+  withdrawn: boolean;
 };
 
 export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput = {
@@ -658,6 +727,97 @@ const SCHEMA_V5 = `${SCHEMA_V4}${SCHEMA_V5_APPEND}`
   .replace("UNIQUE(capture_id, account_id, scope_start, scope_end)", "UNIQUE(scope_id, capture_id), UNIQUE(scope_id, account_id), UNIQUE(capture_id, account_id, scope_start, scope_end)")
   .replace("absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range', 'tombstone'))", "absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range'))");
 
+const SCHEMA_V6_APPEND = `
+CREATE TABLE IF NOT EXISTS derived_import_runs (
+  run_id BLOB PRIMARY KEY CHECK(length(run_id) = 16),
+  source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id),
+  authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
+  stream TEXT NOT NULL, producer_id TEXT NOT NULL, origin TEXT NOT NULL,
+  rule_lineage TEXT NOT NULL, observed_at TEXT NOT NULL,
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  status TEXT NOT NULL CHECK(status = 'complete'),
+  UNIQUE(run_id, producer_id, rule_lineage)
+);
+CREATE TABLE IF NOT EXISTS derived_scope_coordinates (
+  coordinate_id BLOB PRIMARY KEY CHECK(length(coordinate_id) = 16),
+  run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  producer_id TEXT NOT NULL, origin TEXT NOT NULL, rule_lineage TEXT NOT NULL,
+  output_state TEXT NOT NULL CHECK(output_state IN ('supported','unsupported')),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(run_id, transaction_id, field_name, producer_id, origin, rule_lineage)
+);
+CREATE TABLE IF NOT EXISTS derived_assertions (
+  assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  producer_id TEXT NOT NULL, origin TEXT NOT NULL, rule_lineage TEXT NOT NULL,
+  value_text TEXT NOT NULL, run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage)
+);
+CREATE TABLE IF NOT EXISTS derived_assertion_provenance (
+  assertion_id BLOB NOT NULL REFERENCES derived_assertions(assertion_id),
+  run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
+  coordinate_id BLOB NOT NULL REFERENCES derived_scope_coordinates(coordinate_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(assertion_id, run_id, coordinate_id)
+);
+CREATE TABLE IF NOT EXISTS derived_assertion_lifecycle_events (
+  event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
+  assertion_id BLOB NOT NULL REFERENCES derived_assertions(assertion_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  run_id BLOB NOT NULL REFERENCES derived_import_runs(run_id),
+  coordinate_id BLOB REFERENCES derived_scope_coordinates(coordinate_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','restored','provenance_only'))
+);
+CREATE TABLE IF NOT EXISTS user_assertions (
+  assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  user_id TEXT NOT NULL, value_text TEXT NOT NULL,
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(assertion_id, transaction_id, field_name, user_id)
+);
+CREATE TABLE IF NOT EXISTS user_assertion_lifecycle_events (
+  event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
+  assertion_id BLOB NOT NULL REFERENCES user_assertions(assertion_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  user_id TEXT NOT NULL, commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('observed','superseded','withdrawn','provenance_only'))
+);
+CREATE TABLE IF NOT EXISTS user_assertion_provenance (
+  assertion_id BLOB NOT NULL REFERENCES user_assertions(assertion_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(assertion_id, commit_id)
+);
+CREATE TABLE IF NOT EXISTS current_transaction_fields (
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  value_text TEXT NOT NULL,
+  origin TEXT NOT NULL CHECK(origin IN ('derived','user')),
+  derived_assertion_id BLOB REFERENCES derived_assertions(assertion_id),
+  user_assertion_id BLOB REFERENCES user_assertions(assertion_id),
+  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(transaction_id, field_name),
+  CHECK((origin = 'derived' AND derived_assertion_id IS NOT NULL AND user_assertion_id IS NULL)
+    OR (origin = 'user' AND user_assertion_id IS NOT NULL AND derived_assertion_id IS NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_derived_scope_coordinates_lineage ON derived_scope_coordinates(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
+CREATE INDEX IF NOT EXISTS idx_derived_assertions_lineage ON derived_assertions(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
+CREATE INDEX IF NOT EXISTS idx_derived_assertion_provenance_run ON derived_assertion_provenance(run_id, coordinate_id, assertion_id);
+CREATE INDEX IF NOT EXISTS idx_derived_assertion_lifecycle_knowledge ON derived_assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id);
+CREATE INDEX IF NOT EXISTS idx_user_assertion_lifecycle_knowledge ON user_assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id);
+CREATE INDEX IF NOT EXISTS idx_user_assertion_provenance_commit ON user_assertion_provenance(commit_id, assertion_id);
+CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id);
+`;
+const SCHEMA_V6 = `${SCHEMA_V5.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
+
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
 // Keeping this target schema separate prevents an older database from being created at a
 // partially upgraded shape before its migration transaction reaches the next version.
@@ -703,7 +863,7 @@ function migrateV1ToV2(db: DatabaseSync): void {
     }
     const latestCommit = db.prepare("SELECT commit_id FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as Record<string, unknown> | undefined;
     if (latestCommit) db.prepare("INSERT OR REPLACE INTO current_projection_state(generation, commit_id) VALUES (1, ?)").run(blob(latestCommit.commit_id));
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(2, currentUtcMicros());
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(2, currentUtcMicros());
     db.exec("PRAGMA user_version = 2");
     db.exec("COMMIT");
   } catch (error) {
@@ -727,7 +887,7 @@ function migrateV2ToV3(db: DatabaseSync): void {
       SELECT source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id FROM source_sync_states_v2`);
     db.exec("DROP TABLE source_sync_states_v2");
     db.exec(SCHEMA_V2);
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(3, currentUtcMicros());
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(3, currentUtcMicros());
     db.exec("PRAGMA user_version = 3");
     db.exec("COMMIT");
   } catch (error) {
@@ -758,7 +918,7 @@ function migrateV3ToV4(db: DatabaseSync): void {
         cs.contract_fingerprint, cs.preflight_fingerprint, cs.commit_id
       FROM capture_scopes cs LEFT JOIN capture_scope_pages existing_page ON existing_page.scope_id = cs.scope_id
       WHERE existing_page.scope_id IS NULL`);
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(4, currentUtcMicros());
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(4, currentUtcMicros());
     db.exec("PRAGMA user_version = 4");
     db.exec("COMMIT");
   } catch (error) {
@@ -766,7 +926,7 @@ function migrateV3ToV4(db: DatabaseSync): void {
     throw error;
   }
 }
-export type CanonicalMigrationFailureInjection = "v4-v5-after-record-copy";
+export type CanonicalMigrationFailureInjection = "v4-v5-after-record-copy" | "v5-v6-after-derived-schema";
 export type CanonicalDatabaseOptions = { readOnly?: boolean; injectMigrationFailure?: CanonicalMigrationFailureInjection };
 
 function migrateV4ToV5(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection): void {
@@ -854,8 +1014,35 @@ function migrateV4ToV5(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_capture ON capture_scopes(scope_id, capture_id); CREATE UNIQUE INDEX IF NOT EXISTS idx_capture_scopes_scope_account ON capture_scopes(scope_id, account_id)");
     db.exec(SCHEMA_V5_APPEND);
     db.exec("INSERT INTO source_record_scopes(source_record_id, scope_id, capture_id, account_id, sequence_lexeme, commit_id) SELECT source_record_id, scope_id, capture_id, account_id, provider_sequence, commit_id FROM source_record_scope_migration");
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(5, currentUtcMicros());
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(5, currentUtcMicros());
     db.exec("PRAGMA user_version = 5");
+    db.exec("COMMIT");
+    db.exec("PRAGMA foreign_keys = ON");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    db.exec("PRAGMA foreign_keys = ON");
+    throw error;
+  }
+}
+
+function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection): void {
+  // commit_kind was intentionally narrow in v5. Rebuild only that table while
+  // foreign keys are disabled; every existing child reference is preserved by
+  // the same primary keys and the whole operation remains one transaction.
+  db.exec("PRAGMA foreign_keys = OFF");
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(`CREATE TABLE canonical_commits_v6 (
+      commit_id BLOB PRIMARY KEY CHECK(length(commit_id) = 16), commit_sequence INTEGER NOT NULL UNIQUE,
+      recorded_at_utc_us INTEGER NOT NULL, authority_route TEXT NOT NULL,
+      commit_kind TEXT NOT NULL CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))
+    )`);
+    db.exec("INSERT INTO canonical_commits_v6 SELECT * FROM canonical_commits");
+    db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v6 RENAME TO canonical_commits");
+    db.exec(SCHEMA_V6_APPEND);
+    if (injectMigrationFailure === "v5-v6-after-derived-schema") throw new Error("Injected v5-v6 migration failure after derived schema.");
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(6, currentUtcMicros());
+    db.exec("PRAGMA user_version = 6");
     db.exec("COMMIT");
     db.exec("PRAGMA foreign_keys = ON");
   } catch (error) {
@@ -874,21 +1061,29 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     migrateV2ToV3(db);
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
+    migrateV5ToV6(db, options.injectMigrationFailure);
     return;
   }
   if (version === 2) {
     migrateV2ToV3(db);
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
+    migrateV5ToV6(db, options.injectMigrationFailure);
     return;
   }
   if (version === 3) {
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
+    migrateV5ToV6(db, options.injectMigrationFailure);
     return;
   }
   if (version === 4) {
     migrateV4ToV5(db, options.injectMigrationFailure);
+    migrateV5ToV6(db, options.injectMigrationFailure);
+    return;
+  }
+  if (version === 5) {
+    migrateV5ToV6(db, options.injectMigrationFailure);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -899,7 +1094,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
   }
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec(SCHEMA_V5);
+    db.exec(SCHEMA_V6);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
@@ -910,9 +1105,9 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state"];
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
   for (const table of requiredTables) {
-    if (!tableExists(db, table)) throw new Error(`Canonical schema v5 table ${table} is missing.`);
+    if (!tableExists(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
   }
   const requiredColumns: Record<string, string[]> = {
     source_captures: ["account_no", "completeness_basis", "completeness_rule_version"],
@@ -923,21 +1118,24 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   };
   for (const [table, columns] of Object.entries(requiredColumns)) {
     const actual = new Set((db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>).map((column) => column.name));
-    for (const column of columns) if (!actual.has(column)) throw new Error(`Canonical schema v5 column ${table}.${column} is missing.`);
+    for (const column of columns) if (!actual.has(column)) throw new Error(`Canonical schema v6 column ${table}.${column} is missing.`);
   }
   const requiredIndexes = [
     "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof", "idx_assertion_lifecycle_scope",
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
+    "idx_derived_scope_coordinates_lineage", "idx_derived_assertions_lineage", "idx_derived_assertion_provenance_run",
+    "idx_derived_assertion_lifecycle_knowledge", "idx_user_assertion_lifecycle_knowledge", "idx_current_transaction_fields_projection",
+    "idx_user_assertion_provenance_commit",
   ];
   for (const index of requiredIndexes) {
-    if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v5 index ${index} is missing.`);
+    if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v6 index ${index} is missing.`);
   }
   const tableSql = (table: string): string => String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) as { sql?: unknown } | undefined)?.sql ?? "");
   if (!/FOREIGN KEY\s*\(source_record_id,\s*capture_id\)/i.test(tableSql("source_record_scopes")) || !/capture_scopes/i.test(tableSql("source_record_scopes"))) {
-    throw new Error("Canonical schema v5 source-record scope constraints are missing.");
+    throw new Error("Canonical schema v6 source-record scope constraints are missing.");
   }
   if (!/economic_status.*canceled.*refund.*reversal/i.test(tableSql("transaction_revisions")) || !/administrative_state.*deleted.*purged/i.test(tableSql("transaction_revisions"))) {
-    throw new Error("Canonical schema v5 semantic constraints are missing.");
+    throw new Error("Canonical schema v6 semantic constraints are missing.");
   }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
@@ -986,7 +1184,8 @@ export type CanonicalTransaction = {
   id: string; accountId: string; accountNo: string; sourceSequence: string; amount: CanonicalAmount; currency: "TWD";
   direction: "inflow" | "outflow"; postingStatus: "posted"; postingOrigin: "provider_booked_history"; postingBasis: "query-status-success-with-accounting-date"; postingRuleVersion: "cathay/domestic-deposit/v1";
   assertionSupportState: CanonicalAssertionSupportState; economicStatus: CanonicalEconomicStatus; administrativeState: CanonicalAdministrativeState; semanticRuleVersion: "cathay/domestic-deposit/v1";
-  displayLabel: string | null; effectiveOn: string; effectiveTimeBasis: "accounting"; effectiveTimeRuleVersion: "cathay/domestic-deposit/v1"; transactionDateTimeLocal: string;
+  displayLabel: string | null; displayLabelOrigin: "source" | "derived" | "user"; displayLabelCommitSequence: number | null; note: string | null; noteOrigin: "derived" | "user" | null; noteCommitSequence: number | null;
+  effectiveOn: string; effectiveTimeBasis: "accounting"; effectiveTimeRuleVersion: "cathay/domestic-deposit/v1"; transactionDateTimeLocal: string;
   timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE; timePrecision: "second"; timeOrigin: "source_reported";
   utcInstantUtcUs: number; revisionId: string; commitSequence: number;
 };
@@ -1009,6 +1208,8 @@ export type CathayCanonicalLineageEntry = {
   capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
   provenance: Array<{ sourceRecordId: string; captureId: string }>;
   lifecycleEvents: CathayCanonicalLifecycleEvent[];
+  derivedAssertions: Array<{ id: string; field: CathayDerivedField; producerId: string; origin: string; ruleLineage: string; value: string; state: "supported" | "withdrawn"; commitSequence: number; runId: string; provenance: Array<{ runId: string; coordinateId: string }> }>;
+  userAssertions: Array<{ id: string; field: CathayUserAssertionField; userId: string; value: string; state: "supported" | "withdrawn"; commitSequence: number; provenance: Array<{ commitSequence: number }> }>;
 };
 export type CathayCanonicalLineageQueryResult = { status: "ok"; kind: "lineage"; subject: CathayCanonicalLineageQueryRequest["subject"]; entries: CathayCanonicalLineageEntry[] };
 export type CanonicalTransactionRevision = CanonicalTransaction & { transactionId: string };
@@ -1256,14 +1457,284 @@ export function commitCathayDomesticDepositSync(
   return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, validated, admissionClock));
 }
 
+function importCoordinates(input: CathayDerivedImportRunInput): CathayDerivedImportCoordinate[] {
+  if (input.complete === false) throw new Error("Derived import is partial; no canonical mutation was admitted.");
+  const structuredScope = [input.scope, input.outputScope].find((candidate): candidate is CathayDerivedImportScope => candidate !== undefined && !Array.isArray(candidate));
+  if (structuredScope) {
+    if (!Array.isArray(structuredScope.subjects) || !Array.isArray(structuredScope.fields) || structuredScope.subjects.length === 0 || structuredScope.fields.length === 0) throw new Error("A structured derived import scope requires subjects and fields.");
+    const expected = new Set<string>();
+    for (const subject of structuredScope.subjects) {
+      const transactionId = typeof subject === "string" ? subject : subject.kind === "transaction" ? subject.id : "";
+      if (!transactionId) throw new Error("Derived import scope contains a non-transaction subject.");
+      for (const field of structuredScope.fields) expected.add(`${transactionId}:${field}`);
+    }
+    const outputCandidates = [input.coordinates, input.outputs, input.scope, input.outputScope].filter((candidate): candidate is CathayDerivedImportCoordinate[] => Array.isArray(candidate));
+    const outputs = outputCandidates[0];
+    if (!outputs) throw new Error("A structured derived import scope requires output coordinates.");
+    const actual = new Set(outputs.map((coordinate) => `${coordinate.transactionId}:${coordinate.field}`));
+    if (expected.size !== actual.size || [...expected].some((key) => !actual.has(key))) throw new Error("Derived import output does not cover the complete declared scope.");
+    return normalizeDerivedCoordinates(outputs);
+  }
+  const candidates = [input.coordinates, input.outputs, input.scope, input.outputScope].filter((candidate): candidate is CathayDerivedImportCoordinate[] => Array.isArray(candidate));
+  if (candidates.length === 0) throw new Error("A complete derived import requires an explicit coordinate matrix.");
+  const first = candidates[0]!;
+  for (const candidate of candidates.slice(1)) {
+    if (JSON.stringify(candidate) !== JSON.stringify(first)) throw new Error("Derived import coordinate matrices disagree.");
+  }
+  return normalizeDerivedCoordinates(first);
+}
+
+function normalizeDerivedCoordinates(first: CathayDerivedImportCoordinate[]): CathayDerivedImportCoordinate[] {
+  const normalized = first.map((coordinate) => {
+    if (!coordinate || typeof coordinate !== "object") throw new Error("Derived import coordinate must be an object.");
+    if (!coordinate.transactionId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(coordinate.transactionId)) throw new Error("Derived import coordinate has an invalid transaction subject.");
+    const normalizedField = coordinate.field === ("displayName" as CathayDerivedField) || coordinate.field === ("displayLabel" as CathayDerivedField) ? "display_name" : coordinate.field;
+    if (normalizedField !== "display_name" && normalizedField !== "note") throw new Error("Derived import field is not supported.");
+    if (coordinate.state !== "supported" && coordinate.state !== "unsupported") throw new Error("Derived import coordinate has an invalid output state.");
+    if (coordinate.state === "supported" && typeof coordinate.value !== "string") throw new Error("Supported derived output must provide a typed string value.");
+    if (coordinate.state === "unsupported" && coordinate.value !== undefined && coordinate.value !== null) throw new Error("Unsupported derived output cannot carry a value.");
+    return { transactionId: coordinate.transactionId, field: normalizedField, state: coordinate.state, value: coordinate.state === "supported" ? coordinate.value! : null };
+  });
+  const seen = new Set<string>();
+  for (const coordinate of normalized) {
+    const key = `${coordinate.transactionId}:${coordinate.field}`;
+    if (seen.has(key)) throw new Error("Derived import coordinate matrix contains a duplicate subject/field.");
+    seen.add(key);
+  }
+  return normalized;
+}
+
+function validateDerivedImportInput(input: CathayDerivedImportRunInput): CathayDerivedImportCoordinate[] {
+  if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) throw new Error("Derived import Source Connection and Identity Epoch are required.");
+  if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY || input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Derived import authority route or stream is not supported.");
+  if (!input.producerId.trim() || !input.ruleLineage.trim()) throw new Error("Derived import producer and rule lineage are required.");
+  if (input.origin !== undefined && !input.origin.trim()) throw new Error("Derived import origin is required when supplied.");
+  if (input.observedAt !== undefined) parseRfc3339UtcMicros(input.observedAt, "Derived import observedAt");
+  return importCoordinates(input);
+}
+
+function derivedDiagnostic(error: unknown, input: CathayDerivedImportRunInput, stage: CathayDerivedImportDiagnostic["stage"]): CathayDerivedImportDiagnostic {
+  return { kind: "derived-import-diagnostic", stage, reason: error instanceof Error ? error.message : String(error), producerId: input.producerId, ruleLineage: input.ruleLineage };
+}
+
+function insertDerivedLifecycleEvent(db: DatabaseSync, values: { assertionId: CanonicalId; transactionId: CanonicalId; field: CathayDerivedField; runId: CanonicalId; coordinateId: CanonicalId | null; commitId: CanonicalId; kind: "observed" | "superseded" | "withdrawn" | "restored" | "provenance_only" }): void {
+  db.prepare("INSERT INTO derived_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, run_id, coordinate_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.field, values.runId, values.coordinateId, values.commitId, values.kind);
+}
+
+function latestDerivedLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
+  const row = db.prepare(`SELECT event_kind FROM derived_assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+    WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
+  return row?.event_kind ?? null;
+}
+
+function latestUserLifecycle(db: DatabaseSync, assertionId: CanonicalId): string | null {
+  const row = db.prepare(`SELECT event_kind FROM user_assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+    WHERE assertion_id = ? ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
+  return row?.event_kind ?? null;
+}
+
+function insertCurrentDerivedField(db: DatabaseSync, transactionId: CanonicalId, field: CathayDerivedField, assertionId: CanonicalId, value: string, commitId: CanonicalId): void {
+  const user = db.prepare("SELECT 1 FROM current_transaction_fields WHERE transaction_id = ? AND field_name = ? AND origin = 'user'").get(transactionId, field);
+  if (user) return;
+  db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+    VALUES (?, ?, ?, 'derived', ?, NULL, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'derived', derived_assertion_id = excluded.derived_assertion_id, user_assertion_id = NULL, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, value, assertionId, commitId);
+}
+
+function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: CanonicalId, field: CathayDerivedField, commitId: CanonicalId): void {
+  const user = db.prepare(`SELECT ua.assertion_id, ua.value_text FROM user_assertions ua
+    JOIN user_assertion_lifecycle_events e ON e.assertion_id = ua.assertion_id
+    WHERE ua.transaction_id = ? AND ua.field_name = ?
+    AND e.event_kind NOT IN ('withdrawn','superseded')
+    AND NOT EXISTS (SELECT 1 FROM user_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+      WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id)
+        OR (nc.commit_sequence = (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) AND newer.rowid > e.rowid)))
+    ORDER BY (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) DESC, e.rowid DESC LIMIT 1`).get(transactionId, field) as Record<string, unknown> | undefined;
+  if (user) {
+    db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+      VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, String(user.value_text), blob(user.assertion_id), commitId);
+    return;
+  }
+  const derived = db.prepare(`SELECT da.assertion_id, da.value_text FROM derived_assertions da
+    JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
+    WHERE da.transaction_id = ? AND da.field_name = ? AND e.event_kind NOT IN ('withdrawn','superseded')
+    AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+      WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id)
+        OR (nc.commit_sequence = (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) AND newer.rowid > e.rowid)))
+    ORDER BY (SELECT c.commit_sequence FROM canonical_commits c WHERE c.commit_id = e.commit_id) DESC, e.rowid DESC LIMIT 1`).get(transactionId, field) as Record<string, unknown> | undefined;
+  if (derived) insertCurrentDerivedField(db, transactionId, field, blob(derived.assertion_id), String(derived.value_text), commitId);
+  else db.prepare("DELETE FROM current_transaction_fields WHERE transaction_id = ? AND field_name = ?").run(transactionId, field);
+}
+
+function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock): { runId: string; commitSequence: number; assertionIds: string[] } {
+  const db = openCanonicalDatabase(ledgerDir);
+  let inTransaction = false;
+  try {
+    db.exec("BEGIN IMMEDIATE");
+    inTransaction = true;
+    const connection = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
+    if (!connection) throw new Error("Derived import source connection is unknown; source lineage must already exist.");
+    const sourceConnectionId = blob(dbRow<{ source_connection_id: unknown }>(connection).source_connection_id);
+    const epoch = db.prepare("SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?").get(sourceConnectionId, input.identityEpoch);
+    if (!epoch) throw new Error("Derived import identity epoch is unknown; source lineage must already exist.");
+    const identityEpochId = blob(dbRow<{ identity_epoch_id: unknown }>(epoch).identity_epoch_id);
+    const commitId = uuidV7();
+    const commitSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0) + 1;
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, 'derived_import')").run(commitId, commitSequence, recordedAtUtcUs(clock()), input.authorityRoute);
+    const runId = uuidV7();
+    const origin = input.origin?.trim() || input.authorityRoute;
+    db.prepare("INSERT INTO derived_import_runs(run_id, source_connection_id, identity_epoch_id, authority_route, stream, producer_id, origin, rule_lineage, observed_at, commit_id, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'complete')").run(runId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, input.producerId, origin, input.ruleLineage, input.observedAt ?? clock(), commitId);
+    const assertionIds: string[] = [];
+    for (const coordinate of coordinates) {
+      const transactionId = idFromString(coordinate.transactionId);
+      const transaction = db.prepare(`SELECT t.account_id, a.source_connection_id, a.identity_epoch_id, a.stream FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id WHERE t.transaction_id = ?`).get(transactionId) as Record<string, unknown> | undefined;
+      if (!transaction) throw new Error("Derived import targets an unknown transaction subject.");
+      if (Buffer.compare(blob(transaction.source_connection_id), sourceConnectionId) !== 0 || Buffer.compare(blob(transaction.identity_epoch_id), identityEpochId) !== 0 || transaction.stream !== input.stream) throw new Error("Derived import crossed a source identity or stream boundary.");
+      const coordinateId = uuidV7();
+      db.prepare("INSERT INTO derived_scope_coordinates(coordinate_id, run_id, transaction_id, field_name, producer_id, origin, rule_lineage, output_state, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(coordinateId, runId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, coordinate.state, commitId);
+      const existingCurrent = db.prepare(`SELECT f.origin, f.derived_assertion_id, f.user_assertion_id FROM current_transaction_fields f WHERE f.transaction_id = ? AND f.field_name = ?`).get(transactionId, coordinate.field) as Record<string, unknown> | undefined;
+      const conflicting = db.prepare(`SELECT da.assertion_id, da.producer_id, da.origin, da.rule_lineage FROM derived_assertions da
+        JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
+        WHERE da.transaction_id = ? AND da.field_name = ? AND (da.producer_id <> ? OR da.origin <> ?)
+        AND e.event_kind NOT IN ('withdrawn','superseded') LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin) as Record<string, unknown> | undefined;
+      if (conflicting) throw new Error("A different derived producer or origin cannot supersede the current lineage.");
+      const latest = db.prepare(`SELECT da.* FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
+        WHERE da.transaction_id = ? AND da.field_name = ? AND da.producer_id = ? AND da.origin = ? AND da.rule_lineage = ?
+        ORDER BY c.commit_sequence DESC, da.assertion_id DESC LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin, input.ruleLineage) as Record<string, unknown> | undefined;
+      if (coordinate.state === "unsupported") {
+        if (latest && latestDerivedLifecycle(db, blob(latest.assertion_id)) !== "withdrawn") {
+          const withdrawnAssertion = blob(latest.assertion_id);
+          insertDerivedLifecycleEvent(db, { assertionId: withdrawnAssertion, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "withdrawn" });
+          if (existingCurrent?.origin === "derived" && existingCurrent.derived_assertion_id && Buffer.compare(blob(existingCurrent.derived_assertion_id), withdrawnAssertion) === 0) refreshCurrentFieldAfterWithdrawal(db, transactionId, coordinate.field, commitId);
+        }
+        continue;
+      }
+      const value = coordinate.value!;
+      let assertionId: CanonicalId;
+      let eventKind: "observed" | "superseded" | "restored" | "provenance_only" = "observed";
+      if (latest && String(latest.value_text) === value) {
+        assertionId = blob(latest.assertion_id);
+        eventKind = latestDerivedLifecycle(db, assertionId) === "withdrawn" ? "restored" : "provenance_only";
+      } else {
+        assertionId = uuidV7();
+        if (latest) insertDerivedLifecycleEvent(db, { assertionId: blob(latest.assertion_id), transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "superseded" });
+        db.prepare("INSERT INTO derived_assertions(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage, value_text, run_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, value, runId, commitId);
+      }
+      db.prepare("INSERT INTO derived_assertion_provenance(assertion_id, run_id, coordinate_id, commit_id) VALUES (?, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
+      insertDerivedLifecycleEvent(db, { assertionId, transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: eventKind });
+      assertionIds.push(idToString(assertionId));
+      if (existingCurrent?.origin !== "user") insertCurrentDerivedField(db, transactionId, coordinate.field, assertionId, value, commitId);
+    }
+    db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
+    db.exec("COMMIT");
+    inTransaction = false;
+    return { runId: idToString(runId), commitSequence, assertionIds };
+  } catch (error) {
+    if (inTransaction) db.exec("ROLLBACK");
+    throw error;
+  } finally { db.close(); }
+}
+
+export function commitCathayDerivedImportRun(ledgerDir: string, input: CathayDerivedImportRunInput, options: CathayDerivedImportOptions = {}): Promise<CathayDerivedImportResult & { status: "committed" }> {
+  const coordinates = validateDerivedImportInput(input);
+  const clock = options.clock ?? (() => new Date().toISOString());
+  return withCanonicalWriter(ledgerDir, () => ({ status: "committed", ...commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, clock) }));
+}
+
+export const commitCathayImportRun = commitCathayDerivedImportRun;
+export const commitDerivedImportRun = commitCathayDerivedImportRun;
+export const commitCathayDerivedImport = commitCathayDerivedImportRun;
+
+export async function runCathayDerivedImportRun(ledgerDir: string, input: CathayDerivedImportRunInput, options: CathayDerivedImportOptions = {}): Promise<CathayDerivedImportResult> {
+  let coordinates: CathayDerivedImportCoordinate[];
+  try { coordinates = validateDerivedImportInput(input); }
+  catch (error) {
+    const diagnostic = derivedDiagnostic(error, input, "preflight");
+    options.onDiagnostic?.(diagnostic);
+    return { status: "diagnostic", diagnostic };
+  }
+  try { return { status: "committed", ...await withCanonicalWriter(ledgerDir, () => commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, options.clock ?? (() => new Date().toISOString()))) }; }
+  catch (error) {
+    const diagnostic = derivedDiagnostic(error, input, "commit");
+    options.onDiagnostic?.(diagnostic);
+    return { status: "diagnostic", diagnostic };
+  }
+}
+
+export async function commitCathayUserAssertion(ledgerDir: string, input: CathayUserAssertionInput, options: CathayCanonicalCommitOptions = {}): Promise<CathayUserAssertionResult> {
+  const rawField = typeof input.field === "string" ? input.field : typeof input.target === "object" ? input.target.field : undefined;
+  const field = rawField === "displayName" || rawField === "displayLabel" ? "display_name" : rawField;
+  if (field !== "display_name" && field !== "note") throw new Error("User Assertions may target only display_name or note.");
+  const transactionIdText = input.transactionId ?? input.subject?.id ?? (typeof input.target === "object" ? input.target.id : undefined);
+  if (!transactionIdText) throw new Error("User Assertion requires a transaction subject.");
+  if (input.subject && input.subject.kind !== "transaction") throw new Error("User Assertions support transaction subjects only.");
+  const transactionId = idFromString(transactionIdText);
+  if (input.value !== undefined && input.value !== null && typeof input.value !== "string") throw new Error("User Assertion value must be a string or null.");
+  const userId = input.userId?.trim() || "local-user";
+  if (!userId) throw new Error("User Assertion user identity is required.");
+  if (input.observedAt) parseRfc3339UtcMicros(input.observedAt, "User Assertion observedAt");
+  const clock = options.clock ?? (() => new Date().toISOString());
+  return withCanonicalWriter(ledgerDir, () => {
+    const db = openCanonicalDatabase(ledgerDir);
+    let inTransaction = false;
+    try {
+      db.exec("BEGIN IMMEDIATE"); inTransaction = true;
+      if (!db.prepare("SELECT 1 FROM financial_transactions WHERE transaction_id = ?").get(transactionId)) throw new Error("User Assertion targets an unknown transaction.");
+      const commitId = uuidV7();
+      const commitSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0) + 1;
+      db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, 'user_assertion')").run(commitId, commitSequence, recordedAtUtcUs(clock()), "user/local");
+      const prior = db.prepare(`SELECT ua.* FROM user_assertions ua JOIN canonical_commits c ON c.commit_id = ua.commit_id
+        WHERE ua.transaction_id = ? AND ua.field_name = ? AND ua.user_id = ? ORDER BY c.commit_sequence DESC, ua.assertion_id DESC LIMIT 1`).get(transactionId, field, userId) as Record<string, unknown> | undefined;
+      let assertionId: CanonicalId;
+      const withdrawn = input.value === null;
+      if (withdrawn) {
+        if (!prior) throw new Error("Cannot withdraw a user assertion that does not exist.");
+        assertionId = blob(prior.assertion_id);
+        db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'withdrawn')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
+      } else {
+        const value = input.value ?? "";
+        if (prior && String(prior.value_text) === value && latestUserLifecycle(db, blob(prior.assertion_id)) !== "withdrawn") {
+          assertionId = blob(prior.assertion_id);
+          db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'provenance_only')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
+        } else {
+          assertionId = uuidV7();
+          if (prior) db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
+          db.prepare("INSERT INTO user_assertions(assertion_id, transaction_id, field_name, user_id, value_text, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
+          db.prepare("INSERT INTO user_assertion_lifecycle_events(event_id, assertion_id, transaction_id, field_name, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
+        }
+      }
+      if (withdrawn) {
+        db.prepare("DELETE FROM current_transaction_fields WHERE transaction_id = ? AND field_name = ? AND origin = 'user' AND user_assertion_id = ?").run(transactionId, field, assertionId);
+        refreshCurrentFieldAfterWithdrawal(db, transactionId, field, commitId);
+      }
+      else db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+        VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, input.value ?? "", assertionId, commitId);
+      db.prepare("INSERT OR IGNORE INTO user_assertion_provenance(assertion_id, commit_id) VALUES (?, ?)").run(assertionId, commitId);
+      db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
+      db.exec("COMMIT"); inTransaction = false;
+      return { status: "committed", assertionId: idToString(assertionId), commitSequence, field, withdrawn };
+    } catch (error) { if (inTransaction) db.exec("ROLLBACK"); throw error; }
+    finally { db.close(); }
+  });
+}
+
+export const setCathayUserAssertion = commitCathayUserAssertion;
+export const commitCathayUserTransactionAssertion = commitCathayUserAssertion;
+export const commitCathayUserAssertionAction = commitCathayUserAssertion;
+
 function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }
 function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction {
+  const selectedDisplay = typeof row.selected_display_label === "string" ? row.selected_display_label : typeof row.description === "string" ? row.description : null;
+  const selectedDisplayOrigin = row.selected_display_origin === "user" || row.selected_display_origin === "derived" ? row.selected_display_origin : "source";
+  const selectedDisplayCommitSequence = typeof row.selected_display_commit_sequence === "number" ? row.selected_display_commit_sequence : row.selected_display_commit_sequence !== undefined && row.selected_display_commit_sequence !== null ? Number(row.selected_display_commit_sequence) : null;
+  const selectedNote = typeof row.selected_note === "string" ? row.selected_note : null;
+  const selectedNoteOrigin = row.selected_note_origin === "user" || row.selected_note_origin === "derived" ? row.selected_note_origin : null;
+  const selectedNoteCommitSequence = typeof row.selected_note_commit_sequence === "number" ? row.selected_note_commit_sequence : row.selected_note_commit_sequence !== undefined && row.selected_note_commit_sequence !== null ? Number(row.selected_note_commit_sequence) : null;
   return {
     id: idToString(row.transaction_id), accountId: idToString(row.account_id), accountNo: String(row.account_no), sourceSequence: String(row.source_sequence),
     amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: row.posting_status as "posted",
     postingOrigin: row.posting_origin as "provider_booked_history", postingBasis: row.posting_basis as "query-status-success-with-accounting-date", postingRuleVersion: row.posting_rule_version as "cathay/domestic-deposit/v1",
     assertionSupportState: row.assertion_support_state === "withdrawn" ? "withdrawn" : "supported", economicStatus: row.economic_status as CanonicalEconomicStatus, administrativeState: row.administrative_state as CanonicalAdministrativeState, semanticRuleVersion: row.semantic_rule_version as "cathay/domestic-deposit/v1",
-    displayLabel: typeof row.description === "string" ? row.description : null, effectiveOn: String(row.effective_on), effectiveTimeBasis: row.effective_time_basis as "accounting", effectiveTimeRuleVersion: row.effective_time_rule_version as "cathay/domestic-deposit/v1",
+    displayLabel: selectedDisplay, displayLabelOrigin: selectedDisplayOrigin, displayLabelCommitSequence: selectedDisplayCommitSequence, note: selectedNote, noteOrigin: selectedNoteOrigin, noteCommitSequence: selectedNoteCommitSequence, effectiveOn: String(row.effective_on), effectiveTimeBasis: row.effective_time_basis as "accounting", effectiveTimeRuleVersion: row.effective_time_rule_version as "cathay/domestic-deposit/v1",
     transactionDateTimeLocal: String(row.transaction_date_time_local), timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, timePrecision: "second", timeOrigin: "source_reported",
     utcInstantUtcUs: Number(row.utc_instant_utc_us), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence),
   };
@@ -1271,6 +1742,35 @@ function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction 
 function transactionRevisionFromRow(row: Record<string, unknown>): CanonicalTransactionRevision {
   const transaction = transactionFromRow(row);
   return { ...transaction, id: idToString(row.revision_id), transactionId: transaction.id };
+}
+
+function selectedCurrentField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField): { value: string; origin: "derived" | "user"; commitSequence: number } | undefined {
+  const row = db.prepare("SELECT f.value_text, f.origin, c.commit_sequence FROM current_transaction_fields f JOIN canonical_commits c ON c.commit_id = f.projection_commit_id WHERE f.transaction_id = ? AND f.field_name = ?").get(transactionId as CanonicalId, field) as { value_text?: unknown; origin?: string; commit_sequence?: number } | undefined;
+  if (row?.origin !== "derived" && row?.origin !== "user") return undefined;
+  return { value: String(row.value_text), origin: row.origin, commitSequence: Number(row.commit_sequence) };
+}
+
+function selectedHistoricalField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField, knowledgeAt: number): { value: string; origin: "derived" | "user"; commitSequence: number } | undefined {
+  const user = db.prepare(`SELECT ua.value_text, c.commit_sequence FROM user_assertions ua JOIN user_assertion_lifecycle_events e ON e.assertion_id = ua.assertion_id
+    JOIN canonical_commits c ON c.commit_id = e.commit_id
+    WHERE ua.transaction_id = ? AND ua.field_name = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+      AND NOT EXISTS (SELECT 1 FROM user_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+        WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
+    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
+  if (user) return { value: String(user.value_text), origin: "user", commitSequence: Number(user.commit_sequence) };
+  const derived = db.prepare(`SELECT da.value_text, c.commit_sequence FROM derived_assertions da JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
+    JOIN canonical_commits c ON c.commit_id = e.commit_id
+    WHERE da.transaction_id = ? AND da.field_name = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+      AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+        WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ? AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
+    ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(transactionId as CanonicalId, field, knowledgeAt, knowledgeAt) as { value_text?: unknown; commit_sequence?: number } | undefined;
+  return derived ? { value: String(derived.value_text), origin: "derived", commitSequence: Number(derived.commit_sequence) } : undefined;
+}
+
+function addSelectedFields(db: DatabaseSync, row: Record<string, unknown>, knowledgeAt?: number): Record<string, unknown> {
+  const display = knowledgeAt === undefined ? selectedCurrentField(db, row.transaction_id, "display_name") : selectedHistoricalField(db, row.transaction_id, "display_name", knowledgeAt);
+  const note = knowledgeAt === undefined ? selectedCurrentField(db, row.transaction_id, "note") : selectedHistoricalField(db, row.transaction_id, "note", knowledgeAt);
+  return { ...row, selected_display_label: display?.value, selected_display_origin: display?.origin, selected_display_commit_sequence: display?.commitSequence, selected_note: note?.value, selected_note_origin: note?.origin, selected_note_commit_sequence: note?.commitSequence };
 }
 
 class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQuery {
@@ -1291,7 +1791,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
       const projection = db.prepare(`SELECT c.commit_sequence FROM current_projection_state state
         JOIN canonical_commits c ON c.commit_id = state.commit_id WHERE state.generation = 1`).get() as { commit_sequence?: number } | undefined;
       if (!projection) throw new Error("Canonical current projection cutoff is missing.");
-      return { status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow), commitSequence: Number(projection.commit_sequence) };
+      return { status: "ok", kind: "current", accounts, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row))), commitSequence: Number(projection.commit_sequence) };
     } finally { db.close(); }
   }
   async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {
@@ -1316,7 +1816,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
           WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
         ) ORDER BY a.account_no, t.source_sequence`).all(knowledgeAt, request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
-      return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map(transactionFromRow) };
+      return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row, knowledgeAt))) };
     } finally { db.close(); }
   }
   async lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult> {
@@ -1342,7 +1842,13 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         const lifecycleEvents = db.prepare(`SELECT e.event_id, e.event_kind, c.commit_sequence, cs.scope_id, cs.completeness, cs.absence_authority, cs.contract_fingerprint, cs.page_count
           FROM assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
           LEFT JOIN capture_scopes cs ON cs.scope_id = e.scope_id WHERE e.assertion_id = ? ORDER BY c.commit_sequence, e.event_id`).all(assertionId) as Record<string, unknown>[];
-        const revision = transactionRevisionFromRow(row);
+        const derivedRows = db.prepare(`SELECT da.assertion_id, da.field_name, da.producer_id, da.origin, da.rule_lineage, da.value_text, da.run_id, c.commit_sequence
+          FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
+          WHERE da.transaction_id = ? ORDER BY c.commit_sequence, da.assertion_id`).all(transactionId) as Record<string, unknown>[];
+        const userRows = db.prepare(`SELECT ua.assertion_id, ua.field_name, ua.user_id, ua.value_text, c.commit_sequence
+          FROM user_assertions ua JOIN canonical_commits c ON c.commit_id = ua.commit_id
+          WHERE ua.transaction_id = ? ORDER BY c.commit_sequence, ua.assertion_id`).all(transactionId) as Record<string, unknown>[];
+        const revision = transactionRevisionFromRow(addSelectedFields(db, row, Number(row.commit_sequence)));
         return {
           transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },
           revision,
@@ -1354,6 +1860,16 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
             id: idToString(event.event_id), kind: event.event_kind as CathayCanonicalLifecycleEvent["kind"], commitSequence: Number(event.commit_sequence),
             scopeProof: event.scope_id ? { id: idToString(event.scope_id), completeness: "complete-range" as const, absenceAuthority: (event.absence_authority as CathayAbsenceAuthority | null) ?? null, contractFingerprint: String(event.contract_fingerprint), pageCount: Number(event.page_count) } : null,
           })),
+          derivedAssertions: derivedRows.map((derived) => {
+            const derivedAssertionId = blob(derived.assertion_id);
+            const provenanceRows = db.prepare("SELECT run_id, coordinate_id FROM derived_assertion_provenance WHERE assertion_id = ? ORDER BY run_id, coordinate_id").all(derivedAssertionId) as Record<string, unknown>[];
+            return { id: idToString(derivedAssertionId), field: derived.field_name as CathayDerivedField, producerId: String(derived.producer_id), origin: String(derived.origin), ruleLineage: String(derived.rule_lineage), value: String(derived.value_text), state: latestDerivedLifecycle(db, derivedAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(derived.commit_sequence), runId: idToString(derived.run_id), provenance: provenanceRows.map((provenanceRow) => ({ runId: idToString(provenanceRow.run_id), coordinateId: idToString(provenanceRow.coordinate_id) })) };
+          }),
+          userAssertions: userRows.map((user) => {
+            const userAssertionId = blob(user.assertion_id);
+            const userProvenance = db.prepare(`SELECT c.commit_sequence FROM user_assertion_provenance p JOIN canonical_commits c ON c.commit_id = p.commit_id WHERE p.assertion_id = ? ORDER BY c.commit_sequence`).all(userAssertionId) as Array<Record<string, unknown>>;
+            return { id: idToString(userAssertionId), field: user.field_name as CathayUserAssertionField, userId: String(user.user_id), value: String(user.value_text), state: latestUserLifecycle(db, userAssertionId) === "withdrawn" ? "withdrawn" as const : "supported" as const, commitSequence: Number(user.commit_sequence), provenance: userProvenance.map((item) => ({ commitSequence: Number(item.commit_sequence) })) };
+          }),
         } satisfies CathayCanonicalLineageEntry;
       });
       return { status: "ok", kind: "lineage", subject: request.subject, entries };

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -968,7 +968,6 @@ WHEN NOT EXISTS (
   SELECT 1 FROM assertions assertion JOIN projection_generations generation ON generation.generation_id = NEW.generation_id
   WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
     AND assertion.origin = NEW.origin AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
-    AND NEW.projection_commit_id IS COALESCE(generation.switched_commit_id, generation.created_commit_id)
 )
 BEGIN SELECT RAISE(ABORT, 'projection generation field assertion integrity mismatch'); END;
 CREATE TRIGGER IF NOT EXISTS trg_projection_generation_fields_integrity_update
@@ -977,9 +976,88 @@ WHEN NOT EXISTS (
   SELECT 1 FROM assertions assertion JOIN projection_generations generation ON generation.generation_id = NEW.generation_id
   WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
     AND assertion.origin = NEW.origin AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
-    AND NEW.projection_commit_id IS COALESCE(generation.switched_commit_id, generation.created_commit_id)
 )
 BEGIN SELECT RAISE(ABORT, 'projection generation field assertion integrity mismatch'); END;
+CREATE TRIGGER IF NOT EXISTS trg_assertion_transitions_integrity_insert
+BEFORE INSERT ON assertion_transitions
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion
+  WHERE assertion.assertion_id = NEW.assertion_id AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
+    AND (assertion.origin = 'source'
+      OR (assertion.origin = 'user' AND NEW.capture_id IS NULL AND NEW.scope_id IS NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL AND NEW.user_id = assertion.producer_id)
+      OR (assertion.origin = 'derived' AND NEW.capture_id IS NULL AND NEW.scope_id IS NULL AND NEW.user_id IS NULL AND EXISTS (
+        SELECT 1 FROM derived_import_runs run JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = NEW.coordinate_id
+        JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+        WHERE run.run_id = NEW.run_id AND coordinate.run_id = run.run_id
+          AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+          AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+          AND run.authority_route = 'cathay/domestic-deposit/v1' AND run.stream = 'domestic-deposit'
+          AND run.producer_id = assertion.producer_id AND run.origin = 'derived/cathay/domestic-deposit/v1'
+          AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+          AND registered.integration_namespace = 'cathay' AND registered.stream = 'domestic-deposit' AND registered.contract_version = 'v1'
+      )))
+)
+BEGIN SELECT RAISE(ABORT, 'assertion transition coordinate mismatch'); END;
+CREATE TRIGGER IF NOT EXISTS trg_assertion_transitions_integrity_update
+BEFORE UPDATE OF assertion_id, transaction_id, field_name ON assertion_transitions
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion
+  WHERE assertion.assertion_id = NEW.assertion_id AND assertion.transaction_id = NEW.transaction_id AND assertion.field_name = NEW.field_name
+    AND (assertion.origin = 'source'
+      OR (assertion.origin = 'user' AND NEW.capture_id IS NULL AND NEW.scope_id IS NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL AND NEW.user_id = assertion.producer_id)
+      OR (assertion.origin = 'derived' AND NEW.capture_id IS NULL AND NEW.scope_id IS NULL AND NEW.user_id IS NULL AND EXISTS (
+        SELECT 1 FROM derived_import_runs run JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = NEW.coordinate_id
+        JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+        WHERE run.run_id = NEW.run_id AND coordinate.run_id = run.run_id
+          AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+          AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+          AND run.authority_route = 'cathay/domestic-deposit/v1' AND run.stream = 'domestic-deposit'
+          AND run.producer_id = assertion.producer_id AND run.origin = 'derived/cathay/domestic-deposit/v1'
+          AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+          AND registered.integration_namespace = 'cathay' AND registered.stream = 'domestic-deposit' AND registered.contract_version = 'v1'
+      )))
+)
+BEGIN SELECT RAISE(ABORT, 'assertion transition coordinate mismatch'); END;
+CREATE TRIGGER IF NOT EXISTS trg_assertion_provenance_integrity_insert
+BEFORE INSERT ON assertion_provenance
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion
+  WHERE assertion.assertion_id = NEW.assertion_id
+    AND (assertion.origin = 'source' AND NEW.source_record_id IS NOT NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL
+      OR assertion.origin = 'user' AND NEW.source_record_id IS NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL
+      OR assertion.origin = 'derived' AND NEW.source_record_id IS NULL AND EXISTS (
+        SELECT 1 FROM derived_import_runs run JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = NEW.coordinate_id
+        JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+        WHERE run.run_id = NEW.run_id AND coordinate.run_id = run.run_id
+          AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+          AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+          AND run.authority_route = 'cathay/domestic-deposit/v1' AND run.stream = 'domestic-deposit'
+          AND run.producer_id = assertion.producer_id AND run.origin = 'derived/cathay/domestic-deposit/v1'
+          AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+          AND registered.integration_namespace = 'cathay' AND registered.stream = 'domestic-deposit' AND registered.contract_version = 'v1'
+      ))
+)
+BEGIN SELECT RAISE(ABORT, 'assertion provenance coordinate mismatch'); END;
+CREATE TRIGGER IF NOT EXISTS trg_assertion_provenance_integrity_update
+BEFORE UPDATE OF assertion_id, source_record_id, run_id, coordinate_id ON assertion_provenance
+WHEN NOT EXISTS (
+  SELECT 1 FROM assertions assertion
+  WHERE assertion.assertion_id = NEW.assertion_id
+    AND (assertion.origin = 'source' AND NEW.source_record_id IS NOT NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL
+      OR assertion.origin = 'user' AND NEW.source_record_id IS NULL AND NEW.run_id IS NULL AND NEW.coordinate_id IS NULL
+      OR assertion.origin = 'derived' AND NEW.source_record_id IS NULL AND EXISTS (
+        SELECT 1 FROM derived_import_runs run JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = NEW.coordinate_id
+        JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+        WHERE run.run_id = NEW.run_id AND coordinate.run_id = run.run_id
+          AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+          AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+          AND run.authority_route = 'cathay/domestic-deposit/v1' AND run.stream = 'domestic-deposit'
+          AND run.producer_id = assertion.producer_id AND run.origin = 'derived/cathay/domestic-deposit/v1'
+          AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+          AND registered.integration_namespace = 'cathay' AND registered.stream = 'domestic-deposit' AND registered.contract_version = 'v1'
+      ))
+)
+BEGIN SELECT RAISE(ABORT, 'assertion provenance coordinate mismatch'); END;
 `;
 
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
@@ -1515,11 +1593,10 @@ function projectionIdentityKey(row: { transaction_id?: unknown; revision_id?: un
 }
 
 /** Rebuild population is intentionally allowed to omit malformed evidence;
- * this equality check makes that omission observable before a shadow can be
- * validated. The expected set is derived from immutable revision/scope rows,
+ * this calculator derives the expected set from immutable revision/scope rows,
  * not from the Source Assertion join used by the population query. */
-function validateGenerationTransactionCompleteness(db: DatabaseSync, generationId: number, cutoff: number): void {
-  const expected = db.prepare(`SELECT transaction_row.transaction_id, revision.revision_id
+function expectedGenerationTransactions(db: DatabaseSync, cutoff: number): Array<{ transaction_id?: unknown; revision_id?: unknown }> {
+  return db.prepare(`SELECT transaction_row.transaction_id, revision.revision_id
     FROM financial_transactions transaction_row
     JOIN transaction_revisions revision ON revision.transaction_id = transaction_row.transaction_id
     JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
@@ -1536,6 +1613,10 @@ function validateGenerationTransactionCompleteness(db: DatabaseSync, generationI
         WHERE source_assertion.origin = 'source' AND source_assertion.revision_id = revision.revision_id
           AND transition_commit.commit_sequence <= ?
         ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1), 'observed') <> 'withdrawn'`).all(cutoff, cutoff, cutoff) as Array<{ transaction_id?: unknown; revision_id?: unknown }>;
+}
+
+function validateGenerationTransactionIntegrity(db: DatabaseSync, generationId: number, cutoff: number): void {
+  const expected = expectedGenerationTransactions(db, cutoff);
   const actual = db.prepare("SELECT transaction_id, revision_id FROM projection_generation_transactions WHERE generation_id = ?").all(generationId) as Array<{ transaction_id?: unknown; revision_id?: unknown }>;
   const expectedKeys = new Set(expected.map(projectionIdentityKey));
   const actualKeys = new Set(actual.map(projectionIdentityKey));
@@ -1543,6 +1624,23 @@ function validateGenerationTransactionCompleteness(db: DatabaseSync, generationI
   const extra = [...actualKeys].filter((key) => !expectedKeys.has(key));
   if (missing.length !== 0 || extra.length !== 0 || expectedKeys.size !== actualKeys.size) {
     throw new Error(`Projection rebuild completeness mismatch: missing=${missing.length}, extra=${extra.length}.`);
+  }
+  const rows = db.prepare(`SELECT projected.transaction_id, projected.revision_id, projected.projection_commit_id, projected.revision_commit_id,
+      revision.transaction_id AS revision_transaction_id, revision.commit_id AS source_revision_commit_id,
+      revision_commit.commit_sequence AS revision_commit_sequence, projection_commit.commit_sequence AS projection_commit_sequence,
+      upper_commit.commit_sequence AS upper_commit_sequence
+    FROM projection_generation_transactions projected
+    JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
+    JOIN canonical_commits projection_commit ON projection_commit.commit_id = projected.projection_commit_id
+    JOIN projection_generations generation ON generation.generation_id = projected.generation_id
+    JOIN canonical_commits upper_commit ON upper_commit.commit_id = COALESCE(generation.switched_commit_id, generation.created_commit_id)
+    WHERE projected.generation_id = ?`).all(generationId) as Array<Record<string, unknown>>;
+  if (rows.some((row) => !canonicalIdsEqual(row.revision_transaction_id, row.transaction_id)
+    || !canonicalIdsEqual(row.revision_commit_id, row.source_revision_commit_id)
+    || Number(row.projection_commit_sequence) < Number(row.revision_commit_sequence)
+    || Number(row.projection_commit_sequence) > Number(row.upper_commit_sequence))) {
+    throw new Error("Canonical v7 projection transaction commit semantics are invalid.");
   }
 }
 
@@ -1558,7 +1656,15 @@ function validateGenerationFieldIntegrity(db: DatabaseSync, generationId: number
       projected.transaction_id AS projected_transaction_id, projected.revision_id AS projected_revision_id,
       projected.projection_commit_id AS projected_projection_commit_id, projected.revision_commit_id AS projected_revision_commit_id,
       revision.transaction_id AS revision_transaction_id, revision.commit_id AS revision_commit_id,
+      revision_commit.commit_sequence AS revision_commit_sequence,
       projection_commit.commit_sequence AS projection_commit_sequence,
+      projection_commit.commit_kind AS projection_commit_kind,
+      projected_projection_commit.commit_sequence AS projected_projection_commit_sequence,
+      upper_commit.commit_sequence AS upper_commit_sequence,
+      EXISTS (SELECT 1 FROM assertion_transitions projection_transition
+        WHERE projection_transition.transaction_id = field.transaction_id
+          AND projection_transition.field_name = field.field_name
+          AND projection_transition.commit_id = field.projection_commit_id) AS projection_commit_is_field_event,
       (SELECT transition.event_kind FROM assertion_transitions transition JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
         WHERE transition.assertion_id = assertion.assertion_id AND transition_commit.commit_sequence <= generation.build_cutoff_commit_sequence
         ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1) AS lifecycle_event,
@@ -1572,24 +1678,43 @@ function validateGenerationFieldIntegrity(db: DatabaseSync, generationId: number
     LEFT JOIN canonical_commits assertion_commit ON assertion_commit.commit_id = assertion.created_commit_id
     LEFT JOIN projection_generation_transactions projected ON projected.generation_id = field.generation_id AND projected.transaction_id = field.transaction_id
     LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    LEFT JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
     LEFT JOIN canonical_commits projection_commit ON projection_commit.commit_id = field.projection_commit_id
+    LEFT JOIN canonical_commits projected_projection_commit ON projected_projection_commit.commit_id = projected.projection_commit_id
+    LEFT JOIN canonical_commits upper_commit ON upper_commit.commit_id = COALESCE(generation.switched_commit_id, generation.created_commit_id)
     LEFT JOIN derived_import_runs run ON run.commit_id = assertion.created_commit_id AND run.producer_id = assertion.producer_id AND run.rule_lineage = assertion.rule_lineage
     LEFT JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
     WHERE field.generation_id = ?`).all(generationId) as Array<Record<string, unknown>>;
   for (const row of rows) {
-    const expectedProjectionCommit = row.generation_switched_commit_id ?? row.generation_created_commit_id;
     const validLifecycle = row.lifecycle_event === "observed" || row.lifecycle_event === "restored";
     const assertionMatches = row.assertion_id !== undefined && row.assertion_id !== null
       && canonicalIdsEqual(row.assertion_transaction_id, row.transaction_id)
       && row.assertion_field_name === row.field_name && row.assertion_origin === row.origin
       && row.assertion_value_text === row.value_text;
-    const projectionMatches = canonicalIdsEqual(row.projection_commit_id, expectedProjectionCommit)
+    const fieldProjectionSequence = Number(row.projection_commit_sequence);
+    const projectedProjectionSequence = Number(row.projected_projection_commit_sequence);
+    const revisionSequence = Number(row.revision_commit_sequence);
+    const assertionSequence = Number(row.assertion_commit_sequence);
+    const upperSequence = Number(row.upper_commit_sequence);
+    const projectionMatches = row.projection_commit_id !== undefined && row.projection_commit_id !== null
       && row.projected_projection_commit_id !== undefined && row.projected_projection_commit_id !== null
-      && canonicalIdsEqual(row.projected_projection_commit_id, row.projection_commit_id)
       && canonicalIdsEqual(row.projected_revision_commit_id, row.revision_commit_id)
       && canonicalIdsEqual(row.revision_transaction_id, row.transaction_id)
       && row.projected_transaction_id !== undefined && row.projected_transaction_id !== null
       && row.projection_commit_sequence !== undefined && row.projection_commit_sequence !== null;
+    const projectionCommitIsLegitimate = canonicalIdsEqual(row.projection_commit_id, row.assertion_created_commit_id)
+      || canonicalIdsEqual(row.projection_commit_id, row.generation_created_commit_id)
+      || row.projection_commit_kind === "projection_rebuild"
+      || Number(row.projection_commit_is_field_event) === 1;
+    const commitSemantics = Number.isSafeInteger(fieldProjectionSequence)
+      && Number.isSafeInteger(projectedProjectionSequence)
+      && Number.isSafeInteger(revisionSequence)
+      && Number.isSafeInteger(assertionSequence)
+      && Number.isSafeInteger(upperSequence)
+      && fieldProjectionSequence >= assertionSequence
+      && fieldProjectionSequence <= upperSequence
+      && projectedProjectionSequence >= revisionSequence
+      && projectedProjectionSequence <= upperSequence;
     const assertionAsOfCutoff = row.assertion_commit_sequence !== undefined && row.assertion_commit_sequence !== null
       && Number(row.assertion_commit_sequence) <= Number(row.build_cutoff_commit_sequence);
     const authorityValid = row.origin === "user"
@@ -1601,10 +1726,85 @@ function validateGenerationFieldIntegrity(db: DatabaseSync, generationId: number
         && row.run_origin === CATHAY_DERIVED_ORIGIN && row.run_status === "complete"
         && row.registered_namespace === CATHAY_INTEGRATION_NAMESPACE && row.registered_stream === CATHAY_DOMESTIC_DEPOSIT_STREAM
         && row.registered_contract_version === CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION;
-    if (!assertionMatches || !projectionMatches || !validLifecycle || !assertionAsOfCutoff || !authorityValid) {
+    if (!assertionMatches || !projectionMatches || !projectionCommitIsLegitimate || !commitSemantics || !validLifecycle || !assertionAsOfCutoff || !authorityValid) {
       throw new Error("Canonical v7 projection field assertion integrity is invalid.");
     }
   }
+}
+
+function validateGenerationFieldCompleteness(db: DatabaseSync, generationId: number, cutoff: number): void {
+  const expected: string[] = [];
+  for (const transaction of expectedGenerationTransactions(db, cutoff)) {
+    const transactionId = blob(transaction.transaction_id);
+    for (const field of ["display_name", "note"] as const) {
+      const selected = selectAssertionAsOf(db, transactionId, field, cutoff, "user")
+        ?? selectAssertionAsOf(db, transactionId, field, cutoff, "derived");
+      if (selected) expected.push(`${transactionId.toString("hex")}:${field}:${blob(selected.assertion_id).toString("hex")}:${selected.origin}:${selected.value_text}`);
+    }
+  }
+  const actualRows = db.prepare(`SELECT transaction_id, field_name, origin, value_text,
+      CASE WHEN origin = 'derived' THEN derived_assertion_id ELSE user_assertion_id END AS assertion_id
+    FROM projection_generation_transaction_fields WHERE generation_id = ?`).all(generationId) as Array<{ transaction_id?: unknown; field_name?: unknown; origin?: unknown; value_text?: unknown; assertion_id?: unknown }>;
+  const actual = actualRows.map((row) => `${blob(row.transaction_id).toString("hex")}:${String(row.field_name)}:${blob(row.assertion_id).toString("hex")}:${String(row.origin)}:${String(row.value_text)}`);
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  const missing = [...expectedSet].filter((key) => !actualSet.has(key));
+  const extra = [...actualSet].filter((key) => !expectedSet.has(key));
+  if (missing.length !== 0 || extra.length !== 0 || expectedSet.size !== actualSet.size) {
+    throw new Error(`Canonical v7 projection field completeness mismatch: missing=${missing.length}, extra=${extra.length}.`);
+  }
+}
+
+function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: number): void {
+  const invalidTransitions = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transaction_fields field
+    JOIN projection_generations generation ON generation.generation_id = field.generation_id
+    JOIN assertions assertion ON assertion.assertion_id = CASE WHEN field.origin = 'derived' THEN field.derived_assertion_id ELSE field.user_assertion_id END
+    JOIN assertion_transitions transition ON transition.assertion_id = assertion.assertion_id
+    JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
+    WHERE field.generation_id = ? AND transition_commit.commit_sequence <= generation.build_cutoff_commit_sequence
+      AND NOT (
+        transition.transaction_id = assertion.transaction_id AND transition.field_name = assertion.field_name
+        AND ((assertion.origin = 'user' AND transition.capture_id IS NULL AND transition.scope_id IS NULL
+              AND transition.run_id IS NULL AND transition.coordinate_id IS NULL AND transition.user_id = assertion.producer_id
+              AND transition_commit.authority_route = 'user/local')
+          OR (assertion.origin = 'derived' AND transition.capture_id IS NULL AND transition.scope_id IS NULL
+              AND transition.user_id IS NULL AND transition_commit.authority_route = ? AND EXISTS (
+            SELECT 1 FROM derived_import_runs run
+            JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = transition.coordinate_id
+            JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+            WHERE run.run_id = transition.run_id AND coordinate.run_id = run.run_id
+              AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+              AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+              AND run.authority_route = ? AND run.stream = ? AND run.producer_id = assertion.producer_id
+              AND run.origin = ? AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+              AND registered.integration_namespace = ? AND registered.stream = ? AND registered.contract_version = ?
+          )))
+      )`).get(generationId, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DERIVED_ORIGIN,
+    CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION) as { count?: number }).count ?? 0);
+  if (invalidTransitions !== 0) throw new Error("Canonical v7 selected assertion lifecycle coordinates are invalid.");
+
+  const invalidProvenance = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transaction_fields field
+    JOIN projection_generations generation ON generation.generation_id = field.generation_id
+    JOIN assertions assertion ON assertion.assertion_id = CASE WHEN field.origin = 'derived' THEN field.derived_assertion_id ELSE field.user_assertion_id END
+    JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
+    JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+    WHERE field.generation_id = ? AND provenance_commit.commit_sequence <= generation.build_cutoff_commit_sequence AND (
+      (assertion.origin = 'user' AND provenance_commit.authority_route = 'user/local'
+        AND (provenance.source_record_id IS NOT NULL OR provenance.run_id IS NOT NULL OR provenance.coordinate_id IS NOT NULL))
+      OR (assertion.origin = 'derived' AND (provenance.source_record_id IS NOT NULL OR provenance_commit.authority_route <> 'cathay/domestic-deposit/v1' OR NOT EXISTS (
+        SELECT 1 FROM derived_import_runs run
+        JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = provenance.coordinate_id
+        JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+        WHERE run.run_id = provenance.run_id AND coordinate.run_id = run.run_id
+          AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+          AND coordinate.producer_id = assertion.producer_id AND coordinate.rule_lineage = assertion.rule_lineage
+          AND run.authority_route = ? AND run.stream = ? AND run.producer_id = assertion.producer_id
+          AND run.origin = ? AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+          AND registered.integration_namespace = ? AND registered.stream = ? AND registered.contract_version = ?
+      )))
+    )`).get(generationId, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DERIVED_ORIGIN,
+    CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION) as { count?: number }).count ?? 0);
+  if (invalidProvenance !== 0) throw new Error("Canonical v7 selected assertion provenance coordinates are invalid.");
 }
 
 /** Validate the one switch boundary used by both writer and read-only startup.
@@ -1640,7 +1840,11 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
   }
   validateGenerationExactAmounts(db, generationId);
   validateCathayAuthorityRoute(db, generationId);
+  const activeCutoff = Number((db.prepare("SELECT build_cutoff_commit_sequence FROM projection_generations WHERE generation_id = ?").get(generationId) as { build_cutoff_commit_sequence?: number } | undefined)?.build_cutoff_commit_sequence ?? 0);
+  validateGenerationTransactionIntegrity(db, generationId, activeCutoff);
+  validateGenerationFieldCompleteness(db, generationId, activeCutoff);
   validateGenerationFieldIntegrity(db, generationId);
+  validateGenerationLifecycleCoordinates(db, generationId);
   return generationId;
 }
 
@@ -2180,10 +2384,12 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
       LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
       WHERE projected.generation_id = ? AND (transaction_row.transaction_id IS NULL OR revision.revision_id IS NULL OR revision.transaction_id <> projected.transaction_id)`).get(generation) as { count?: number }).count ?? 0);
     if (dangling !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
-    validateGenerationTransactionCompleteness(db, generation, cutoff);
+    validateGenerationTransactionIntegrity(db, generation, cutoff);
+    validateGenerationFieldCompleteness(db, generation, cutoff);
     validateGenerationExactAmounts(db, generation);
     validateCathayAuthorityRoute(db, generation);
     validateGenerationFieldIntegrity(db, generation);
+    validateGenerationLifecycleCoordinates(db, generation);
     const duplicate = Number((db.prepare(`SELECT COUNT(*) AS count FROM (SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ? GROUP BY transaction_id HAVING COUNT(*) <> 1)`).get(generation) as { count?: number }).count ?? 0);
     if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
     rebuildFailure(options.injectFailure, ["validation", "after-validation"]);
@@ -2351,7 +2557,9 @@ function insertCurrentDerivedField(db: DatabaseSync, transactionId: CanonicalId,
   const user = db.prepare("SELECT 1 FROM current_transaction_fields WHERE transaction_id = ? AND field_name = ? AND origin = 'user'").get(transactionId, field);
   if (user) return;
   db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
-    VALUES (?, ?, ?, 'derived', ?, NULL, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'derived', derived_assertion_id = excluded.derived_assertion_id, user_assertion_id = NULL, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, value, assertionId, commitId);
+    VALUES (?, ?, ?, 'derived', ?, NULL, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'derived', derived_assertion_id = excluded.derived_assertion_id, user_assertion_id = NULL,
+      projection_commit_id = CASE WHEN current_transaction_fields.derived_assertion_id = excluded.derived_assertion_id AND current_transaction_fields.value_text = excluded.value_text
+        THEN current_transaction_fields.projection_commit_id ELSE excluded.projection_commit_id END`).run(transactionId, field, value, assertionId, commitId);
 }
 
 function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: CanonicalId, field: CathayDerivedField, commitId: CanonicalId): void {
@@ -2564,7 +2772,9 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
         refreshCurrentFieldAfterWithdrawal(db, transactionId, field, commitId);
       }
       else db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
-        VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, input.value ?? "", assertionId, commitId);
+        VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id,
+          projection_commit_id = CASE WHEN current_transaction_fields.user_assertion_id = excluded.user_assertion_id AND current_transaction_fields.value_text = excluded.value_text
+            THEN current_transaction_fields.projection_commit_id ELSE excluded.projection_commit_id END`).run(transactionId, field, input.value ?? "", assertionId, commitId);
       db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, NULL, NULL, ?)").run(assertionId, commitId);
       syncActiveProjectionFromCompatibility(db, commitId);
       db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
@@ -2653,10 +2863,11 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
-        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM projection_generation_transactions current_row
+        r.utc_instant_utc_us, r.revision_id, projection_cutoff.commit_sequence FROM projection_generation_transactions current_row
         JOIN active_projection_generation pointer ON pointer.singleton_id = 1 AND pointer.generation_id = current_row.generation_id
+        JOIN canonical_commits projection_cutoff ON projection_cutoff.commit_id = pointer.switched_commit_id
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
-        JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.projection_commit_id
+        JOIN transaction_revisions r ON r.revision_id = current_row.revision_id
         ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
       const projection = db.prepare(`SELECT c.commit_sequence FROM active_projection_generation pointer
         JOIN canonical_commits c ON c.commit_id = pointer.switched_commit_id WHERE pointer.singleton_id = 1`).get() as { commit_sequence?: number } | undefined;

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -2117,13 +2117,11 @@ function validateSelectedAssertionProvenance(db: DatabaseSync, generationId: num
       SELECT 1 FROM assertion_provenance provenance
       JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
       WHERE provenance.assertion_id = assertion.assertion_id
+        AND assertion.origin = 'user'
+        AND assertion.transaction_id = field.transaction_id AND assertion.field_name = field.field_name
         AND provenance.source_record_id IS NULL AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL
         AND provenance_commit.commit_sequence <= ?
         AND provenance_commit.commit_kind = 'user_assertion' AND provenance_commit.authority_route = 'user/local'
-        AND (provenance.commit_id = assertion.created_commit_id OR EXISTS (
-          SELECT 1 FROM assertion_transitions transition
-          WHERE transition.assertion_id = assertion.assertion_id AND transition.user_id IS NOT NULL AND transition.commit_id = provenance.commit_id
-        ))
     )`).get(generationId, cutoff) as { count?: number }).count ?? 0);
   const invalidDerivedFields = Number((db.prepare(`SELECT COUNT(*) AS count
     FROM projection_generation_transaction_fields field
@@ -2202,12 +2200,56 @@ function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: 
   if (invalidProvenance !== 0) throw new Error("Canonical v7 selected assertion provenance coordinates are invalid.");
 }
 
+function isValidUserAssertionProvenanceEvidence(db: DatabaseSync, assertionId: CanonicalId, commitId: CanonicalId): boolean {
+  return Boolean(db.prepare(`SELECT 1
+    FROM assertion_provenance provenance
+    JOIN assertions assertion ON assertion.assertion_id = provenance.assertion_id AND assertion.origin = 'user'
+    JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+    JOIN canonical_commits created_commit ON created_commit.commit_id = assertion.created_commit_id
+    WHERE provenance.assertion_id = ? AND provenance.commit_id = ?
+      AND provenance.source_record_id IS NULL AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL
+      AND provenance_commit.commit_kind = 'user_assertion' AND provenance_commit.authority_route = 'user/local'
+      AND created_commit.commit_sequence <= provenance_commit.commit_sequence
+      AND (
+        assertion.created_commit_id = provenance.commit_id
+        OR EXISTS (SELECT 1 FROM assertion_transitions transition
+          WHERE transition.assertion_id = assertion.assertion_id AND transition.transaction_id = assertion.transaction_id
+            AND transition.field_name = assertion.field_name AND transition.user_id = assertion.producer_id
+            AND transition.commit_id = provenance.commit_id)
+        OR EXISTS (SELECT 1 FROM assertion_transitions observed
+          JOIN canonical_commits observed_commit ON observed_commit.commit_id = observed.commit_id
+          WHERE observed.assertion_id = assertion.assertion_id AND observed.transaction_id = assertion.transaction_id
+            AND observed.field_name = assertion.field_name AND observed.user_id = assertion.producer_id
+            AND observed.event_kind = 'observed' AND observed_commit.commit_sequence <= provenance_commit.commit_sequence)
+      )
+      AND (
+        EXISTS (SELECT 1 FROM assertion_transitions transition
+          WHERE transition.assertion_id = assertion.assertion_id AND transition.commit_id = provenance.commit_id)
+        OR COALESCE((SELECT latest.event_kind FROM assertion_transitions latest
+          JOIN canonical_commits latest_commit ON latest_commit.commit_id = latest.commit_id
+          WHERE latest.assertion_id = assertion.assertion_id AND latest_commit.commit_sequence <= provenance_commit.commit_sequence
+          ORDER BY latest_commit.commit_sequence DESC, latest.event_id DESC LIMIT 1), 'observed') <> 'withdrawn'
+      )
+      AND NOT EXISTS (SELECT 1 FROM assertions newer
+        JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.created_commit_id
+        WHERE newer.origin = 'user' AND newer.transaction_id = assertion.transaction_id
+          AND newer.field_name = assertion.field_name AND newer.producer_id = assertion.producer_id
+          AND newer_commit.commit_sequence <= provenance_commit.commit_sequence
+          AND newer_commit.commit_sequence > created_commit.commit_sequence)
+    LIMIT 1`).get(assertionId, commitId));
+}
+
 function canonicalCommitHasEvidence(db: DatabaseSync, commitKind: string, commitId: CanonicalId): boolean {
   if (commitKind === "source_capture") return Boolean(db.prepare("SELECT 1 FROM source_captures WHERE commit_id = ? LIMIT 1").get(commitId));
   if (commitKind === "derived_import") return Boolean(db.prepare("SELECT 1 FROM derived_import_runs WHERE commit_id = ? LIMIT 1").get(commitId));
-  if (commitKind === "user_assertion") return Boolean(db.prepare(`SELECT 1 FROM assertions
+  if (commitKind === "user_assertion") {
+    if (db.prepare(`SELECT 1 FROM assertions
       WHERE origin = 'user' AND created_commit_id = ?
-      UNION ALL SELECT 1 FROM assertion_transitions WHERE user_id IS NOT NULL AND commit_id = ? LIMIT 1`).get(commitId, commitId));
+      UNION ALL SELECT 1 FROM assertion_transitions WHERE user_id IS NOT NULL AND commit_id = ? LIMIT 1`).get(commitId, commitId)) return true;
+    const provenanceRows = db.prepare(`SELECT assertion_id FROM assertion_provenance
+      WHERE commit_id = ? AND source_record_id IS NULL AND run_id IS NULL AND coordinate_id IS NULL`).all(commitId) as Array<{ assertion_id?: unknown }>;
+    return provenanceRows.some((row) => isValidUserAssertionProvenanceEvidence(db, blob(row.assertion_id), commitId));
+  }
   return false;
 }
 
@@ -2224,12 +2266,14 @@ function validateUserAssertionProvenanceAuthority(db: DatabaseSync): void {
       OR provenance_commit.authority_route <> 'user/local'
       OR EXISTS (SELECT 1 FROM source_captures capture WHERE capture.commit_id = provenance.commit_id)
       OR EXISTS (SELECT 1 FROM derived_import_runs run WHERE run.commit_id = provenance.commit_id)
-      OR NOT EXISTS (SELECT 1 FROM assertions created
-        WHERE created.assertion_id = assertion.assertion_id AND created.origin = 'user' AND created.created_commit_id = provenance.commit_id)
-      AND NOT EXISTS (SELECT 1 FROM assertion_transitions transition
-        WHERE transition.assertion_id = assertion.assertion_id AND transition.user_id IS NOT NULL AND transition.commit_id = provenance.commit_id)
     )`).get() as { count?: number }).count ?? 0);
   if (invalid !== 0) throw new Error("Canonical user assertion provenance authority is invalid.");
+  const provenanceRows = db.prepare(`SELECT provenance.assertion_id, provenance.commit_id
+    FROM assertion_provenance provenance JOIN assertions assertion ON assertion.assertion_id = provenance.assertion_id
+    WHERE assertion.origin = 'user'`).all() as Array<{ assertion_id?: unknown; commit_id?: unknown }>;
+  if (provenanceRows.some((row) => !isValidUserAssertionProvenanceEvidence(db, blob(row.assertion_id), blob(row.commit_id)))) {
+    throw new Error("Canonical user assertion provenance evidence is incomplete.");
+  }
 }
 
 const CANONICAL_EMPTY_STORE_TABLES = [

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -771,15 +771,27 @@ function migrateV4ToV5(db: DatabaseSync): void {
   db.exec("BEGIN IMMEDIATE");
   try {
     db.exec(`CREATE TEMP TABLE source_record_scope_migration AS
-      SELECT DISTINCT sr.source_record_id, sr.capture_id, sr.commit_id, sr.sequence_lexeme AS old_sequence,
-        sr.description, sr.payload_json, cs.scope_id, cs.account_id, cs.account_no,
-        CASE WHEN sr.sequence_lexeme LIKE cs.account_no || ':%'
-          THEN substr(sr.sequence_lexeme, length(cs.account_no) + 2) ELSE sr.sequence_lexeme END AS provider_sequence
-      FROM source_records sr
-      JOIN transaction_revisions revision ON revision.source_record_id = sr.source_record_id
-      JOIN financial_transactions transaction_row ON transaction_row.transaction_id = revision.transaction_id
-      JOIN financial_accounts account_row ON account_row.account_id = transaction_row.account_id
-      JOIN capture_scopes cs ON cs.capture_id = sr.capture_id AND cs.account_id = account_row.account_id`);
+      WITH source_record_accounts AS (
+        SELECT sr.source_record_id, sr.capture_id, sr.commit_id, sr.sequence_lexeme, sr.description, sr.payload_json, account_row.account_id
+        FROM source_records sr
+        JOIN transaction_revisions revision ON revision.source_record_id = sr.source_record_id
+        JOIN financial_transactions transaction_row ON transaction_row.transaction_id = revision.transaction_id
+        JOIN financial_accounts account_row ON account_row.account_id = transaction_row.account_id
+        UNION
+        SELECT sr.source_record_id, sr.capture_id, sr.commit_id, sr.sequence_lexeme, sr.description, sr.payload_json, account_row.account_id
+        FROM source_records sr
+        JOIN assertion_provenance provenance ON provenance.source_record_id = sr.source_record_id
+        JOIN source_assertions assertion ON assertion.assertion_id = provenance.assertion_id
+        JOIN financial_transactions transaction_row ON transaction_row.transaction_id = assertion.transaction_id
+        JOIN financial_accounts account_row ON account_row.account_id = transaction_row.account_id
+      )
+      SELECT DISTINCT source_record_accounts.source_record_id, source_record_accounts.capture_id, source_record_accounts.commit_id,
+        source_record_accounts.sequence_lexeme AS old_sequence, source_record_accounts.description, source_record_accounts.payload_json,
+        cs.scope_id, cs.account_id, cs.account_no,
+        CASE WHEN source_record_accounts.sequence_lexeme LIKE cs.account_no || ':%'
+          THEN substr(source_record_accounts.sequence_lexeme, length(cs.account_no) + 2) ELSE source_record_accounts.sequence_lexeme END AS provider_sequence
+      FROM source_record_accounts
+      JOIN capture_scopes cs ON cs.capture_id = source_record_accounts.capture_id AND cs.account_id = source_record_accounts.account_id`);
     const recordCount = Number((db.prepare("SELECT COUNT(*) AS count FROM source_records").get() as { count?: number }).count ?? 0);
     const mappedCount = Number((db.prepare("SELECT COUNT(*) AS count FROM source_record_scope_migration").get() as { count?: number }).count ?? 0);
     if (recordCount !== mappedCount) throw new Error("v4 source records could not be deterministically mapped to capture scopes.");

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -838,15 +838,14 @@ CREATE TABLE IF NOT EXISTS current_transaction_fields (
   field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
   value_text TEXT NOT NULL,
   origin TEXT NOT NULL CHECK(origin IN ('derived','user')),
-  derived_assertion_id BLOB REFERENCES derived_assertions(assertion_id),
-  user_assertion_id BLOB REFERENCES user_assertions(assertion_id),
+  derived_assertion_id BLOB REFERENCES assertions(assertion_id),
+  user_assertion_id BLOB REFERENCES assertions(assertion_id),
   projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   PRIMARY KEY(transaction_id, field_name),
   CHECK((origin = 'derived' AND derived_assertion_id IS NOT NULL AND user_assertion_id IS NULL)
     OR (origin = 'user' AND user_assertion_id IS NOT NULL AND derived_assertion_id IS NULL))
 );
 CREATE INDEX IF NOT EXISTS idx_derived_scope_coordinates_lineage ON derived_scope_coordinates(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
-CREATE INDEX IF NOT EXISTS idx_derived_assertions_lineage ON derived_assertions(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
 CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id);
 `;
 const SCHEMA_V6 = `${SCHEMA_V5.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
@@ -1034,9 +1033,44 @@ function backfillV6DerivedAndUserAssertions(db: DatabaseSync): void {
   }
 }
 
+function rebuildCurrentTransactionFieldsForSharedAssertions(db: DatabaseSync): void {
+  const sql = String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'current_transaction_fields'").get() as { sql?: unknown } | undefined)?.sql ?? "");
+  if (/derived_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(sql) && /user_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(sql)) return;
+  db.exec(`CREATE TABLE current_transaction_fields_shared (
+    transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+    field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+    value_text TEXT NOT NULL,
+    origin TEXT NOT NULL CHECK(origin IN ('derived','user')),
+    derived_assertion_id BLOB REFERENCES assertions(assertion_id),
+    user_assertion_id BLOB REFERENCES assertions(assertion_id),
+    projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+    PRIMARY KEY(transaction_id, field_name),
+    CHECK((origin = 'derived' AND derived_assertion_id IS NOT NULL AND user_assertion_id IS NULL)
+      OR (origin = 'user' AND user_assertion_id IS NOT NULL AND derived_assertion_id IS NULL))
+  )`);
+  db.exec(`INSERT INTO current_transaction_fields_shared(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+    SELECT transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`);
+  db.exec("DROP TABLE current_transaction_fields; ALTER TABLE current_transaction_fields_shared RENAME TO current_transaction_fields");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id)");
+}
+
 function convertV6CompatibilityTables(db: DatabaseSync): void {
   backfillV6DerivedAndUserAssertions(db);
   const compatibilityViews: Array<{ name: string; select: string }> = [
+    {
+      name: "derived_assertions",
+      select: `SELECT assertion.assertion_id, assertion.transaction_id, assertion.field_name, assertion.producer_id,
+        run.origin, assertion.rule_lineage, assertion.value_text, run.run_id, assertion.created_commit_id AS commit_id
+        FROM assertions assertion JOIN derived_import_runs run ON run.commit_id = assertion.created_commit_id
+          AND run.producer_id = assertion.producer_id AND run.rule_lineage = assertion.rule_lineage
+        WHERE assertion.origin = 'derived'`,
+    },
+    {
+      name: "user_assertions",
+      select: `SELECT assertion.assertion_id, assertion.transaction_id, assertion.field_name, assertion.producer_id AS user_id,
+        assertion.value_text, assertion.created_commit_id AS commit_id
+        FROM assertions assertion WHERE assertion.origin = 'user'`,
+    },
     {
       name: "assertion_lifecycle_events",
       select: `SELECT transition.event_id, transition.assertion_id, transition.transaction_id, assertion.revision_id,
@@ -1195,6 +1229,7 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v6 RENAME TO canonical_commits");
     ensureV6SharedAssertionSpine(db);
     db.exec(SCHEMA_V6_APPEND);
+    rebuildCurrentTransactionFieldsForSharedAssertions(db);
     convertV6CompatibilityTables(db);
     if (injectMigrationFailure === "v5-v6-after-derived-schema") throw new Error("Injected v5-v6 migration failure after derived schema.");
     db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(6, currentUtcMicros());
@@ -1251,6 +1286,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     try {
       ensureV6SharedAssertionSpine(db);
       if (relationType(db, "assertion_lifecycle_events") !== "view") db.exec(SCHEMA_V6_APPEND);
+      rebuildCurrentTransactionFieldsForSharedAssertions(db);
       convertV6CompatibilityTables(db);
       db.exec("PRAGMA foreign_keys = ON");
       db.exec("COMMIT");
@@ -1261,16 +1297,20 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     }
     return;
   }
+  db.exec("PRAGMA foreign_keys = OFF");
   db.exec("BEGIN IMMEDIATE");
   try {
     db.exec(SCHEMA_V6);
     ensureV6SharedAssertionSpine(db);
+    rebuildCurrentTransactionFieldsForSharedAssertions(db);
     convertV6CompatibilityTables(db);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
+    db.exec("PRAGMA foreign_keys = ON");
   } catch (error) {
     db.exec("ROLLBACK");
+    db.exec("PRAGMA foreign_keys = ON");
     throw error;
   }
 }
@@ -1280,8 +1320,11 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   for (const table of requiredTables) {
     if (!relationType(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
   }
-  for (const table of ["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+  for (const table of ["derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
     if (relationType(db, table) !== "view") throw new Error(`Canonical schema v6 compatibility relation ${table} is not a read-only view.`);
+  }
+  for (const table of ["assertions", "assertion_transitions", "assertion_provenance", "current_transaction_fields"]) {
+    if (relationType(db, table) !== "table") throw new Error(`Canonical schema v6 shared authority relation ${table} is not a table.`);
   }
   const requiredColumns: Record<string, string[]> = {
     assertions: ["assertion_id", "transaction_id", "field_name", "target_kind", "origin", "producer_id", "rule_lineage", "revision_id", "value_text", "created_commit_id"],
@@ -1310,7 +1353,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     "idx_canonical_commits_sequence", "idx_capture_scopes_account_time", "idx_capture_scope_pages_proof",
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
     "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
-    "idx_derived_scope_coordinates_lineage", "idx_derived_assertions_lineage",
+    "idx_derived_scope_coordinates_lineage",
     "idx_current_transaction_fields_projection",
   ];
   for (const index of requiredIndexes) {
@@ -1326,12 +1369,24 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   if (!/origin\s+TEXT\s+NOT NULL\s+CHECK\s*\(origin\s+IN\s*\('source','derived','user'\)\)/i.test(tableSql("assertions"))) {
     throw new Error("Canonical schema v6 assertion origin taxonomy is missing.");
   }
+  if (!/derived_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(tableSql("current_transaction_fields")) || !/user_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(tableSql("current_transaction_fields"))) {
+    throw new Error("Canonical schema v6 current assertion references are not on the shared authority.");
+  }
   const transitionCheck = /event_kind\s+TEXT\s+NOT NULL\s+CHECK\s*\(event_kind\s+IN\s*\('observed','superseded','withdrawn'(?:,'restored')?\)\)/i;
   if (!transitionCheck.test(tableSql("assertion_transitions"))) {
     throw new Error("Canonical schema v6 shared assertion transition taxonomy is missing.");
   }
-  if (!["assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"].every((view) => /assertion_(?:transitions|provenance)/i.test(tableSql(view)))) {
-    throw new Error("Canonical schema v6 compatibility views are not backed by the shared assertion spine.");
+  const compatibilityAuthority: Record<string, RegExp> = {
+    derived_assertions: /FROM\s+assertions\b/i,
+    user_assertions: /FROM\s+assertions\b/i,
+    assertion_lifecycle_events: /FROM\s+assertion_transitions\b/i,
+    derived_assertion_lifecycle_events: /FROM\s+assertion_transitions\b/i,
+    user_assertion_lifecycle_events: /FROM\s+assertion_transitions\b/i,
+    derived_assertion_provenance: /FROM\s+assertion_provenance\b/i,
+    user_assertion_provenance: /FROM\s+assertion_provenance\b/i,
+  };
+  for (const [view, authority] of Object.entries(compatibilityAuthority)) {
+    if (!authority.test(tableSql(view))) throw new Error(`Canonical schema v6 compatibility view ${view} is not backed by the shared assertion spine.`);
   }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
@@ -1769,13 +1824,15 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       const coordinateId = uuidV7();
       db.prepare("INSERT INTO derived_scope_coordinates(coordinate_id, run_id, transaction_id, field_name, producer_id, origin, rule_lineage, output_state, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(coordinateId, runId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, coordinate.state, commitId);
       const existingCurrent = db.prepare(`SELECT f.origin, f.derived_assertion_id, f.user_assertion_id FROM current_transaction_fields f WHERE f.transaction_id = ? AND f.field_name = ?`).get(transactionId, coordinate.field) as Record<string, unknown> | undefined;
-      const conflicting = db.prepare(`SELECT da.assertion_id, da.producer_id, da.origin, da.rule_lineage FROM derived_assertions da
-        WHERE da.transaction_id = ? AND da.field_name = ? AND (da.producer_id <> ? OR da.origin <> ? OR da.rule_lineage <> ?)
-        LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin, input.ruleLineage) as Record<string, unknown> | undefined;
+      const conflicting = db.prepare(`SELECT assertion.assertion_id, assertion.producer_id, assertion.origin, assertion.rule_lineage FROM assertions assertion
+        WHERE assertion.origin = 'derived' AND assertion.transaction_id = ? AND assertion.field_name = ?
+          AND (assertion.producer_id <> ? OR assertion.origin <> 'derived' OR assertion.rule_lineage <> ?)
+        LIMIT 1`).get(transactionId, coordinate.field, input.producerId, input.ruleLineage) as Record<string, unknown> | undefined;
       if (conflicting) throw new Error("A different derived producer or origin cannot supersede the current lineage.");
-      const latest = db.prepare(`SELECT da.* FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
-        WHERE da.transaction_id = ? AND da.field_name = ? AND da.producer_id = ? AND da.origin = ? AND da.rule_lineage = ?
-        ORDER BY c.commit_sequence DESC, da.assertion_id DESC LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin, input.ruleLineage) as Record<string, unknown> | undefined;
+      const latest = db.prepare(`SELECT assertion.* FROM assertions assertion JOIN canonical_commits c ON c.commit_id = assertion.created_commit_id
+        WHERE assertion.origin = 'derived' AND assertion.transaction_id = ? AND assertion.field_name = ?
+          AND assertion.producer_id = ? AND assertion.rule_lineage = ?
+        ORDER BY c.commit_sequence DESC, assertion.assertion_id DESC LIMIT 1`).get(transactionId, coordinate.field, input.producerId, input.ruleLineage) as Record<string, unknown> | undefined;
       if (coordinate.state === "unsupported") {
         if (latest && latestDerivedLifecycle(db, blob(latest.assertion_id)) !== "withdrawn") {
           const withdrawnAssertion = blob(latest.assertion_id);
@@ -1793,7 +1850,6 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       } else {
         assertionId = uuidV7();
         if (latest) insertDerivedLifecycleEvent(db, { assertionId: blob(latest.assertion_id), transactionId, field: coordinate.field, runId, coordinateId, commitId, kind: "superseded" });
-        db.prepare("INSERT INTO derived_assertions(assertion_id, transaction_id, field_name, producer_id, origin, rule_lineage, value_text, run_id, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, value, runId, commitId);
         db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'derived', ?, ?, NULL, ?, ?)").run(assertionId, transactionId, coordinate.field, input.producerId, input.ruleLineage, value, commitId);
       }
       db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, ?, ?, ?)").run(assertionId, runId, coordinateId, commitId);
@@ -1856,8 +1912,11 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
       const commitId = uuidV7();
       const commitSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0) + 1;
       db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, 'user_assertion')").run(commitId, commitSequence, recordedAtUtcUs(clock()), "user/local");
-      const prior = db.prepare(`SELECT ua.* FROM user_assertions ua JOIN canonical_commits c ON c.commit_id = ua.commit_id
-        WHERE ua.transaction_id = ? AND ua.field_name = ? AND ua.user_id = ? ORDER BY c.commit_sequence DESC, ua.assertion_id DESC LIMIT 1`).get(transactionId, field, userId) as Record<string, unknown> | undefined;
+      const prior = db.prepare(`SELECT assertion.assertion_id, assertion.transaction_id, assertion.field_name,
+          assertion.producer_id AS user_id, assertion.value_text, assertion.created_commit_id AS commit_id
+        FROM assertions assertion JOIN canonical_commits c ON c.commit_id = assertion.created_commit_id
+        WHERE assertion.origin = 'user' AND assertion.transaction_id = ? AND assertion.field_name = ? AND assertion.producer_id = ?
+        ORDER BY c.commit_sequence DESC, assertion.assertion_id DESC LIMIT 1`).get(transactionId, field, userId) as Record<string, unknown> | undefined;
       let assertionId: CanonicalId;
       const withdrawn = input.value === null;
       if (withdrawn) {
@@ -1873,7 +1932,6 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
           if (prior) {
             db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'superseded')").run(uuidV7(), blob(prior.assertion_id), transactionId, field, userId, commitId);
           }
-          db.prepare("INSERT INTO user_assertions(assertion_id, transaction_id, field_name, user_id, value_text, commit_id) VALUES (?, ?, ?, ?, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
           db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, ?, 'transaction', 'user', ?, 'user/local', NULL, ?, ?)").run(assertionId, transactionId, field, userId, value, commitId);
           db.prepare("INSERT INTO assertion_transitions(event_id, assertion_id, transaction_id, field_name, capture_id, scope_id, run_id, coordinate_id, user_id, commit_id, event_kind) VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 'observed')").run(uuidV7(), assertionId, transactionId, field, userId, commitId);
         }
@@ -2014,12 +2072,18 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         const lifecycleEvents = db.prepare(`SELECT e.event_id, e.event_kind, c.commit_sequence, cs.scope_id, cs.completeness, cs.absence_authority, cs.contract_fingerprint, cs.page_count
           FROM assertion_transitions e JOIN canonical_commits c ON c.commit_id = e.commit_id
           LEFT JOIN capture_scopes cs ON cs.scope_id = e.scope_id WHERE e.assertion_id = ? ORDER BY c.commit_sequence, e.event_id`).all(assertionId) as Record<string, unknown>[];
-        const derivedRows = db.prepare(`SELECT da.assertion_id, da.field_name, da.producer_id, da.origin, da.rule_lineage, da.value_text, da.run_id, c.commit_sequence
-          FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id
-          WHERE da.transaction_id = ? ORDER BY c.commit_sequence, da.assertion_id`).all(transactionId) as Record<string, unknown>[];
-        const userRows = db.prepare(`SELECT ua.assertion_id, ua.field_name, ua.user_id, ua.value_text, c.commit_sequence
-          FROM user_assertions ua JOIN canonical_commits c ON c.commit_id = ua.commit_id
-          WHERE ua.transaction_id = ? ORDER BY c.commit_sequence, ua.assertion_id`).all(transactionId) as Record<string, unknown>[];
+        const derivedRows = db.prepare(`SELECT assertion.assertion_id, assertion.field_name, assertion.producer_id, assertion.origin,
+            assertion.rule_lineage, assertion.value_text, run.run_id, c.commit_sequence
+          FROM assertions assertion JOIN derived_import_runs run ON run.commit_id = assertion.created_commit_id
+            AND run.producer_id = assertion.producer_id AND run.rule_lineage = assertion.rule_lineage
+          JOIN canonical_commits c ON c.commit_id = assertion.created_commit_id
+          WHERE assertion.transaction_id = ? AND assertion.origin = 'derived'
+          ORDER BY c.commit_sequence, assertion.assertion_id`).all(transactionId) as Record<string, unknown>[];
+        const userRows = db.prepare(`SELECT assertion.assertion_id, assertion.field_name, assertion.producer_id AS user_id,
+            assertion.value_text, c.commit_sequence
+          FROM assertions assertion JOIN canonical_commits c ON c.commit_id = assertion.created_commit_id
+          WHERE assertion.transaction_id = ? AND assertion.origin = 'user'
+          ORDER BY c.commit_sequence, assertion.assertion_id`).all(transactionId) as Record<string, unknown>[];
         const revision = transactionRevisionFromRow(addSelectedFields(db, row, Number(row.commit_sequence)));
         return {
           transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -2,6 +2,12 @@ import { createHash, randomBytes } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import {
+  configureCanonicalRuntime,
+  verifyCanonicalRuntime,
+  withCanonicalWriterQueue,
+  type CanonicalRuntimeOptions,
+} from "./canonical-runtime.ts";
 
 export const CATHAY_INTEGRATION_NAMESPACE = "cathay";
 export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
@@ -9,7 +15,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CATHAY_DERIVED_ORIGIN = "derived/cathay/domestic-deposit/v1" as const;
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 6;
+export const CANONICAL_SCHEMA_VERSION = 7;
 export const CATHAY_POSTING_MAPPING = {
   contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   postingStatus: "posted",
@@ -869,6 +875,54 @@ const SCHEMA_V6_BASE = SCHEMA_V5
   .replace("CREATE INDEX IF NOT EXISTS idx_assertion_provenance_record ON assertion_provenance(source_record_id, assertion_id, commit_id);", "");
 const SCHEMA_V6 = `${SCHEMA_V6_BASE.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
 
+/** v7 keeps the public Current query contract while moving its physical rows
+ * behind an immutable generation boundary. Compatibility tables are mirrored
+ * inside the same write transaction for older #129/#130 callers; these rows
+ * are never consulted by the v7 query adapter. */
+const SCHEMA_V7_APPEND = `
+CREATE TABLE IF NOT EXISTS projection_generations (
+  generation_id INTEGER PRIMARY KEY CHECK(generation_id > 0),
+  status TEXT NOT NULL CHECK(status IN ('building','validated','active','retired')),
+  build_cutoff_commit_sequence INTEGER NOT NULL CHECK(build_cutoff_commit_sequence >= 0),
+  rule_version TEXT NOT NULL,
+  created_commit_id BLOB REFERENCES canonical_commits(commit_id),
+  validated_commit_id BLOB REFERENCES canonical_commits(commit_id),
+  switched_commit_id BLOB REFERENCES canonical_commits(commit_id),
+  UNIQUE(generation_id, status)
+);
+CREATE TABLE IF NOT EXISTS active_projection_generation (
+  singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+  generation_id INTEGER NOT NULL UNIQUE REFERENCES projection_generations(generation_id),
+  switched_commit_id BLOB REFERENCES canonical_commits(commit_id)
+);
+CREATE TABLE IF NOT EXISTS projection_generation_transactions (
+  generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(generation_id, transaction_id),
+  UNIQUE(generation_id, revision_id)
+);
+CREATE TABLE IF NOT EXISTS projection_generation_transaction_fields (
+  generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  field_name TEXT NOT NULL CHECK(field_name IN ('display_name','note')),
+  value_text TEXT NOT NULL,
+  origin TEXT NOT NULL CHECK(origin IN ('derived','user')),
+  derived_assertion_id BLOB REFERENCES assertions(assertion_id),
+  user_assertion_id BLOB REFERENCES assertions(assertion_id),
+  projection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(generation_id, transaction_id, field_name),
+  CHECK((origin = 'derived' AND derived_assertion_id IS NOT NULL AND user_assertion_id IS NULL)
+    OR (origin = 'user' AND user_assertion_id IS NOT NULL AND derived_assertion_id IS NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_active ON projection_generation_transactions(generation_id, transaction_id, revision_id);
+CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_revision ON projection_generation_transactions(generation_id, revision_id, projection_commit_id);
+CREATE INDEX IF NOT EXISTS idx_projection_generation_fields_active ON projection_generation_transaction_fields(generation_id, transaction_id, field_name, projection_commit_id);
+CREATE INDEX IF NOT EXISTS idx_projection_generations_status ON projection_generations(status, build_cutoff_commit_sequence, generation_id);
+`;
+
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
 // Keeping this target schema separate prevents an older database from being created at a
 // partially upgraded shape before its migration transaction reaches the next version.
@@ -981,8 +1035,18 @@ function migrateV3ToV4(db: DatabaseSync): void {
     throw error;
   }
 }
-export type CanonicalMigrationFailureInjection = "v4-v5-after-record-copy" | "v5-v6-after-derived-schema";
-export type CanonicalDatabaseOptions = { readOnly?: boolean; injectMigrationFailure?: CanonicalMigrationFailureInjection };
+export type CanonicalMigrationFailureInjection =
+  | "v4-v5-after-record-copy"
+  | "v5-v6-after-derived-schema"
+  | "v6-v7-after-generation-creation"
+  | "v6-v7-after-generation-copy"
+  | "v6-v7-after-pointer"
+  | "v6-v7-after-validation";
+export type CanonicalDatabaseOptions = {
+  readOnly?: boolean;
+  injectMigrationFailure?: CanonicalMigrationFailureInjection;
+  runtime?: CanonicalRuntimeOptions;
+};
 
 function ensureV6SharedAssertionSpine(db: DatabaseSync): void {
   const provenanceSql = String((db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'assertion_provenance'").get() as { sql?: unknown } | undefined)?.sql ?? "");
@@ -1300,6 +1364,76 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     throw error;
   }
 }
+
+function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigrationFailureInjection, transactionAlreadyOpen = false): void {
+  if (!transactionAlreadyOpen) {
+    db.exec("PRAGMA foreign_keys = OFF");
+    db.exec("BEGIN IMMEDIATE");
+  }
+  try {
+    // The v6 commit-kind constraint predates projection switches. Rebuild the
+    // small root table while all children are protected by this transaction.
+    db.exec(`CREATE TABLE canonical_commits_v7 (
+      commit_id BLOB PRIMARY KEY CHECK(length(commit_id) = 16), commit_sequence INTEGER NOT NULL UNIQUE,
+      recorded_at_utc_us INTEGER NOT NULL, authority_route TEXT NOT NULL,
+      commit_kind TEXT NOT NULL CHECK(commit_kind IN ('source_capture','derived_import','user_assertion','projection_rebuild'))
+    )`);
+    db.exec("INSERT INTO canonical_commits_v7 SELECT * FROM canonical_commits");
+    db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v7 RENAME TO canonical_commits");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
+    db.exec(SCHEMA_V7_APPEND);
+    if (injectMigrationFailure === "v6-v7-after-generation-creation") throw new Error("Injected v6-v7 migration failure after generation creation.");
+
+    const latest = db.prepare("SELECT commit_id, commit_sequence FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as { commit_id?: unknown; commit_sequence?: number } | undefined;
+    const latestCommit = latest?.commit_id ? blob(latest.commit_id) : undefined;
+    let latestSequence = Number(latest?.commit_sequence ?? 0);
+    const generationExists = db.prepare("SELECT 1 FROM projection_generations WHERE generation_id = 1").get();
+    if (!generationExists) {
+      db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id)
+      VALUES (1, 'active', ?, 'canonical/projection/v1', ?)`).run(latestSequence, latestCommit ?? null);
+      db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
+        SELECT 1, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run();
+      db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+        SELECT 1, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run();
+    }
+    if (injectMigrationFailure === "v6-v7-after-generation-copy") throw new Error("Injected v6-v7 migration failure after generation copy.");
+    db.prepare(`INSERT INTO active_projection_generation(singleton_id, generation_id, switched_commit_id)
+      VALUES (1, 1, ?) ON CONFLICT(singleton_id) DO UPDATE SET generation_id = excluded.generation_id, switched_commit_id = excluded.switched_commit_id`).run(latestCommit ?? null);
+    if (latestCommit) db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(latestCommit);
+    if (injectMigrationFailure === "v6-v7-after-pointer") throw new Error("Injected v6-v7 migration failure after active pointer.");
+    db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (7, ?)").run(currentUtcMicros());
+    db.exec("PRAGMA user_version = 7");
+    if (!transactionAlreadyOpen) {
+      db.exec("COMMIT");
+      db.exec("PRAGMA foreign_keys = ON");
+    }
+  } catch (error) {
+    if (!transactionAlreadyOpen) {
+      db.exec("ROLLBACK");
+      db.exec("PRAGMA foreign_keys = ON");
+    }
+    throw error;
+  }
+}
+
+function ensureV7ProjectionSchema(db: DatabaseSync): void {
+  db.exec(SCHEMA_V7_APPEND);
+  const pointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
+  if (!pointer) throw new Error("Canonical v7 active projection pointer is missing.");
+  const generationId = Number(pointer.generation_id ?? 0);
+  const generation = db.prepare("SELECT generation_id, status FROM projection_generations WHERE generation_id = ?").get(generationId) as { generation_id?: number; status?: string } | undefined;
+  if (!generation || generation.status !== "active") throw new Error("Canonical v7 active projection generation is not active.");
+  const activeCount = Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generations WHERE status = 'active'").get() as { count?: number }).count ?? 0);
+  if (activeCount !== 1) throw new Error("Canonical v7 active projection generation is ambiguous.");
+  const mixedRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
+    WHERE rows.generation_id = ? AND (rows.revision_id NOT IN (SELECT revision_id FROM transaction_revisions)
+      OR rows.transaction_id NOT IN (SELECT transaction_id FROM financial_transactions))`).get(generationId) as { count?: number }).count ?? 0);
+  if (mixedRows !== 0) throw new Error("Canonical v7 active projection contains mixed or dangling rows.");
+  const badArithmetic = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
+    JOIN transaction_revisions revision ON revision.revision_id = rows.revision_id
+    WHERE revision.amount_coefficient NOT GLOB '-[0-9]*' AND revision.amount_coefficient NOT GLOB '[0-9]*'`).get() as { count?: number }).count ?? 0);
+  if (badArithmetic !== 0) throw new Error("Canonical v7 projection contains non-exact arithmetic values.");
+}
 function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOptions = {}): void {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
   const version = Number(row.user_version ?? 0);
@@ -1311,6 +1445,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
     migrateV5ToV6(db, options.injectMigrationFailure);
+    migrateV6ToV7(db, options.injectMigrationFailure);
     return;
   }
   if (version === 2) {
@@ -1318,21 +1453,29 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
     migrateV5ToV6(db, options.injectMigrationFailure);
+    migrateV6ToV7(db, options.injectMigrationFailure);
     return;
   }
   if (version === 3) {
     migrateV3ToV4(db);
     migrateV4ToV5(db, options.injectMigrationFailure);
     migrateV5ToV6(db, options.injectMigrationFailure);
+    migrateV6ToV7(db, options.injectMigrationFailure);
     return;
   }
   if (version === 4) {
     migrateV4ToV5(db, options.injectMigrationFailure);
     migrateV5ToV6(db, options.injectMigrationFailure);
+    migrateV6ToV7(db, options.injectMigrationFailure);
     return;
   }
   if (version === 5) {
     migrateV5ToV6(db, options.injectMigrationFailure);
+    migrateV6ToV7(db, options.injectMigrationFailure);
+    return;
+  }
+  if (version === 6) {
+    migrateV6ToV7(db, options.injectMigrationFailure);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -1347,6 +1490,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
       rebuildCurrentTransactionFieldsForSharedAssertions(db);
       convertV6CompatibilityTables(db);
       ensureV6ProjectionOriginConstraints(db);
+      ensureV7ProjectionSchema(db);
       db.exec("PRAGMA foreign_keys = ON");
       db.exec("COMMIT");
     } catch (error) {
@@ -1364,10 +1508,10 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     rebuildCurrentTransactionFieldsForSharedAssertions(db);
     convertV6CompatibilityTables(db);
     ensureV6ProjectionOriginConstraints(db);
-    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
-    db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
+    migrateV6ToV7(db, options.injectMigrationFailure, true);
     db.exec("COMMIT");
     db.exec("PRAGMA foreign_keys = ON");
+    return;
   } catch (error) {
     db.exec("ROLLBACK");
     db.exec("PRAGMA foreign_keys = ON");
@@ -1376,15 +1520,15 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  const requiredTables = ["capture_scopes", "capture_scope_pages", "source_assertions", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "source_assertions", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields", "projection_generations", "active_projection_generation", "projection_generation_transactions", "projection_generation_transaction_fields"];
   for (const table of requiredTables) {
-    if (!relationType(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
+    if (!relationType(db, table)) throw new Error(`Canonical schema v7 table ${table} is missing.`);
   }
   for (const table of ["source_assertions", "derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
-    if (relationType(db, table) !== "view") throw new Error(`Canonical schema v6 compatibility relation ${table} is not a read-only view.`);
+    if (relationType(db, table) !== "view") throw new Error(`Canonical schema v7 compatibility relation ${table} is not a read-only view.`);
   }
   for (const table of ["assertions", "assertion_transitions", "assertion_provenance", "current_transaction_fields"]) {
-    if (relationType(db, table) !== "table") throw new Error(`Canonical schema v6 shared authority relation ${table} is not a table.`);
+    if (relationType(db, table) !== "table") throw new Error(`Canonical schema v7 shared authority relation ${table} is not a table.`);
   }
   const requiredColumns: Record<string, string[]> = {
     assertions: ["assertion_id", "transaction_id", "field_name", "target_kind", "origin", "producer_id", "rule_lineage", "revision_id", "value_text", "created_commit_id"],
@@ -1405,6 +1549,10 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     source_record_scopes: ["source_record_id", "scope_id", "capture_id", "account_id", "sequence_lexeme"],
     transaction_revisions: ["economic_status", "administrative_state", "semantic_rule_version"],
     current_transactions: ["projection_commit_id", "revision_commit_id"],
+    projection_generations: ["generation_id", "status", "build_cutoff_commit_sequence", "rule_version", "created_commit_id", "validated_commit_id", "switched_commit_id"],
+    active_projection_generation: ["singleton_id", "generation_id", "switched_commit_id"],
+    projection_generation_transactions: ["generation_id", "transaction_id", "revision_id", "projection_commit_id", "revision_commit_id"],
+    projection_generation_transaction_fields: ["generation_id", "transaction_id", "field_name", "value_text", "origin", "derived_assertion_id", "user_assertion_id", "projection_commit_id"],
   };
   for (const [table, columns] of Object.entries(requiredColumns)) {
     const actual = new Set((db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>).map((column) => column.name));
@@ -1415,27 +1563,27 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
     "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
     "idx_derived_scope_coordinates_lineage",
-    "idx_current_transaction_fields_projection",
+    "idx_current_transaction_fields_projection", "idx_projection_generation_transactions_active", "idx_projection_generation_transactions_revision", "idx_projection_generation_fields_active", "idx_projection_generations_status",
   ];
   for (const index of requiredIndexes) {
     if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v6 index ${index} is missing.`);
   }
   const tableSql = (table: string): string => String((db.prepare("SELECT sql FROM sqlite_master WHERE (type = 'table' OR type = 'view') AND name = ?").get(table) as { sql?: unknown } | undefined)?.sql ?? "");
   if (!/FOREIGN KEY\s*\(source_record_id,\s*capture_id\)/i.test(tableSql("source_record_scopes")) || !/capture_scopes/i.test(tableSql("source_record_scopes"))) {
-    throw new Error("Canonical schema v6 source-record scope constraints are missing.");
+    throw new Error("Canonical schema v7 source-record scope constraints are missing.");
   }
   if (!/economic_status.*canceled.*refund.*reversal/i.test(tableSql("transaction_revisions")) || !/administrative_state.*deleted.*purged/i.test(tableSql("transaction_revisions"))) {
-    throw new Error("Canonical schema v6 semantic constraints are missing.");
+    throw new Error("Canonical schema v7 semantic constraints are missing.");
   }
   if (!/origin\s+TEXT\s+NOT NULL\s+CHECK\s*\(origin\s+IN\s*\('source','derived','user'\)\)/i.test(tableSql("assertions"))) {
-    throw new Error("Canonical schema v6 assertion origin taxonomy is missing.");
+    throw new Error("Canonical schema v7 assertion origin taxonomy is missing.");
   }
   if (!/derived_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(tableSql("current_transaction_fields")) || !/user_assertion_id\s+BLOB\s+REFERENCES\s+assertions\s*\(/i.test(tableSql("current_transaction_fields"))) {
-    throw new Error("Canonical schema v6 current assertion references are not on the shared authority.");
+    throw new Error("Canonical schema v7 current assertion references are not on the shared authority.");
   }
   const transitionCheck = /event_kind\s+TEXT\s+NOT NULL\s+CHECK\s*\(event_kind\s+IN\s*\('observed','superseded','withdrawn'(?:,'restored')?\)\)/i;
   if (!transitionCheck.test(tableSql("assertion_transitions"))) {
-    throw new Error("Canonical schema v6 shared assertion transition taxonomy is missing.");
+    throw new Error("Canonical schema v7 shared assertion transition taxonomy is missing.");
   }
   const compatibilityAuthority: Record<string, RegExp> = {
     source_assertions: /FROM\s+assertions\b/i,
@@ -1480,6 +1628,20 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.revision_commit_id
       AND current_row.commit_id = current_row.projection_commit_id`).get() as { count?: number }).count ?? 0);
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
+  const activePointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
+  if (!activePointer) throw new Error("Canonical v7 active projection pointer is missing.");
+  const activeGenerationId = Number(activePointer.generation_id ?? 0);
+  const activeGeneration = db.prepare("SELECT status, build_cutoff_commit_sequence FROM projection_generations WHERE generation_id = ?").get(activeGenerationId) as { status?: string; build_cutoff_commit_sequence?: number } | undefined;
+  if (!activeGeneration || activeGeneration.status !== "active") throw new Error("Canonical v7 active projection is not readable.");
+  if (activePointer.switched_commit_id !== null && activePointer.switched_commit_id !== undefined
+    && !db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(activePointer.switched_commit_id))) throw new Error("Canonical v7 active projection pointer references no commit.");
+  const activeRows = Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transactions WHERE generation_id = ?").get(activeGenerationId) as { count?: number }).count ?? 0);
+  const activeDangling = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions projected
+    LEFT JOIN financial_transactions transaction_row ON transaction_row.transaction_id = projected.transaction_id
+    LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    WHERE projected.generation_id = ? AND (transaction_row.transaction_id IS NULL OR revision.revision_id IS NULL OR revision.transaction_id <> projected.transaction_id)`).get(activeGenerationId) as { count?: number }).count ?? 0);
+  if (activeDangling !== 0) throw new Error("Canonical v7 active projection has dangling or mixed-generation rows.");
+  if (activeRows !== currentCount) throw new Error("Canonical v7 active projection does not match its compatibility mirror.");
 }
 
 export function openCanonicalDatabase(ledgerDir: string, options: CanonicalDatabaseOptions = {}): DatabaseSync {
@@ -1488,13 +1650,13 @@ export function openCanonicalDatabase(ledgerDir: string, options: CanonicalDatab
   if (!options.readOnly) mkdirSync(ledgerDir, { recursive: true });
   const db = new DatabaseSync(path, options.readOnly ? { readOnly: true } : {});
   try {
-    db.exec("PRAGMA foreign_keys = ON");
-    db.exec("PRAGMA busy_timeout = 30000");
-    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); db.exec("PRAGMA synchronous = FULL"); applySchemaMigration(db, options); }
+    configureCanonicalRuntime(db, { readOnly: options.readOnly, busyTimeoutMs: options.runtime?.busyTimeoutMs ?? 30_000 });
+    if (!options.readOnly) { applySchemaMigration(db, options); configureCanonicalRuntime(db, { busyTimeoutMs: options.runtime?.busyTimeoutMs ?? 30_000 }); verifyCanonicalRuntime(db); }
     else {
       const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
       if (Number(row.user_version ?? 0) !== CANONICAL_SCHEMA_VERSION) throw new Error("Canonical SQLite schema is missing or unsupported for read-only access.");
       validateReadOnlyDatabase(db);
+      verifyCanonicalRuntime(db, { readOnly: true });
     }
     return db;
   } catch (error) { db.close(); throw error; }
@@ -1546,6 +1708,25 @@ export type CathayCommitTransactionResult = { transactionId: string; revisionId:
 export type CathayCanonicalCommitScopeResult = { scopeId: string; accountId: string; accountNo: string; transactions: CathayCommitTransactionResult[] };
 export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountIds: string[]; transactions: CathayCommitTransactionResult[]; scopes: CathayCanonicalCommitScopeResult[] };
 
+export type CanonicalProjectionRebuildFailureInjection =
+  | "creation" | "population" | "validation" | "pre-switch"
+  | "after-generation-creation" | "after-generation-population" | "after-validation";
+export type CanonicalProjectionKnowledgePoint = { kind: "commit-sequence"; commitSequence: number };
+export type CanonicalProjectionRebuildOptions = CanonicalRuntimeOptions & {
+  cutoff?: CanonicalProjectionKnowledgePoint;
+  injectFailure?: CanonicalProjectionRebuildFailureInjection;
+  clock?: CanonicalAdmissionClock;
+};
+export type CanonicalProjectionRebuildResult = {
+  status: "switched";
+  previousGeneration: number;
+  generation: number;
+  cutoffCommitSequence: number;
+  commitSequence: number;
+  transactionCount: number;
+  fieldCount: number;
+};
+
 function dbRow<T extends Record<string, unknown>>(value: unknown): T { return value as T; }
 function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow): boolean {
   return row.amount_coefficient === detail.amount.coefficient.toString()
@@ -1567,7 +1748,7 @@ function currentUtcMicros(): number {
 }
 
 export type CanonicalAdmissionClock = () => string;
-export type CathayCanonicalCommitOptions = { clock?: CanonicalAdmissionClock };
+export type CathayCanonicalCommitOptions = { clock?: CanonicalAdmissionClock; runtime?: CanonicalRuntimeOptions };
 
 type LifecycleEventKind = CathayCanonicalLifecycleEvent["kind"];
 function insertLifecycleEvent(
@@ -1587,8 +1768,9 @@ function commitCathayDomesticDepositSyncOnce(
   ledgerDir: string,
   input: ValidatedCathaySync,
   admissionClock: CanonicalAdmissionClock,
+  runtime?: CanonicalRuntimeOptions,
 ): CathayCanonicalCommitResult {
-  const db = openCanonicalDatabase(ledgerDir);
+  const db = openCanonicalDatabase(ledgerDir, { runtime });
   let inTransaction = false;
   try {
     db.exec("BEGIN IMMEDIATE");
@@ -1709,6 +1891,7 @@ function commitCathayDomesticDepositSyncOnce(
         scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, input.stream, scope.startDate, scope.endDate, input.syncState.cursor ?? null, captureId, commitId);
       scopeResults.push({ scopeId: idToString(scopeId), accountId: idToString(accountId), accountNo: scope.accountNo, transactions: scopeTransactions });
     }
+    syncActiveProjectionFromCompatibility(db, commitId);
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
@@ -1719,28 +1902,104 @@ function commitCathayDomesticDepositSyncOnce(
   } finally { db.close(); }
 }
 
-const writerQueues = new Map<string, Promise<void>>();
-async function withCanonicalWriter<T>(ledgerDir: string, operation: () => T): Promise<T> {
-  const key = canonicalSqlitePath(ledgerDir);
-  const previous = writerQueues.get(key) ?? Promise.resolve();
-  let release!: () => void;
-  const turn = new Promise<void>((resolve) => { release = resolve; });
-  const queued = previous.then(() => turn);
-  writerQueues.set(key, queued);
-  await previous;
+async function withCanonicalWriter<T>(ledgerDir: string, operation: () => T, runtime?: CanonicalRuntimeOptions): Promise<T> {
+  return withCanonicalWriterQueue(canonicalSqlitePath(ledgerDir), operation, runtime);
+}
+
+function rebuildFailure(stage: CanonicalProjectionRebuildFailureInjection | undefined, expected: CanonicalProjectionRebuildFailureInjection[]): void {
+  if (stage !== undefined && expected.includes(stage)) throw new Error(`Injected projection rebuild failure at ${stage}.`);
+}
+
+function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: CanonicalProjectionRebuildOptions): CanonicalProjectionRebuildResult {
+  const db = openCanonicalDatabase(ledgerDir, { runtime: options });
+  let inTransaction = false;
   try {
-    for (let attempt = 0; ; attempt += 1) {
-      try { return operation(); }
-      catch (error) {
-        if (attempt >= 2 || !/busy|locked/i.test(String(error))) throw error;
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    db.exec("BEGIN IMMEDIATE");
+    inTransaction = true;
+    const latest = db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number };
+    const currentKnowledgePoint = Number(latest.max_sequence ?? 0);
+    const cutoff = options.cutoff?.commitSequence ?? currentKnowledgePoint;
+    if (!Number.isSafeInteger(cutoff) || cutoff < 0 || cutoff > currentKnowledgePoint) throw new Error("Projection rebuild cutoff must be a retained Canonical Knowledge Point.");
+    const active = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
+    if (!active) throw new Error("Projection rebuild requires an active generation.");
+    const previousGeneration = Number(active.generation_id);
+    const generation = Number((db.prepare("SELECT COALESCE(MAX(generation_id), 0) AS generation_id FROM projection_generations").get() as { generation_id?: number }).generation_id ?? 0) + 1;
+    const commitId = uuidV7();
+    const commitSequence = currentKnowledgePoint + 1;
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, 'canonical/projection/v1', 'projection_rebuild')").run(commitId, commitSequence, recordedAtUtcUs((options.clock ?? (() => new Date().toISOString()))()));
+    db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id)
+      VALUES (?, 'building', ?, 'canonical/projection/v1', ?)`).run(generation, cutoff, commitId);
+    rebuildFailure(options.injectFailure, ["creation", "after-generation-creation"]);
+    db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
+      SELECT ?, t.transaction_id, revision.revision_id, ?, revision.commit_id
+      FROM financial_transactions t JOIN transaction_revisions revision ON revision.transaction_id = t.transaction_id
+      JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
+      JOIN assertions source_assertion ON source_assertion.revision_id = revision.revision_id AND source_assertion.origin = 'source'
+      WHERE revision_commit.commit_sequence <= ?
+        AND NOT EXISTS (SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
+          WHERE newer.transaction_id = revision.transaction_id AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > revision_commit.commit_sequence)
+        AND COALESCE((SELECT transition.event_kind FROM assertion_transitions transition JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
+          WHERE transition.assertion_id = source_assertion.assertion_id AND transition_commit.commit_sequence <= ?
+          ORDER BY transition_commit.commit_sequence DESC, transition.event_id DESC LIMIT 1), 'observed') <> 'withdrawn'`).run(generation, commitId, cutoff, cutoff, cutoff);
+    const insertField = db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
+    const generationTransactions = db.prepare("SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ?").all(generation) as Array<Record<string, unknown>>;
+    let fieldCount = 0;
+    for (const transaction of generationTransactions) {
+      for (const field of ["display_name", "note"] as const) {
+        const selectAsOf = (origin: "user" | "derived") => db.prepare(`SELECT a.assertion_id, a.value_text FROM assertions a
+          JOIN assertion_transitions e ON e.assertion_id = a.assertion_id JOIN canonical_commits c ON c.commit_id = e.commit_id
+          WHERE a.transaction_id = ? AND a.field_name = ? AND a.origin = ? AND c.commit_sequence <= ? AND e.event_kind NOT IN ('withdrawn','superseded')
+            AND NOT EXISTS (SELECT 1 FROM assertion_transitions newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
+              WHERE newer.assertion_id = e.assertion_id AND nc.commit_sequence <= ?
+                AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
+          ORDER BY c.commit_sequence DESC, e.rowid DESC LIMIT 1`).get(blob(transaction.transaction_id), field, origin, cutoff, cutoff) as { assertion_id?: unknown; value_text?: unknown } | undefined;
+        const selected = selectAsOf("user") ?? selectAsOf("derived");
+        if (!selected) continue;
+        const assertion = blob(selected.assertion_id);
+        insertField.run(generation, blob(transaction.transaction_id), field, String(selected.value_text), (selectAsOf("user") ? "user" : "derived"), (selectAsOf("user") ? null : assertion), (selectAsOf("user") ? assertion : null), commitId);
+        fieldCount += 1;
       }
     }
-  } finally {
-    release();
-    if (writerQueues.get(key) === queued) writerQueues.delete(key);
-  }
+    rebuildFailure(options.injectFailure, ["population", "after-generation-population"]);
+    const dangling = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions projected
+      LEFT JOIN financial_transactions transaction_row ON transaction_row.transaction_id = projected.transaction_id
+      LEFT JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+      WHERE projected.generation_id = ? AND (transaction_row.transaction_id IS NULL OR revision.revision_id IS NULL OR revision.transaction_id <> projected.transaction_id)`).get(generation) as { count?: number }).count ?? 0);
+    const arithmetic = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions projected
+      JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+      WHERE projected.generation_id = ? AND (revision.amount_coefficient NOT GLOB '[0-9]*' AND revision.amount_coefficient NOT GLOB '-[0-9]*')`).get(generation) as { count?: number }).count ?? 0);
+    if (dangling !== 0 || arithmetic !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
+    const duplicate = Number((db.prepare(`SELECT COUNT(*) AS count FROM (SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ? GROUP BY transaction_id HAVING COUNT(*) <> 1)`).get(generation) as { count?: number }).count ?? 0);
+    if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
+    rebuildFailure(options.injectFailure, ["validation", "after-validation"]);
+    db.prepare("UPDATE projection_generations SET status = 'validated', validated_commit_id = ? WHERE generation_id = ?").run(commitId, generation);
+    rebuildFailure(options.injectFailure, ["pre-switch"]);
+    db.prepare("UPDATE projection_generations SET status = 'retired' WHERE status = 'active'").run();
+    db.prepare("UPDATE projection_generations SET status = 'active', switched_commit_id = ? WHERE generation_id = ?").run(commitId, generation);
+    db.prepare("UPDATE active_projection_generation SET generation_id = ?, switched_commit_id = ? WHERE singleton_id = 1").run(generation, commitId);
+    db.prepare("DELETE FROM current_transactions").run();
+    db.prepare(`INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id)
+      SELECT transaction_id, revision_id, ?, projection_commit_id, revision_commit_id FROM projection_generation_transactions WHERE generation_id = ?`).run(commitId, generation);
+    db.prepare("DELETE FROM current_transaction_fields").run();
+    db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+      SELECT transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, ? FROM projection_generation_transaction_fields WHERE generation_id = ?`).run(commitId, generation);
+    db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
+    db.exec("COMMIT");
+    inTransaction = false;
+    return { status: "switched", previousGeneration, generation, cutoffCommitSequence: cutoff, commitSequence, transactionCount: Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transactions WHERE generation_id = ?").get(generation) as { count?: number }).count ?? 0), fieldCount };
+  } catch (error) {
+    if (inTransaction) db.exec("ROLLBACK");
+    throw error;
+  } finally { db.close(); }
 }
+
+export function rebuildCathayCanonicalProjection(ledgerDir: string, options: CanonicalProjectionRebuildOptions = {}): Promise<CanonicalProjectionRebuildResult> {
+  return withCanonicalWriterQueue(canonicalSqlitePath(ledgerDir), () => rebuildCathayCanonicalProjectionOnce(ledgerDir, options), options);
+}
+
+/** Generic name for callers that do not depend on the Cathay adapter. */
+export const rebuildCanonicalProjection = rebuildCathayCanonicalProjection;
 
 export function commitCathayDomesticDeposit(
   ledgerDir: string,
@@ -1769,7 +2028,7 @@ export function commitCathayDomesticDeposit(
       absenceAuthority: input.absenceAuthority,
     }],
   });
-  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, sync, admissionClock));
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, sync, admissionClock, options.runtime), options.runtime);
 }
 
 export function commitCathayDomesticDepositSync(
@@ -1779,7 +2038,7 @@ export function commitCathayDomesticDepositSync(
 ): Promise<CathayCanonicalCommitResult> {
   const validated = validateSyncInput(input);
   const admissionClock = options.clock ?? (() => new Date().toISOString());
-  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, validated, admissionClock));
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, validated, admissionClock, options.runtime), options.runtime);
 }
 
 function importCoordinates(input: CathayDerivedImportRunInput): CathayDerivedImportCoordinate[] {
@@ -1906,8 +2165,27 @@ function refreshCurrentFieldAfterWithdrawal(db: DatabaseSync, transactionId: Can
   else db.prepare("DELETE FROM current_transaction_fields WHERE transaction_id = ? AND field_name = ?").run(transactionId, field);
 }
 
-function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock): { runId: string; commitSequence: number; assertionIds: string[] } {
-  const db = openCanonicalDatabase(ledgerDir);
+/** Keep the v6 compatibility rows and the active v7 generation in lockstep.
+ * This helper is called before every routine commit's COMMIT, so no reader can
+ * observe evidence from one commit with projection rows from another. */
+function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommitId: CanonicalId): void {
+  const pointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
+  if (!pointer) throw new Error("Canonical active projection pointer is missing during routine write.");
+  const generationId = Number(pointer.generation_id);
+  const generation = db.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(generationId) as { status?: string } | undefined;
+  if (!generation || generation.status !== "active") throw new Error("Canonical active projection generation is not writable.");
+  db.prepare("DELETE FROM projection_generation_transaction_fields WHERE generation_id = ?").run(generationId);
+  db.prepare("DELETE FROM projection_generation_transactions WHERE generation_id = ?").run(generationId);
+  db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
+    SELECT ?, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run(generationId);
+  db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
+    SELECT ?, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run(generationId);
+  db.prepare("UPDATE projection_generations SET build_cutoff_commit_sequence = (SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?), switched_commit_id = ?, validated_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
+  db.prepare("UPDATE active_projection_generation SET switched_commit_id = ? WHERE singleton_id = 1").run(projectionCommitId);
+}
+
+function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock, runtime?: CanonicalRuntimeOptions): { runId: string; commitSequence: number; assertionIds: string[] } {
+  const db = openCanonicalDatabase(ledgerDir, { runtime });
   let inTransaction = false;
   try {
     db.exec("BEGIN IMMEDIATE");
@@ -1969,6 +2247,7 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       assertionIds.push(idToString(assertionId));
       if (existingCurrent?.origin !== "user") insertCurrentDerivedField(db, transactionId, coordinate.field, assertionId, value, commitId);
     }
+    syncActiveProjectionFromCompatibility(db, commitId);
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
@@ -1983,7 +2262,7 @@ export function commitCathayDerivedImportRun(ledgerDir: string, input: CathayDer
   const coordinates = validateDerivedImportInput(input);
   validateDerivedImportSubjects(ledgerDir, input, coordinates);
   const clock = options.clock ?? (() => new Date().toISOString());
-  return withCanonicalWriter(ledgerDir, () => ({ status: "committed", ...commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, clock) }));
+  return withCanonicalWriter(ledgerDir, () => ({ status: "committed", ...commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, clock, options.runtime) }), options.runtime);
 }
 
 export async function runCathayDerivedImportRun(ledgerDir: string, input: CathayDerivedImportRunInput, options: CathayDerivedImportOptions = {}): Promise<CathayDerivedImportResult> {
@@ -1996,7 +2275,7 @@ export async function runCathayDerivedImportRun(ledgerDir: string, input: Cathay
   }
   try {
     validateDerivedImportSubjects(ledgerDir, input, coordinates);
-    return { status: "committed", ...await withCanonicalWriter(ledgerDir, () => commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, options.clock ?? (() => new Date().toISOString()))) };
+    return { status: "committed", ...await withCanonicalWriter(ledgerDir, () => commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, options.clock ?? (() => new Date().toISOString()), options.runtime), options.runtime) };
   }
   catch (error) {
     const diagnostic = derivedDiagnostic(error, input, "commit");
@@ -2033,7 +2312,7 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
   if (input.observedAt) parseRfc3339UtcMicros(input.observedAt, "User Assertion observedAt");
   const clock = options.clock ?? (() => new Date().toISOString());
   return withCanonicalWriter(ledgerDir, () => {
-    const db = openCanonicalDatabase(ledgerDir);
+    const db = openCanonicalDatabase(ledgerDir, { runtime: options.runtime });
     let inTransaction = false;
     try {
       db.exec("BEGIN IMMEDIATE"); inTransaction = true;
@@ -2072,12 +2351,13 @@ export async function commitCathayUserAssertion(ledgerDir: string, input: Cathay
       else db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
         VALUES (?, ?, ?, 'user', NULL, ?, ?) ON CONFLICT(transaction_id, field_name) DO UPDATE SET value_text = excluded.value_text, origin = 'user', derived_assertion_id = NULL, user_assertion_id = excluded.user_assertion_id, projection_commit_id = excluded.projection_commit_id`).run(transactionId, field, input.value ?? "", assertionId, commitId);
       db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, run_id, coordinate_id, commit_id) VALUES (?, NULL, NULL, NULL, ?)").run(assertionId, commitId);
+      syncActiveProjectionFromCompatibility(db, commitId);
       db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
       db.exec("COMMIT"); inTransaction = false;
       return { status: "committed", assertionId: idToString(assertionId), commitSequence, field, withdrawn };
     } catch (error) { if (inTransaction) db.exec("ROLLBACK"); throw error; }
     finally { db.close(); }
-  });
+  }, options.runtime);
 }
 
 function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }
@@ -2104,7 +2384,10 @@ function transactionRevisionFromRow(row: Record<string, unknown>): CanonicalTran
 }
 
 function selectedCurrentField(db: DatabaseSync, transactionId: unknown, field: CathayDerivedField): { value: string; origin: "derived" | "user"; commitSequence: number } | undefined {
-  const row = db.prepare("SELECT f.value_text, f.origin, c.commit_sequence FROM current_transaction_fields f JOIN canonical_commits c ON c.commit_id = f.projection_commit_id WHERE f.transaction_id = ? AND f.field_name = ?").get(transactionId as CanonicalId, field) as { value_text?: unknown; origin?: string; commit_sequence?: number } | undefined;
+  const row = db.prepare(`SELECT f.value_text, f.origin, c.commit_sequence FROM projection_generation_transaction_fields f
+    JOIN active_projection_generation pointer ON pointer.singleton_id = 1 AND pointer.generation_id = f.generation_id
+    JOIN canonical_commits c ON c.commit_id = f.projection_commit_id
+    WHERE f.transaction_id = ? AND f.field_name = ?`).get(transactionId as CanonicalId, field) as { value_text?: unknown; origin?: string; commit_sequence?: number } | undefined;
   if (row?.origin !== "derived" && row?.origin !== "user") return undefined;
   return { value: String(row.value_text), origin: row.origin, commitSequence: Number(row.commit_sequence) };
 }
@@ -2140,18 +2423,22 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
   async current(_request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult> {
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
+      db.exec("BEGIN");
       const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
-        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM current_transactions current_row
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM projection_generation_transactions current_row
+        JOIN active_projection_generation pointer ON pointer.singleton_id = 1 AND pointer.generation_id = current_row.generation_id
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.projection_commit_id
         ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
-      const projection = db.prepare(`SELECT c.commit_sequence FROM current_projection_state state
-        JOIN canonical_commits c ON c.commit_id = state.commit_id WHERE state.generation = 1`).get() as { commit_sequence?: number } | undefined;
+      const projection = db.prepare(`SELECT c.commit_sequence FROM active_projection_generation pointer
+        JOIN canonical_commits c ON c.commit_id = pointer.switched_commit_id WHERE pointer.singleton_id = 1`).get() as { commit_sequence?: number } | undefined;
       if (!projection) throw new Error("Canonical current projection cutoff is missing.");
-      return { status: "ok", kind: "current", accounts, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row))), commitSequence: Number(projection.commit_sequence) };
+      const result = { status: "ok", kind: "current", accounts, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row))), commitSequence: Number(projection.commit_sequence) } satisfies CathayCanonicalCurrentQueryResult;
+      db.exec("COMMIT");
+      return result;
     } finally { db.close(); }
   }
   async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {
@@ -2161,6 +2448,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     if (!Number.isSafeInteger(knowledgeAt)) throw new Error("Canonical historical knowledgeAt is outside the supported sequence range.");
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
+      db.exec("BEGIN");
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
@@ -2176,7 +2464,9 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
           WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
         ) ORDER BY a.account_no, t.source_sequence`).all(knowledgeAt, request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
-      return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row, knowledgeAt))) };
+      const result = { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row, knowledgeAt))) } satisfies CathayCanonicalHistoricalQueryResult;
+      db.exec("COMMIT");
+      return result;
     } finally { db.close(); }
   }
   async lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult> {
@@ -2184,6 +2474,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
     const transactionId = idFromString(request.subject.id);
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
+      db.exec("BEGIN");
       const revisionRows = db.prepare(`SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.economic_status, r.administrative_state, r.semantic_rule_version, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
@@ -2238,7 +2529,9 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           }),
         } satisfies CathayCanonicalLineageEntry;
       });
-      return { status: "ok", kind: "lineage", subject: request.subject, entries };
+      const result = { status: "ok", kind: "lineage", subject: request.subject, entries } satisfies CathayCanonicalLineageQueryResult;
+      db.exec("COMMIT");
+      return result;
     } finally { db.close(); }
   }
 }

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -17,7 +17,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_PROVENANCE = {
   note: "Human-assisted validation covered response shape only; no live values are retained.",
 } as const;
 
-export const CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE = `{"success":true,"returnCode":"000","content":{"datas":[{"queryStatus":"Success","accountNumber":"SYNTHETIC-ACCOUNT-001","count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":[{"sequenceNumber":1,"txnDateTime":"2026-07-01T09:00:00","accountDate":"2026-07-01","description":"Synthetic deposit","expendAmt":null,"incomeAmt":12500,"balance":12500},{"sequenceNumber":2,"txnDateTime":"2026-07-02T10:15:30","accountDate":"2026-07-02","description":"Synthetic transfer","expendAmt":300,"incomeAmt":null,"balance":12200},{"sequenceNumber":3,"txnDateTime":"2026-07-03T11:45:00","accountDate":"2026-07-03","description":"Synthetic credit","expendAmt":null,"incomeAmt":800,"balance":13000}]}]}}`;
+export const CATHAY_DOMESTIC_DEPOSIT_RAW_FIXTURE = `{"success":true,"returnCode":"0000","content":{"datas":[{"queryStatus":"Success","accountNumber":"SYNTHETIC-ACCOUNT-001","count":3,"startDate":"2025-08-17","endDate":"2026-08-17","details":[{"sequenceNumber":1,"txnDateTime":"2026-07-01T09:00:00","accountDate":"2026-07-01","description":"Synthetic deposit","expendAmt":null,"incomeAmt":12500,"balance":12500},{"sequenceNumber":2,"txnDateTime":"2026-07-02T10:15:30","accountDate":"2026-07-02","description":"Synthetic transfer","expendAmt":300,"incomeAmt":null,"balance":12200},{"sequenceNumber":3,"txnDateTime":"2026-07-03T11:45:00","accountDate":"2026-07-03","description":"Synthetic credit","expendAmt":null,"incomeAmt":800,"balance":13000}]}]}}`;
 
 export type CathayDomesticDepositCaptureInput = {
   rawResponse: string;
@@ -32,6 +32,9 @@ export type CathayDomesticDepositCaptureInput = {
     endDate: string;
     complete: boolean;
   };
+  syncState: {
+    cursor: string;
+  };
   observedAt: string;
 };
 
@@ -44,6 +47,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput 
   authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
   scope: { startDate: "2025-08-17", endDate: "2026-08-17", complete: true },
+  syncState: { cursor: "2026-08-17" },
   observedAt: "2026-08-17T12:00:00+08:00",
 };
 
@@ -269,6 +273,7 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
   if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) throw new Error("Invalid authority route.");
   if (input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Invalid Cathay product stream.");
   if (!input.scope.complete) throw new Error("Cathay transfer scope must be complete.");
+  if (!input.syncState.cursor.trim()) throw new Error("Cathay sync state cursor is required.");
   const startDate = requireDate(input.scope.startDate, "scope.startDate");
   const endDate = requireDate(input.scope.endDate, "scope.endDate");
   if (startDate > endDate) throw new Error("Cathay scope startDate must not be after endDate.");
@@ -276,7 +281,7 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
 
   const root = asObject(new LosslessJsonParser(input.rawResponse).parse(), "Cathay response");
   if (root.success !== true) throw new Error("Cathay response was not successful.");
-  if (root.returnCode !== "000") throw new Error("Cathay response returnCode was not 000.");
+  if (root.returnCode !== "0000") throw new Error("Cathay response returnCode was not 0000.");
   const content = asObject(root.content, "Cathay response content");
   const statement = asObject(asArray(content.datas, "Cathay response datas")[0], "Cathay transfer result");
   if (requiredString(statement, "queryStatus") !== "Success") throw new Error("Cathay queryStatus was not Success.");
@@ -450,6 +455,7 @@ CREATE TABLE IF NOT EXISTS source_sync_states (
   stream TEXT NOT NULL,
   scope_start TEXT NOT NULL,
   scope_end TEXT NOT NULL,
+  cursor TEXT NOT NULL,
   last_capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
   commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
   PRIMARY KEY(source_connection_id, account_id, stream)
@@ -474,6 +480,10 @@ export function openCanonicalDatabase(
   if (!options.readOnly) {
     db.exec("PRAGMA journal_mode = WAL");
     db.exec(SCHEMA);
+    const syncColumns = db.prepare("PRAGMA table_info(source_sync_states)").all() as Array<{ name?: string }>;
+    if (!syncColumns.some((column) => column.name === "cursor")) {
+      db.exec("ALTER TABLE source_sync_states ADD COLUMN cursor TEXT NOT NULL DEFAULT ''");
+    }
   }
   return db;
 }
@@ -695,12 +705,12 @@ export function commitCathayDomesticDeposit(
       });
     }
     db.prepare(
-      `INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, last_capture_id, commit_sequence)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_sequence)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET
          scope_start = excluded.scope_start, scope_end = excluded.scope_end,
-         last_capture_id = excluded.last_capture_id, commit_sequence = excluded.commit_sequence`,
-    ).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, captureId, commitSequence);
+         cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_sequence = excluded.commit_sequence`,
+    ).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor, captureId, commitSequence);
     db.exec("COMMIT");
     inTransaction = false;
     return { captureId, commitSequence, accountId, transactions: transactionResults };

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -96,10 +96,15 @@ export type CathayDerivedImportRunInput = {
   stream: string;
   producerId: string;
   ruleLineage: string;
-  origin?: string;
+  origin?: CathayDerivedOrigin;
   observedAt?: string;
-  /** Complete subject/field/producer/rule-lineage coordinate matrix. */
-  scope?: CathayDerivedImportCoordinate[];
+  /** The closed-run marker; only a complete successful run may mutate canonical data. */
+  complete: boolean;
+  status: "complete" | "partial" | "failed";
+  /** Complete, non-empty subject/field/producer/rule-lineage coordinate matrix. */
+  subjectIds: string[];
+  fields: CathayDerivedField[];
+  scope: CathayDerivedImportCoordinate[];
 };
 export type CathayDerivedImportDiagnostic = {
   kind: "derived-import-diagnostic";
@@ -116,11 +121,12 @@ export type CathayDerivedImportOptions = CathayCanonicalCommitOptions & {
 };
 
 export type CathayUserAssertionField = "display_name" | "note";
+export type CathayUserAssertionTargetField = CathayUserAssertionField | "displayName" | "displayLabel";
 export type CathayUserAssertionInput = {
   transactionId?: string;
   subject?: { kind: "transaction"; id: string };
   field?: CathayUserAssertionField | string;
-  target?: { kind?: string; field?: string; id?: string } | string;
+  target?: { kind: "transaction"; field?: CathayUserAssertionTargetField; id: string };
   value?: string | null;
   userId?: string;
   observedAt?: string;
@@ -596,6 +602,7 @@ CREATE INDEX IF NOT EXISTS idx_assertions_lineage ON assertions(transaction_id, 
 CREATE INDEX IF NOT EXISTS idx_assertion_transitions_knowledge ON assertion_transitions(assertion_id, commit_id, event_kind, event_id);
 CREATE INDEX IF NOT EXISTS idx_assertion_transitions_transaction ON assertion_transitions(transaction_id, field_name, commit_id, event_id);
 CREATE INDEX IF NOT EXISTS idx_assertion_provenance_authority ON assertion_provenance(assertion_id, commit_id, source_record_id, run_id, coordinate_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_provenance_record ON assertion_provenance(source_record_id, assertion_id, commit_id);
 `;
 
 const SCHEMA = `
@@ -673,7 +680,12 @@ CREATE TABLE IF NOT EXISTS source_assertions (
   revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(transaction_id, revision_id)
 );
-${SCHEMA_SHARED_ASSERTION_SPINE}
+CREATE TABLE IF NOT EXISTS assertion_provenance (
+  assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id),
+  source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  PRIMARY KEY(assertion_id, source_record_id)
+);
 CREATE TABLE IF NOT EXISTS source_sync_states (
   source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
   stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT,
@@ -847,8 +859,15 @@ CREATE TABLE IF NOT EXISTS current_transaction_fields (
 );
 CREATE INDEX IF NOT EXISTS idx_derived_scope_coordinates_lineage ON derived_scope_coordinates(transaction_id, field_name, origin, producer_id, rule_lineage, commit_id);
 CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id);
+CREATE INDEX IF NOT EXISTS idx_current_transactions_revision ON current_transactions(revision_id, commit_id, transaction_id);
 `;
-const SCHEMA_V6 = `${SCHEMA_V5.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
+// A fresh v6 database must not first create the v5 Source-only provenance table:
+// the shared spine owns provenance at v6, while v5 migrations still retain the
+// legacy table long enough for ensureV6SharedAssertionSpine to backfill it.
+const SCHEMA_V6_BASE = SCHEMA_V5
+  .replace(/CREATE TABLE IF NOT EXISTS assertion_provenance \([\s\S]*?\n\);\n/, "")
+  .replace("CREATE INDEX IF NOT EXISTS idx_assertion_provenance_record ON assertion_provenance(source_record_id, assertion_id, commit_id);", "");
+const SCHEMA_V6 = `${SCHEMA_V6_BASE.replace("CHECK(commit_kind = 'source_capture')", "CHECK(commit_kind IN ('source_capture','derived_import','user_assertion'))")}${SCHEMA_V6_APPEND}`;
 
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
 // Keeping this target schema separate prevents an older database from being created at a
@@ -1054,9 +1073,40 @@ function rebuildCurrentTransactionFieldsForSharedAssertions(db: DatabaseSync): v
   db.exec("CREATE INDEX IF NOT EXISTS idx_current_transaction_fields_projection ON current_transaction_fields(field_name, origin, projection_commit_id, transaction_id)");
 }
 
+function ensureV6ProjectionOriginConstraints(db: DatabaseSync): void {
+  db.exec(`CREATE TRIGGER IF NOT EXISTS trg_current_transaction_fields_origin_insert
+    BEFORE INSERT ON current_transaction_fields
+    WHEN NOT EXISTS (
+      SELECT 1 FROM assertions assertion
+      WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
+        AND assertion.origin = NEW.origin
+        AND assertion.transaction_id = NEW.transaction_id
+        AND assertion.field_name = NEW.field_name
+    )
+    BEGIN SELECT RAISE(ABORT, 'current transaction field assertion origin mismatch'); END;
+  CREATE TRIGGER IF NOT EXISTS trg_current_transaction_fields_origin_update
+    BEFORE UPDATE OF transaction_id, field_name, origin, derived_assertion_id, user_assertion_id ON current_transaction_fields
+    WHEN NOT EXISTS (
+      SELECT 1 FROM assertions assertion
+      WHERE assertion.assertion_id = CASE WHEN NEW.origin = 'derived' THEN NEW.derived_assertion_id ELSE NEW.user_assertion_id END
+        AND assertion.origin = NEW.origin
+        AND assertion.transaction_id = NEW.transaction_id
+        AND assertion.field_name = NEW.field_name
+    )
+    BEGIN SELECT RAISE(ABORT, 'current transaction field assertion origin mismatch'); END;`);
+}
+
 function convertV6CompatibilityTables(db: DatabaseSync): void {
   backfillV6DerivedAndUserAssertions(db);
   const compatibilityViews: Array<{ name: string; select: string }> = [
+    {
+      name: "source_assertions",
+      select: `SELECT assertion.assertion_id, assertion.transaction_id, assertion.revision_id,
+        MIN(provenance.source_record_id) AS source_record_id, assertion.created_commit_id AS commit_id
+        FROM assertions assertion JOIN assertion_provenance provenance ON provenance.assertion_id = assertion.assertion_id
+        WHERE assertion.origin = 'source' AND provenance.source_record_id IS NOT NULL
+        GROUP BY assertion.assertion_id, assertion.transaction_id, assertion.revision_id, assertion.created_commit_id`,
+    },
     {
       name: "derived_assertions",
       select: `SELECT assertion.assertion_id, assertion.transaction_id, assertion.field_name, assertion.producer_id,
@@ -1231,6 +1281,7 @@ function migrateV5ToV6(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     db.exec(SCHEMA_V6_APPEND);
     rebuildCurrentTransactionFieldsForSharedAssertions(db);
     convertV6CompatibilityTables(db);
+    ensureV6ProjectionOriginConstraints(db);
     if (injectMigrationFailure === "v5-v6-after-derived-schema") throw new Error("Injected v5-v6 migration failure after derived schema.");
     db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(6, currentUtcMicros());
     db.exec("PRAGMA user_version = 6");
@@ -1288,6 +1339,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
       if (relationType(db, "assertion_lifecycle_events") !== "view") db.exec(SCHEMA_V6_APPEND);
       rebuildCurrentTransactionFieldsForSharedAssertions(db);
       convertV6CompatibilityTables(db);
+      ensureV6ProjectionOriginConstraints(db);
       db.exec("PRAGMA foreign_keys = ON");
       db.exec("COMMIT");
     } catch (error) {
@@ -1304,6 +1356,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
     ensureV6SharedAssertionSpine(db);
     rebuildCurrentTransactionFieldsForSharedAssertions(db);
     convertV6CompatibilityTables(db);
+    ensureV6ProjectionOriginConstraints(db);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
@@ -1316,11 +1369,11 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  const requiredTables = ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "source_assertions", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields"];
   for (const table of requiredTables) {
     if (!relationType(db, table)) throw new Error(`Canonical schema v6 table ${table} is missing.`);
   }
-  for (const table of ["derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
+  for (const table of ["source_assertions", "derived_assertions", "user_assertions", "assertion_lifecycle_events", "derived_assertion_lifecycle_events", "user_assertion_lifecycle_events", "derived_assertion_provenance", "user_assertion_provenance"]) {
     if (relationType(db, table) !== "view") throw new Error(`Canonical schema v6 compatibility relation ${table} is not a read-only view.`);
   }
   for (const table of ["assertions", "assertion_transitions", "assertion_provenance", "current_transaction_fields"]) {
@@ -1328,6 +1381,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   }
   const requiredColumns: Record<string, string[]> = {
     assertions: ["assertion_id", "transaction_id", "field_name", "target_kind", "origin", "producer_id", "rule_lineage", "revision_id", "value_text", "created_commit_id"],
+    source_assertions: ["assertion_id", "transaction_id", "revision_id", "source_record_id", "commit_id"],
     assertion_transitions: ["event_id", "assertion_id", "transaction_id", "field_name", "capture_id", "scope_id", "run_id", "coordinate_id", "user_id", "commit_id", "event_kind"],
     assertion_provenance: ["assertion_id", "source_record_id", "run_id", "coordinate_id", "commit_id"],
     derived_import_runs: ["run_id", "source_connection_id", "identity_epoch_id", "authority_route", "stream", "producer_id", "origin", "rule_lineage", "observed_at", "commit_id", "status"],
@@ -1377,6 +1431,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     throw new Error("Canonical schema v6 shared assertion transition taxonomy is missing.");
   }
   const compatibilityAuthority: Record<string, RegExp> = {
+    source_assertions: /FROM\s+assertions\b/i,
     derived_assertions: /FROM\s+assertions\b/i,
     user_assertions: /FROM\s+assertions\b/i,
     assertion_lifecycle_events: /FROM\s+assertion_transitions\b/i,
@@ -1388,6 +1443,14 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
   for (const [view, authority] of Object.entries(compatibilityAuthority)) {
     if (!authority.test(tableSql(view))) throw new Error(`Canonical schema v6 compatibility view ${view} is not backed by the shared assertion spine.`);
   }
+  const triggerRows = db.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND name IN ('trg_current_transaction_fields_origin_insert', 'trg_current_transaction_fields_origin_update')").all() as Array<{ name?: string; sql?: string }>;
+  if (triggerRows.length !== 2 || triggerRows.some((row) => !/assertions/i.test(String(row.sql)))) throw new Error("Canonical v6 current projection origin triggers are missing.");
+  const invalidProjectionRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM current_transaction_fields field
+    LEFT JOIN assertions derived ON derived.assertion_id = field.derived_assertion_id
+    LEFT JOIN assertions user_assertion ON user_assertion.assertion_id = field.user_assertion_id
+    WHERE (field.origin = 'derived' AND (derived.origin <> 'derived' OR derived.transaction_id <> field.transaction_id OR derived.field_name <> field.field_name OR derived.assertion_id IS NULL))
+       OR (field.origin = 'user' AND (user_assertion.origin <> 'user' OR user_assertion.transaction_id <> field.transaction_id OR user_assertion.field_name <> field.field_name OR user_assertion.assertion_id IS NULL))`).get() as { count?: number }).count ?? 0);
+  if (invalidProjectionRows !== 0) throw new Error("Canonical v6 current projection assertion origin is inconsistent.");
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
   const integrity = String((db.prepare("PRAGMA integrity_check").get() as { integrity_check?: unknown }).integrity_check ?? "");
@@ -1568,7 +1631,7 @@ function commitCathayDomesticDepositSyncOnce(
         let assertionId: CanonicalId;
         if (revisionCreated) {
           if (latestRow) {
-            const oldAssertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE revision_id = ?").get(blob(latestRow.revision_id));
+            const oldAssertion = db.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' AND revision_id = ?").get(blob(latestRow.revision_id));
             if (oldAssertion) insertLifecycleEvent(db, { assertionId: blob(dbRow<{ assertion_id: unknown }>(oldAssertion).assertion_id), transactionId, revisionId: blob(latestRow.revision_id), captureId, scopeId, commitId, kind: "superseded" });
           }
           revisionId = uuidV7();
@@ -1586,12 +1649,11 @@ function commitCathayDomesticDepositSyncOnce(
           observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "accounting", detail.accountDate, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", detail.accountingUtcInstantUtcUs);
           observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "occurred", detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", detail.utcInstantUtcUs);
           assertionId = uuidV7();
-          db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
           db.prepare("INSERT INTO assertions(assertion_id, transaction_id, field_name, target_kind, origin, producer_id, rule_lineage, revision_id, value_text, created_commit_id) VALUES (?, ?, 'transaction_revision', 'transaction', 'source', ?, ?, ?, NULL, ?)").run(assertionId, transactionId, input.authorityRoute, input.authorityRoute, revisionId, commitId);
           insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: "observed" });
           db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id) VALUES (?, ?, ?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id, projection_commit_id = excluded.projection_commit_id, revision_commit_id = excluded.revision_commit_id").run(transactionId, revisionId, commitId, commitId, commitId);
         } else {
-          const assertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
+          const assertion = db.prepare("SELECT assertion_id FROM assertions WHERE origin = 'source' AND transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
           if (!assertion) throw new Error("Canonical assertion was not created.");
           assertionId = blob(dbRow<{ assertion_id: unknown }>(assertion).assertion_id);
           const wasWithdrawn = latestLifecycleEvent(db, assertionId) === "withdrawn";
@@ -1607,7 +1669,7 @@ function commitCathayDomesticDepositSyncOnce(
         allTransactions.push(result);
       }
       if (scope.absenceAuthority) {
-        const prior = db.prepare(`SELECT sa.assertion_id, sa.transaction_id, sa.revision_id, t.source_sequence FROM source_assertions sa
+        const prior = db.prepare(`SELECT sa.assertion_id, sa.transaction_id, sa.revision_id, t.source_sequence FROM assertions sa
           JOIN financial_transactions t ON t.transaction_id = sa.transaction_id JOIN transaction_revisions r ON r.revision_id = sa.revision_id
           JOIN current_transactions current_row ON current_row.transaction_id = t.transaction_id AND current_row.revision_id = r.revision_id
           JOIN assertion_provenance provenance ON provenance.assertion_id = sa.assertion_id
@@ -1615,7 +1677,7 @@ function commitCathayDomesticDepositSyncOnce(
           JOIN source_record_scopes prior_record_scope ON prior_record_scope.source_record_id = prior_record.source_record_id
           JOIN capture_scopes prior_scope ON prior_scope.scope_id = prior_record_scope.scope_id
           JOIN source_captures prior_capture ON prior_capture.capture_id = prior_scope.capture_id
-          WHERE t.account_id = ? AND r.effective_on BETWEEN ? AND ?
+          WHERE sa.origin = 'source' AND t.account_id = ? AND r.effective_on BETWEEN ? AND ?
             AND prior_scope.source_connection_id = ? AND prior_scope.identity_epoch_id = ? AND prior_scope.account_id = ?
             AND prior_scope.stream = ? AND prior_scope.scope_kind = 'bounded-range'
             AND prior_scope.completeness = 'complete-range' AND prior_scope.completeness_rule_version = ?
@@ -1711,15 +1773,35 @@ export function commitCathayDomesticDepositSync(
 }
 
 function importCoordinates(input: CathayDerivedImportRunInput): CathayDerivedImportCoordinate[] {
-  if (!input.scope) throw new Error("A complete derived import requires an explicit coordinate matrix.");
-  return normalizeDerivedCoordinates(input.scope);
+  if (!Array.isArray(input.subjectIds) || input.subjectIds.length === 0) throw new Error("A complete derived import requires non-empty subjectIds.");
+  if (!Array.isArray(input.fields) || input.fields.length === 0) throw new Error("A complete derived import requires non-empty fields.");
+  if (!Array.isArray(input.scope) || input.scope.length === 0) throw new Error("A complete derived import requires a non-empty coordinate matrix.");
+  const subjectIds = input.subjectIds.map((subjectId) => {
+    if (typeof subjectId !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(subjectId)) throw new Error("Derived import subjectIds contains an invalid transaction subject.");
+    return subjectId;
+  });
+  if (new Set(subjectIds.map((subjectId) => subjectId.toLowerCase())).size !== subjectIds.length) throw new Error("Derived import subjectIds contains a duplicate transaction subject.");
+  const fields = input.fields.map((field) => {
+    if (field !== "display_name" && field !== "note") throw new Error("Derived import fields contains an unsupported field.");
+    return field;
+  });
+  if (new Set(fields).size !== fields.length) throw new Error("Derived import fields contains a duplicate field.");
+  const normalized = normalizeDerivedCoordinates(input.scope);
+  const expected = new Set(subjectIds.flatMap((subjectId) => fields.map((field) => `${subjectId.toLowerCase()}:${field}`)));
+  for (const coordinate of normalized) {
+    const key = `${coordinate.transactionId.toLowerCase()}:${coordinate.field}`;
+    if (!expected.has(key)) throw new Error("Derived import scope contains a coordinate outside the declared subject/field matrix.");
+    expected.delete(key);
+  }
+  if (expected.size > 0) throw new Error("Derived import scope is missing a declared subject/field coordinate.");
+  return normalized;
 }
 
 function normalizeDerivedCoordinates(first: CathayDerivedImportCoordinate[]): CathayDerivedImportCoordinate[] {
   const normalized = first.map((coordinate) => {
     if (!coordinate || typeof coordinate !== "object") throw new Error("Derived import coordinate must be an object.");
     if (!coordinate.transactionId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(coordinate.transactionId)) throw new Error("Derived import coordinate has an invalid transaction subject.");
-    const normalizedField = coordinate.field === ("displayName" as CathayDerivedField) || coordinate.field === ("displayLabel" as CathayDerivedField) ? "display_name" : coordinate.field;
+    const normalizedField = coordinate.field;
     if (normalizedField !== "display_name" && normalizedField !== "note") throw new Error("Derived import field is not supported.");
     if (coordinate.state !== "supported" && coordinate.state !== "unsupported") throw new Error("Derived import coordinate has an invalid output state.");
     if (coordinate.state === "supported" && typeof coordinate.value !== "string") throw new Error("Supported derived output must provide a typed string value.");
@@ -1741,8 +1823,31 @@ function validateDerivedImportInput(input: CathayDerivedImportRunInput): CathayD
   if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY || input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Derived import authority route or stream is not supported.");
   if (!input.producerId.trim() || !input.ruleLineage.trim()) throw new Error("Derived import producer and rule lineage are required.");
   if (input.origin !== undefined && input.origin !== CATHAY_DERIVED_ORIGIN) throw new Error("Derived import origin is not a registered Derived origin.");
+  if (input.complete !== true || input.status !== "complete") throw new Error("Only a complete successful derived import may mutate canonical data.");
   if (input.observedAt !== undefined) parseRfc3339UtcMicros(input.observedAt, "Derived import observedAt");
   return importCoordinates(input);
+}
+
+function validateDerivedImportSubjects(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[]): void {
+  const db = openCanonicalDatabase(ledgerDir, { readOnly: true });
+  try {
+    const connection = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
+    if (!connection) throw new Error("Derived import source connection is unknown; source lineage must already exist.");
+    const sourceConnectionId = blob(dbRow<{ source_connection_id: unknown }>(connection).source_connection_id);
+    const epoch = db.prepare("SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?").get(sourceConnectionId, input.identityEpoch);
+    if (!epoch) throw new Error("Derived import identity epoch is unknown; source lineage must already exist.");
+    const identityEpochId = blob(dbRow<{ identity_epoch_id: unknown }>(epoch).identity_epoch_id);
+    for (const coordinate of coordinates) {
+      const transactionId = idFromString(coordinate.transactionId);
+      const transaction = db.prepare(`SELECT a.source_connection_id, a.identity_epoch_id, a.stream
+        FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
+        WHERE t.transaction_id = ?`).get(transactionId) as Record<string, unknown> | undefined;
+      if (!transaction) throw new Error("Derived import targets an unknown transaction subject.");
+      if (Buffer.compare(blob(transaction.source_connection_id), sourceConnectionId) !== 0
+        || Buffer.compare(blob(transaction.identity_epoch_id), identityEpochId) !== 0
+        || transaction.stream !== input.stream) throw new Error("Derived import crossed a source identity or stream boundary.");
+    }
+  } finally { db.close(); }
 }
 
 function derivedDiagnostic(error: unknown, input: CathayDerivedImportRunInput, stage: CathayDerivedImportDiagnostic["stage"]): CathayDerivedImportDiagnostic {
@@ -1869,6 +1974,7 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
 
 export function commitCathayDerivedImportRun(ledgerDir: string, input: CathayDerivedImportRunInput, options: CathayDerivedImportOptions = {}): Promise<CathayDerivedImportResult & { status: "committed" }> {
   const coordinates = validateDerivedImportInput(input);
+  validateDerivedImportSubjects(ledgerDir, input, coordinates);
   const clock = options.clock ?? (() => new Date().toISOString());
   return withCanonicalWriter(ledgerDir, () => ({ status: "committed", ...commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, clock) }));
 }
@@ -1881,7 +1987,10 @@ export async function runCathayDerivedImportRun(ledgerDir: string, input: Cathay
     options.onDiagnostic?.(diagnostic);
     return { status: "diagnostic", diagnostic };
   }
-  try { return { status: "committed", ...await withCanonicalWriter(ledgerDir, () => commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, options.clock ?? (() => new Date().toISOString()))) }; }
+  try {
+    validateDerivedImportSubjects(ledgerDir, input, coordinates);
+    return { status: "committed", ...await withCanonicalWriter(ledgerDir, () => commitCathayDerivedImportRunOnce(ledgerDir, input, coordinates, options.clock ?? (() => new Date().toISOString()))) };
+  }
   catch (error) {
     const diagnostic = derivedDiagnostic(error, input, "commit");
     options.onDiagnostic?.(diagnostic);
@@ -2054,7 +2163,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           ORDER BY lifecycle_commit.commit_sequence DESC, lifecycle.event_id DESC LIMIT 1), 'supported') AS assertion_support_state
         FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
-        JOIN source_assertions sa ON sa.revision_id = r.revision_id
+        JOIN assertions sa ON sa.revision_id = r.revision_id AND sa.origin = 'source'
         WHERE r.effective_on <= ? AND c.commit_sequence <= ? AND NOT EXISTS (
           SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
           WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
@@ -2077,7 +2186,7 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
         JOIN source_records sr ON sr.source_record_id = r.source_record_id JOIN source_record_scopes record_scope ON record_scope.source_record_id = sr.source_record_id
         JOIN capture_scopes source_scope ON source_scope.scope_id = record_scope.scope_id JOIN source_captures sc ON sc.capture_id = r.capture_id
-        JOIN source_assertions sa ON sa.revision_id = r.revision_id WHERE t.transaction_id = ? ORDER BY r.revision_number`).all(transactionId) as Record<string, unknown>[];
+        JOIN assertions sa ON sa.revision_id = r.revision_id AND sa.origin = 'source' WHERE t.transaction_id = ? ORDER BY r.revision_number`).all(transactionId) as Record<string, unknown>[];
       const entries = revisionRows.map((row) => {
         const assertionId = blob(row.assertion_id);
         const provenance = db.prepare(`SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId FROM assertion_provenance p

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -8,6 +8,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
+export const CANONICAL_SCHEMA_VERSION = 1;
 
 export const CATHAY_DOMESTIC_DEPOSIT_PROVENANCE = {
   validatedAt: "2026-08-17",
@@ -27,14 +28,8 @@ export type CathayDomesticDepositCaptureInput = {
   currency: string;
   authorityRoute: string;
   stream: string;
-  scope: {
-    startDate: string;
-    endDate: string;
-    complete: boolean;
-  };
-  syncState: {
-    cursor: string;
-  };
+  scope: { startDate: string; endDate: string; complete: boolean };
+  syncState: { cursor: string };
   observedAt: string;
 };
 
@@ -51,10 +46,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput 
   observedAt: "2026-08-17T12:00:00+08:00",
 };
 
-export type ExactDecimal = {
-  coefficient: bigint;
-  scale: number;
-};
+export type ExactDecimal = { coefficient: bigint; scale: number };
 
 export function parseExactDecimalLexeme(lexeme: string): ExactDecimal {
   if (!/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(lexeme)) {
@@ -63,8 +55,10 @@ export function parseExactDecimalLexeme(lexeme: string): ExactDecimal {
   const negative = lexeme.startsWith("-");
   const unsigned = negative ? lexeme.slice(1) : lexeme;
   const [whole, fraction = ""] = unsigned.split(".");
-  const coefficient = BigInt(`${negative ? "-" : ""}${whole}${fraction}`);
-  return { coefficient, scale: fraction.length };
+  return {
+    coefficient: BigInt(`${negative ? "-" : ""}${whole}${fraction}`),
+    scale: fraction.length,
+  };
 }
 
 type LosslessJsonNumber = { kind: "number"; lexeme: string };
@@ -80,9 +74,7 @@ class LosslessJsonParser {
   private position = 0;
   private readonly source: string;
 
-  constructor(source: string) {
-    this.source = source;
-  }
+  constructor(source: string) { this.source = source; }
 
   parse(): LosslessJsonValue {
     const value = this.value();
@@ -97,18 +89,9 @@ class LosslessJsonParser {
     if (char === "{") return this.object();
     if (char === "[") return this.array();
     if (char === '"') return this.string();
-    if (this.source.startsWith("true", this.position)) {
-      this.position += 4;
-      return true;
-    }
-    if (this.source.startsWith("false", this.position)) {
-      this.position += 5;
-      return false;
-    }
-    if (this.source.startsWith("null", this.position)) {
-      this.position += 4;
-      return null;
-    }
+    if (this.source.startsWith("true", this.position)) { this.position += 4; return true; }
+    if (this.source.startsWith("false", this.position)) { this.position += 5; return false; }
+    if (this.source.startsWith("null", this.position)) { this.position += 4; return null; }
     return { kind: "number", lexeme: this.number() };
   }
 
@@ -116,10 +99,7 @@ class LosslessJsonParser {
     this.position += 1;
     const output: { [key: string]: LosslessJsonValue } = {};
     this.whitespace();
-    if (this.source[this.position] === "}") {
-      this.position += 1;
-      return output;
-    }
+    if (this.source[this.position] === "}") { this.position += 1; return output; }
     while (true) {
       this.whitespace();
       if (this.source[this.position] !== '"') throw new Error("Invalid JSON object key.");
@@ -130,10 +110,7 @@ class LosslessJsonParser {
       if (key in output) throw new Error(`Duplicate JSON object key: ${key}`);
       output[key] = this.value();
       this.whitespace();
-      if (this.source[this.position] === "}") {
-        this.position += 1;
-        return output;
-      }
+      if (this.source[this.position] === "}") { this.position += 1; return output; }
       if (this.source[this.position] !== ",") throw new Error("Invalid JSON object delimiter.");
       this.position += 1;
     }
@@ -143,17 +120,11 @@ class LosslessJsonParser {
     this.position += 1;
     const output: LosslessJsonValue[] = [];
     this.whitespace();
-    if (this.source[this.position] === "]") {
-      this.position += 1;
-      return output;
-    }
+    if (this.source[this.position] === "]") { this.position += 1; return output; }
     while (true) {
       output.push(this.value());
       this.whitespace();
-      if (this.source[this.position] === "]") {
-        this.position += 1;
-        return output;
-      }
+      if (this.source[this.position] === "]") { this.position += 1; return output; }
       if (this.source[this.position] !== ",") throw new Error("Invalid JSON array delimiter.");
       this.position += 1;
     }
@@ -164,10 +135,7 @@ class LosslessJsonParser {
     this.position += 1;
     while (this.position < this.source.length) {
       const char = this.source[this.position];
-      if (char === "\\") {
-        this.position += 2;
-        continue;
-      }
+      if (char === "\\") { this.position += 2; continue; }
       if (char === '"') {
         this.position += 1;
         return JSON.parse(this.source.slice(start, this.position)) as string;
@@ -190,85 +158,64 @@ class LosslessJsonParser {
 }
 
 function asObject(value: LosslessJsonValue, label: string): { [key: string]: LosslessJsonValue } {
-  if (!value || typeof value !== "object" || Array.isArray(value) || "kind" in value) {
-    throw new Error(`${label} must be an object.`);
-  }
+  if (!value || typeof value !== "object" || Array.isArray(value) || "kind" in value) throw new Error(`${label} must be an object.`);
   return value as { [key: string]: LosslessJsonValue };
 }
-
 function asArray(value: LosslessJsonValue | undefined, label: string): LosslessJsonValue[] {
   if (!Array.isArray(value)) throw new Error(`${label} must be an array.`);
   return value;
 }
-
 function requiredString(object: { [key: string]: LosslessJsonValue }, key: string): string {
   const value = object[key];
   if (typeof value !== "string" || !value) throw new Error(`Missing required string ${key}.`);
   return value;
 }
-
 function isLosslessJsonNumber(value: LosslessJsonValue | undefined): value is LosslessJsonNumber {
   return Boolean(value && typeof value === "object" && !Array.isArray(value) && value.kind === "number");
 }
-
 function requiredNumber(object: { [key: string]: LosslessJsonValue }, key: string): string {
   const value = object[key];
-  if (!isLosslessJsonNumber(value)) {
-    throw new Error(`Missing required JSON number ${key}.`);
-  }
+  if (!isLosslessJsonNumber(value)) throw new Error(`Missing required JSON number ${key}.`);
   return value.lexeme;
 }
-
 function nullableNumber(object: { [key: string]: LosslessJsonValue }, key: string): string | null {
   const value = object[key];
   if (value === null) return null;
-  if (!isLosslessJsonNumber(value)) {
-    throw new Error(`${key} must be a JSON number or null.`);
-  }
+  if (!isLosslessJsonNumber(value)) throw new Error(`${key} must be a JSON number or null.`);
   return value.lexeme;
 }
-
 function requireDate(value: string, label: string): string {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`${label} must be YYYY-MM-DD.`);
   const date = new Date(`${value}T00:00:00.000Z`);
-  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
-    throw new Error(`${label} must be a valid calendar date.`);
-  }
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) throw new Error(`${label} must be a valid calendar date.`);
   return value;
 }
-
 function requireDateTime(value: string, label: string): string {
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
-    throw new Error(`${label} must be YYYY-MM-DDTHH:mm:ss.`);
-  }
-  const date = new Date(`${value}Z`);
-  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 19) !== value) {
-    throw new Error(`${label} must be a valid local date-time.`);
-  }
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) throw new Error(`${label} must be YYYY-MM-DDTHH:mm:ss.`);
+  const calendarShape = new Date(`${value}Z`);
+  if (Number.isNaN(calendarShape.getTime()) || calendarShape.toISOString().slice(0, 19) !== value) throw new Error(`${label} must be a valid local date-time.`);
   return value;
+}
+function localDateTimeToUtcMicros(value: string): number {
+  const milliseconds = new Date(`${value}+08:00`).getTime();
+  if (!Number.isSafeInteger(milliseconds)) throw new Error("Cathay local date-time is outside the supported instant range.");
+  return milliseconds * 1000;
 }
 
 type ValidatedCathayRow = {
   sequence: string;
   accountDate: string;
   transactionDateTime: string;
+  utcInstantUtcUs: number;
   amount: ExactDecimal;
   direction: "inflow" | "outflow";
   balance: ExactDecimal;
   payload: string;
 };
-
-type ValidatedCathayCapture = {
-  accountNo: string;
-  startDate: string;
-  endDate: string;
-  rows: ValidatedCathayRow[];
-};
+type ValidatedCathayCapture = { accountNo: string; startDate: string; endDate: string; rows: ValidatedCathayRow[] };
 
 function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCathayCapture {
-  if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) {
-    throw new Error("Source Connection and Identity Epoch are required.");
-  }
+  if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) throw new Error("Source Connection and Identity Epoch are required.");
   if (input.currency !== "TWD") throw new Error("Cathay domestic deposit currency must be TWD.");
   if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) throw new Error("Invalid authority route.");
   if (input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Invalid Cathay product stream.");
@@ -277,19 +224,20 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
   const startDate = requireDate(input.scope.startDate, "scope.startDate");
   const endDate = requireDate(input.scope.endDate, "scope.endDate");
   if (startDate > endDate) throw new Error("Cathay scope startDate must not be after endDate.");
-  if (Number.isNaN(Date.parse(input.observedAt))) throw new Error("Invalid observation time.");
+  const observedAtMs = Date.parse(input.observedAt);
+  if (!Number.isSafeInteger(observedAtMs)) throw new Error("Invalid observation time.");
 
   const root = asObject(new LosslessJsonParser(input.rawResponse).parse(), "Cathay response");
   if (root.success !== true) throw new Error("Cathay response was not successful.");
   if (root.returnCode !== "0000") throw new Error("Cathay response returnCode was not 0000.");
   const content = asObject(root.content, "Cathay response content");
-  const statement = asObject(asArray(content.datas, "Cathay response datas")[0], "Cathay transfer result");
+  const datas = asArray(content.datas, "Cathay response datas");
+  if (datas.length !== 1) throw new Error("Cathay response must contain exactly one transfer result.");
+  const statement = asObject(datas[0]!, "Cathay transfer result");
   if (requiredString(statement, "queryStatus") !== "Success") throw new Error("Cathay queryStatus was not Success.");
   const accountNo = requiredString(statement, "accountNumber");
   if (accountNo !== input.accountNo) throw new Error("Cathay account scope does not match the response.");
-  if (requiredString(statement, "startDate") !== startDate || requiredString(statement, "endDate") !== endDate) {
-    throw new Error("Cathay response date scope does not match the requested scope.");
-  }
+  if (requiredString(statement, "startDate") !== startDate || requiredString(statement, "endDate") !== endDate) throw new Error("Cathay response date scope does not match the requested scope.");
   const count = parseExactDecimalLexeme(requiredNumber(statement, "count"));
   if (count.scale !== 0 || count.coefficient < 0n) throw new Error("Cathay count must be a non-negative integer.");
   const details = asArray(statement.details, "Cathay transfer details");
@@ -300,19 +248,16 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
     const detail = asObject(detailValue, `Cathay detail ${index}`);
     const sequenceLexeme = requiredNumber(detail, "sequenceNumber");
     const sequence = parseExactDecimalLexeme(sequenceLexeme);
-    if (sequence.scale !== 0 || sequence.coefficient < 0n || sequences.has(sequenceLexeme)) {
-      throw new Error("Cathay sequenceNumber must be a unique exact integer.");
-    }
+    if (sequence.scale !== 0 || sequence.coefficient < 0n || sequences.has(sequenceLexeme)) throw new Error("Cathay sequenceNumber must be a unique exact integer.");
     sequences.add(sequenceLexeme);
     const expendLexeme = nullableNumber(detail, "expendAmt");
     const incomeLexeme = nullableNumber(detail, "incomeAmt");
-    if ((expendLexeme === null) === (incomeLexeme === null)) {
-      throw new Error("Cathay detail must have exactly one direction amount.");
-    }
+    if ((expendLexeme === null) === (incomeLexeme === null)) throw new Error("Cathay detail must have exactly one direction amount.");
     const amountLexeme = incomeLexeme ?? expendLexeme!;
     const amount = parseExactDecimalLexeme(amountLexeme);
     if (amount.coefficient < 0n) throw new Error("Cathay amount must be non-negative.");
-    const balance = parseExactDecimalLexeme(requiredNumber(detail, "balance"));
+    const balanceLexeme = requiredNumber(detail, "balance");
+    const balance = parseExactDecimalLexeme(balanceLexeme);
     const accountDate = requireDate(requiredString(detail, "accountDate"), "accountDate");
     const transactionDateTime = requireDateTime(requiredString(detail, "txnDateTime"), "txnDateTime");
     const direction = incomeLexeme === null ? "outflow" : "inflow";
@@ -320,214 +265,167 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
       sequence: sequenceLexeme,
       accountDate,
       transactionDateTime,
+      utcInstantUtcUs: localDateTimeToUtcMicros(transactionDateTime),
       amount,
       direction,
       balance,
-      payload: JSON.stringify({
-        sequenceNumber: sequenceLexeme,
-        accountDate,
-        txnDateTime: transactionDateTime,
-        amount: amountLexeme,
-        amountDirection: direction,
-        balance: requiredNumber(detail, "balance"),
-      }),
+      payload: JSON.stringify({ sequenceNumber: sequenceLexeme, accountDate, txnDateTime: transactionDateTime, amount: amountLexeme, amountDirection: direction, balance: balanceLexeme }),
     } satisfies ValidatedCathayRow;
   });
   return { accountNo, startDate, endDate, rows };
 }
 
-function uuidV7(): string {
+type CanonicalId = Buffer;
+function uuidV7(): CanonicalId {
   const bytes = randomBytes(16);
   const timestamp = BigInt(Date.now());
-  for (let index = 0; index < 6; index += 1) {
-    bytes[index] = Number((timestamp >> BigInt(40 - index * 8)) & 0xffn);
-  }
+  for (let index = 0; index < 6; index += 1) bytes[index] = Number((timestamp >> BigInt(40 - index * 8)) & 0xffn);
   bytes[6] = (bytes[6]! & 0x0f) | 0x70;
   bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  return bytes;
+}
+function idToString(value: unknown): string {
+  const bytes = value instanceof Uint8Array ? Buffer.from(value) : undefined;
+  if (!bytes || bytes.length !== 16) throw new Error("Canonical ID must be a 16-byte UUID blob.");
   const hex = bytes.toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
-
-export function canonicalSqlitePath(ledgerDir: string): string {
-  return join(ledgerDir, CANONICAL_SQLITE_FILE);
+function idFromString(value: string): CanonicalId {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) throw new Error("Canonical ID must be a UUID string.");
+  return Buffer.from(value.replaceAll("-", ""), "hex");
 }
+function blob(value: unknown): CanonicalId { return value instanceof Uint8Array && value.byteLength === 16 ? Buffer.from(value) : (() => { throw new Error("Expected a 16-byte canonical ID blob."); })(); }
+
+export function canonicalSqlitePath(ledgerDir: string): string { return join(ledgerDir, CANONICAL_SQLITE_FILE); }
 
 const SCHEMA = `
+CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at_utc_us INTEGER NOT NULL);
 CREATE TABLE IF NOT EXISTS canonical_commits (
-  commit_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-  commit_id TEXT NOT NULL UNIQUE,
-  recorded_at TEXT NOT NULL,
+  commit_id BLOB PRIMARY KEY CHECK(length(commit_id) = 16),
+  commit_sequence INTEGER NOT NULL UNIQUE,
+  recorded_at_utc_us INTEGER NOT NULL,
   authority_route TEXT NOT NULL
 );
 CREATE TABLE IF NOT EXISTS source_authority_routes (
-  authority_route TEXT PRIMARY KEY,
-  integration_namespace TEXT NOT NULL,
-  stream TEXT NOT NULL,
-  contract_version TEXT NOT NULL
+  authority_route TEXT PRIMARY KEY, integration_namespace TEXT NOT NULL, stream TEXT NOT NULL, contract_version TEXT NOT NULL,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 CREATE TABLE IF NOT EXISTS source_connections (
-  source_connection_id TEXT PRIMARY KEY,
-  integration_namespace TEXT NOT NULL,
-  source_connection_key TEXT NOT NULL,
-  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  source_connection_id BLOB PRIMARY KEY CHECK(length(source_connection_id) = 16),
+  integration_namespace TEXT NOT NULL, source_connection_key TEXT NOT NULL,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   UNIQUE(integration_namespace, source_connection_key)
 );
 CREATE TABLE IF NOT EXISTS identity_epochs (
-  identity_epoch_id TEXT PRIMARY KEY,
-  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
-  epoch_key TEXT NOT NULL,
-  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
-  UNIQUE(source_connection_id, epoch_key)
+  identity_epoch_id BLOB PRIMARY KEY CHECK(length(identity_epoch_id) = 16),
+  source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), epoch_key TEXT NOT NULL,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(source_connection_id, epoch_key)
 );
 CREATE TABLE IF NOT EXISTS source_captures (
-  capture_id TEXT PRIMARY KEY,
-  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
-  identity_epoch_id TEXT NOT NULL REFERENCES identity_epochs(identity_epoch_id),
-  authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
-  stream TEXT NOT NULL,
-  account_no TEXT NOT NULL,
-  observed_at TEXT NOT NULL,
-  scope_start TEXT NOT NULL,
-  scope_end TEXT NOT NULL,
-  completeness TEXT NOT NULL CHECK (completeness = 'complete-range'),
-  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence)
+  capture_id BLOB PRIMARY KEY CHECK(length(capture_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), authority_route TEXT NOT NULL REFERENCES source_authority_routes(authority_route),
+  stream TEXT NOT NULL, account_no TEXT NOT NULL, observed_at TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL,
+  completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 CREATE TABLE IF NOT EXISTS source_records (
-  source_record_id TEXT PRIMARY KEY,
-  capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
-  sequence_lexeme TEXT NOT NULL,
-  payload_json TEXT NOT NULL,
-  UNIQUE(capture_id, sequence_lexeme)
+  source_record_id BLOB PRIMARY KEY CHECK(length(source_record_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), sequence_lexeme TEXT NOT NULL, payload_json TEXT NOT NULL, UNIQUE(capture_id, sequence_lexeme)
 );
 CREATE TABLE IF NOT EXISTS financial_accounts (
-  account_id TEXT PRIMARY KEY,
-  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
-  identity_epoch_id TEXT NOT NULL REFERENCES identity_epochs(identity_epoch_id),
-  stream TEXT NOT NULL,
-  account_no TEXT NOT NULL,
-  account_type TEXT NOT NULL CHECK (account_type IN ('depository', 'credit', 'loan', 'investment', 'other')),
-  currency TEXT NOT NULL,
-  created_commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
-  UNIQUE(source_connection_id, identity_epoch_id, stream, account_no)
+  account_id BLOB PRIMARY KEY CHECK(length(account_id) = 16), source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id),
+  identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id), stream TEXT NOT NULL, account_no TEXT NOT NULL,
+  account_type TEXT NOT NULL CHECK(account_type IN ('depository','credit','loan','investment','other')), currency TEXT NOT NULL,
+  created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(source_connection_id, identity_epoch_id, stream, account_no)
 );
 CREATE TABLE IF NOT EXISTS financial_transactions (
-  transaction_id TEXT PRIMARY KEY,
-  account_id TEXT NOT NULL REFERENCES financial_accounts(account_id),
-  source_sequence TEXT NOT NULL,
-  UNIQUE(account_id, source_sequence)
+  transaction_id BLOB PRIMARY KEY CHECK(length(transaction_id) = 16), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+  source_sequence TEXT NOT NULL, created_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(account_id, source_sequence)
 );
 CREATE TABLE IF NOT EXISTS transaction_revisions (
-  revision_id TEXT PRIMARY KEY,
-  transaction_id TEXT NOT NULL REFERENCES financial_transactions(transaction_id),
-  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
-  capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
-  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
-  revision_number INTEGER NOT NULL,
-  amount_coefficient TEXT NOT NULL,
-  amount_scale INTEGER NOT NULL CHECK (amount_scale >= 0),
-  currency TEXT NOT NULL,
-  direction TEXT NOT NULL CHECK (direction IN ('inflow', 'outflow')),
-  posting_status TEXT NOT NULL CHECK (posting_status IN ('pending', 'posted')),
-  effective_on TEXT NOT NULL,
-  transaction_date_time_local TEXT NOT NULL,
-  time_zone TEXT NOT NULL,
-  time_precision TEXT NOT NULL CHECK (time_precision = 'second'),
-  balance_coefficient TEXT NOT NULL,
-  balance_scale INTEGER NOT NULL CHECK (balance_scale >= 0),
-  UNIQUE(transaction_id, revision_number)
+  revision_id BLOB PRIMARY KEY CHECK(length(revision_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), revision_number INTEGER NOT NULL,
+  amount_coefficient TEXT NOT NULL, amount_scale INTEGER NOT NULL CHECK(amount_scale >= 0), currency TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK(direction IN ('inflow','outflow')), posting_status TEXT NOT NULL CHECK(posting_status IN ('pending','posted')),
+  effective_on TEXT NOT NULL, transaction_date_time_local TEXT NOT NULL, time_zone TEXT NOT NULL,
+  time_precision TEXT NOT NULL CHECK(time_precision = 'second'), time_origin TEXT NOT NULL CHECK(time_origin = 'source_reported'),
+  utc_instant_utc_us INTEGER NOT NULL, UNIQUE(transaction_id, revision_number)
 );
 CREATE TABLE IF NOT EXISTS source_assertions (
-  assertion_id TEXT PRIMARY KEY,
-  transaction_id TEXT NOT NULL REFERENCES financial_transactions(transaction_id),
-  revision_id TEXT NOT NULL REFERENCES transaction_revisions(revision_id),
-  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
-  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
-  UNIQUE(transaction_id, revision_id)
+  assertion_id BLOB PRIMARY KEY CHECK(length(assertion_id) = 16), transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), UNIQUE(transaction_id, revision_id)
 );
 CREATE TABLE IF NOT EXISTS assertion_provenance (
-  assertion_id TEXT NOT NULL REFERENCES source_assertions(assertion_id),
-  source_record_id TEXT NOT NULL REFERENCES source_records(source_record_id),
-  PRIMARY KEY(assertion_id, source_record_id)
+  assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id), source_record_id BLOB NOT NULL REFERENCES source_records(source_record_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), PRIMARY KEY(assertion_id, source_record_id)
 );
 CREATE TABLE IF NOT EXISTS source_sync_states (
-  source_connection_id TEXT NOT NULL REFERENCES source_connections(source_connection_id),
-  account_id TEXT NOT NULL REFERENCES financial_accounts(account_id),
-  stream TEXT NOT NULL,
-  scope_start TEXT NOT NULL,
-  scope_end TEXT NOT NULL,
-  cursor TEXT NOT NULL,
-  last_capture_id TEXT NOT NULL REFERENCES source_captures(capture_id),
-  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence),
+  source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), account_id BLOB NOT NULL REFERENCES financial_accounts(account_id),
+  stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT NOT NULL,
+  last_capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   PRIMARY KEY(source_connection_id, account_id, stream)
 );
 CREATE TABLE IF NOT EXISTS current_transactions (
-  transaction_id TEXT PRIMARY KEY REFERENCES financial_transactions(transaction_id),
-  revision_id TEXT NOT NULL REFERENCES transaction_revisions(revision_id),
-  commit_sequence INTEGER NOT NULL REFERENCES canonical_commits(commit_sequence)
+  transaction_id BLOB PRIMARY KEY REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)
 );
 `;
 
-export function openCanonicalDatabase(
-  ledgerDir: string,
-  options: { readOnly?: boolean } = {},
-): DatabaseSync {
+function tableExists(db: DatabaseSync, name: string): boolean {
+  return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+function applySchemaMigration(db: DatabaseSync): void {
+  const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
+  const version = Number(row.user_version ?? 0);
+  if (version > CANONICAL_SCHEMA_VERSION) throw new Error(`Canonical SQLite schema ${version} is newer than supported ${CANONICAL_SCHEMA_VERSION}.`);
+  if (version === 0 && tableExists(db, "canonical_commits")) throw new Error("Unversioned canonical SQLite schema is not compatible; refusing ad-hoc migration.");
+  if (version === CANONICAL_SCHEMA_VERSION) {
+    if (!tableExists(db, "schema_migrations")) throw new Error("Canonical SQLite schema version metadata is missing.");
+    const migration = db.prepare("SELECT 1 FROM schema_migrations WHERE version = ?").get(CANONICAL_SCHEMA_VERSION);
+    if (!migration) throw new Error("Canonical SQLite schema migration metadata is incomplete.");
+    return;
+  }
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(SCHEMA);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, Date.now() * 1000);
+    db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: boolean } = {}): DatabaseSync {
   const path = canonicalSqlitePath(ledgerDir);
   if (options.readOnly && !existsSync(path)) throw new Error(`Missing canonical SQLite: ${path}`);
   if (!options.readOnly) mkdirSync(ledgerDir, { recursive: true });
   const db = new DatabaseSync(path, options.readOnly ? { readOnly: true } : {});
-  db.exec("PRAGMA foreign_keys = ON");
-  db.exec("PRAGMA busy_timeout = 30000");
-  if (!options.readOnly) {
-    db.exec("PRAGMA journal_mode = WAL");
-    db.exec(SCHEMA);
-    const syncColumns = db.prepare("PRAGMA table_info(source_sync_states)").all() as Array<{ name?: string }>;
-    if (!syncColumns.some((column) => column.name === "cursor")) {
-      db.exec("ALTER TABLE source_sync_states ADD COLUMN cursor TEXT NOT NULL DEFAULT ''");
+  try {
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec("PRAGMA busy_timeout = 30000");
+    if (!options.readOnly) { db.exec("PRAGMA journal_mode = WAL"); applySchemaMigration(db); }
+    else {
+      const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
+      if (Number(row.user_version ?? 0) !== CANONICAL_SCHEMA_VERSION) throw new Error("Canonical SQLite schema is missing or unsupported for read-only access.");
     }
-  }
-  return db;
+    return db;
+  } catch (error) { db.close(); throw error; }
 }
 
 export type CanonicalAmount = { coefficient: string; scale: number };
 export type CanonicalTransaction = {
-  id: string;
-  accountId: string;
-  accountNo: string;
-  sourceSequence: string;
-  amount: CanonicalAmount;
-  currency: "TWD";
-  direction: "inflow" | "outflow";
-  postingStatus: "posted";
-  effectiveOn: string;
-  transactionDateTimeLocal: string;
-  timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE;
-  balance: CanonicalAmount;
-  revisionId: string;
-  commitSequence: number;
+  id: string; accountId: string; accountNo: string; sourceSequence: string; amount: CanonicalAmount; currency: "TWD";
+  direction: "inflow" | "outflow"; postingStatus: "posted"; effectiveOn: string; transactionDateTimeLocal: string;
+  timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE; timePrecision: "second"; timeOrigin: "source_reported";
+  utcInstantUtcUs: number; revisionId: string; commitSequence: number;
 };
-
 export type CathayCanonicalCurrentQueryRequest = { kind: "current" };
-export type CathayCanonicalCurrentQueryResult = {
-  status: "ok";
-  kind: "current";
-  accounts: Array<{ id: string; accountNo: string; currency: "TWD"; accountType: "depository" }>;
-  transactions: CanonicalTransaction[];
-  commitSequence: number;
-};
-export type CathayCanonicalHistoricalQueryRequest = {
-  kind: "historical";
-  cutoff: { kind: "both"; financialAt: string; knowledgeAt: string };
-};
-export type CathayCanonicalHistoricalQueryResult = {
-  status: "ok";
-  kind: "historical";
-  cutoff: CathayCanonicalHistoricalQueryRequest["cutoff"];
-  transactions: CanonicalTransaction[];
-};
-export type CathayCanonicalLineageQueryRequest = {
-  kind: "lineage";
-  subject: { kind: "transaction"; id: string };
-};
+export type CathayCanonicalCurrentQueryResult = { status: "ok"; kind: "current"; accounts: Array<{ id: string; accountNo: string; currency: "TWD"; accountType: "depository" }>; transactions: CanonicalTransaction[]; commitSequence: number };
+export type CathayCanonicalHistoricalQueryRequest = { kind: "historical"; cutoff: { kind: "both"; financialAt: string; knowledgeAt: string } };
+export type CathayCanonicalHistoricalQueryResult = { status: "ok"; kind: "historical"; cutoff: CathayCanonicalHistoricalQueryRequest["cutoff"]; transactions: CanonicalTransaction[] };
+export type CathayCanonicalLineageQueryRequest = { kind: "lineage"; subject: { kind: "transaction"; id: string } };
 export type CathayCanonicalLineageEntry = {
   transaction: { id: string; accountId: string; sourceSequence: string };
   revision: CanonicalTransactionRevision;
@@ -536,336 +434,206 @@ export type CathayCanonicalLineageEntry = {
   capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
   provenance: Array<{ sourceRecordId: string; captureId: string }>;
 };
-export type CathayCanonicalLineageQueryResult = {
-  status: "ok";
-  kind: "lineage";
-  subject: CathayCanonicalLineageQueryRequest["subject"];
-  entries: CathayCanonicalLineageEntry[];
-};
+export type CathayCanonicalLineageQueryResult = { status: "ok"; kind: "lineage"; subject: CathayCanonicalLineageQueryRequest["subject"]; entries: CathayCanonicalLineageEntry[] };
 export type CanonicalTransactionRevision = CanonicalTransaction & { transactionId: string };
-
 export interface CathayCanonicalFinancialQuery {
   current(request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult>;
   historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult>;
   lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult>;
 }
+export type CathayCommitTransactionResult = { transactionId: string; revisionId: string; sourceSequence: string; direction: "inflow" | "outflow"; amount: CanonicalAmount; revisionCreated: boolean };
+export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountId: string; transactions: CathayCommitTransactionResult[] };
 
-export type CathayCommitTransactionResult = {
-  transactionId: string;
-  revisionId: string;
-  sourceSequence: string;
-  direction: "inflow" | "outflow";
-  amount: CanonicalAmount;
-  revisionCreated: boolean;
-};
-export type CathayCanonicalCommitResult = {
-  captureId: string;
-  commitSequence: number;
-  accountId: string;
-  transactions: CathayCommitTransactionResult[];
-};
-
-function dbRow<T extends Record<string, unknown>>(value: unknown): T {
-  return value as T;
-}
-
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
-function sameRevision(
-  row: Record<string, unknown>,
-  detail: ValidatedCathayRow,
-): boolean {
+function dbRow<T extends Record<string, unknown>>(value: unknown): T { return value as T; }
+function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow): boolean {
   return row.amount_coefficient === detail.amount.coefficient.toString()
-    && row.amount_scale === detail.amount.scale
-    && row.direction === detail.direction
-    && row.effective_on === detail.accountDate
-    && row.transaction_date_time_local === detail.transactionDateTime
-    && row.balance_coefficient === detail.balance.coefficient.toString()
-    && row.balance_scale === detail.balance.scale;
+    && row.amount_scale === detail.amount.scale && row.direction === detail.direction
+    && row.effective_on === detail.accountDate && row.transaction_date_time_local === detail.transactionDateTime
+    && row.time_zone === CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE && row.time_precision === "second"
+    && row.time_origin === "source_reported" && Number(row.utc_instant_utc_us) === detail.utcInstantUtcUs;
+}
+function recordedAtUtcUs(value: string): number {
+  const milliseconds = Date.parse(value);
+  if (!Number.isSafeInteger(milliseconds)) throw new Error("Invalid observation time.");
+  return milliseconds * 1000;
 }
 
-export function commitCathayDomesticDeposit(
-  ledgerDir: string,
-  input: CathayDomesticDepositCaptureInput,
-): CathayCanonicalCommitResult {
-  const validated = validateCapture(input);
+function commitCathayDomesticDepositOnce(ledgerDir: string, input: CathayDomesticDepositCaptureInput, validated: ValidatedCathayCapture): CathayCanonicalCommitResult {
   const db = openCanonicalDatabase(ledgerDir);
   let inTransaction = false;
   try {
     db.exec("BEGIN IMMEDIATE");
     inTransaction = true;
-    db.prepare(
-      "INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version) VALUES (?, ?, ?, ?)",
-    ).run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1");
-    const commitInsert = db.prepare(
-      "INSERT INTO canonical_commits(commit_id, recorded_at, authority_route) VALUES (?, ?, ?)",
-    ).run(uuidV7(), nowIso(), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY);
-    const commitSequence = Number(commitInsert.lastInsertRowid);
-    const connectionExisting = db.prepare(
-      "SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?",
-    ).get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
-    const sourceConnectionId = connectionExisting
-      ? String(dbRow<{ source_connection_id: string }>(connectionExisting).source_connection_id)
-      : uuidV7();
-    if (!connectionExisting) {
-      db.prepare(
-        "INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_sequence) VALUES (?, ?, ?, ?)",
-      ).run(sourceConnectionId, CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId, commitSequence);
-    }
-    const epochExisting = db.prepare(
-      "SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?",
-    ).get(sourceConnectionId, input.identityEpoch);
-    const identityEpochId = epochExisting
-      ? String(dbRow<{ identity_epoch_id: string }>(epochExisting).identity_epoch_id)
-      : uuidV7();
-    if (!epochExisting) {
-      db.prepare(
-        "INSERT INTO identity_epochs(identity_epoch_id, source_connection_id, epoch_key, created_commit_sequence) VALUES (?, ?, ?, ?)",
-      ).run(identityEpochId, sourceConnectionId, input.identityEpoch, commitSequence);
-    }
-    const accountExisting = db.prepare(
-      "SELECT account_id, currency, account_type FROM financial_accounts WHERE source_connection_id = ? AND identity_epoch_id = ? AND stream = ? AND account_no = ?",
-    ).get(sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo);
-    const accountId = accountExisting
-      ? String(dbRow<{ account_id: string }>(accountExisting).account_id)
-      : uuidV7();
+    const commitId = uuidV7();
+    const maxSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0);
+    const commitSequence = maxSequence + 1;
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route) VALUES (?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(input.observedAt), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY);
+    db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1", commitId);
+    const connectionExisting = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
+    const sourceConnectionId = connectionExisting ? blob(dbRow<{ source_connection_id: unknown }>(connectionExisting).source_connection_id) : uuidV7();
+    if (!connectionExisting) db.prepare("INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_id) VALUES (?, ?, ?, ?)").run(sourceConnectionId, CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId, commitId);
+    const epochExisting = db.prepare("SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?").get(sourceConnectionId, input.identityEpoch);
+    const identityEpochId = epochExisting ? blob(dbRow<{ identity_epoch_id: unknown }>(epochExisting).identity_epoch_id) : uuidV7();
+    if (!epochExisting) db.prepare("INSERT INTO identity_epochs(identity_epoch_id, source_connection_id, epoch_key, created_commit_id) VALUES (?, ?, ?, ?)").run(identityEpochId, sourceConnectionId, input.identityEpoch, commitId);
+    const accountExisting = db.prepare("SELECT account_id, currency, account_type FROM financial_accounts WHERE source_connection_id = ? AND identity_epoch_id = ? AND stream = ? AND account_no = ?").get(sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo);
+    const accountId = accountExisting ? blob(dbRow<{ account_id: unknown }>(accountExisting).account_id) : uuidV7();
     if (accountExisting) {
       const account = dbRow<{ currency: string; account_type: string }>(accountExisting);
-      if (account.currency !== input.currency || account.account_type !== "depository") {
-        throw new Error("Cathay account identity has conflicting required classification.");
-      }
-    } else {
-      db.prepare(
-        "INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_sequence) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-      ).run(accountId, sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo, "depository", input.currency, commitSequence);
-    }
+      if (account.currency !== input.currency || account.account_type !== "depository") throw new Error("Cathay account identity has conflicting required classification.");
+    } else db.prepare("INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(accountId, sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo, "depository", input.currency, commitId);
     const captureId = uuidV7();
-    db.prepare(
-      "INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, commit_sequence) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    ).run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, "complete-range", commitSequence);
+    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, "complete-range", commitId);
 
     const transactionResults: CathayCommitTransactionResult[] = [];
     for (const detail of validated.rows) {
       const sourceRecordId = uuidV7();
-      db.prepare(
-        "INSERT INTO source_records(source_record_id, capture_id, sequence_lexeme, payload_json) VALUES (?, ?, ?, ?)",
-      ).run(sourceRecordId, captureId, detail.sequence, detail.payload);
-      const transactionExisting = db.prepare(
-        "SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?",
-      ).get(accountId, detail.sequence);
-      const transactionId = transactionExisting
-        ? String(dbRow<{ transaction_id: string }>(transactionExisting).transaction_id)
-        : uuidV7();
-      if (!transactionExisting) {
-        db.prepare(
-          "INSERT INTO financial_transactions(transaction_id, account_id, source_sequence) VALUES (?, ?, ?)",
-        ).run(transactionId, accountId, detail.sequence);
-      }
-      const latest = db.prepare(
-        "SELECT * FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number DESC LIMIT 1",
-      ).get(transactionId);
+      db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, payload_json) VALUES (?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, detail.sequence, detail.payload);
+      const transactionExisting = db.prepare("SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?").get(accountId, detail.sequence);
+      const transactionId = transactionExisting ? blob(dbRow<{ transaction_id: unknown }>(transactionExisting).transaction_id) : uuidV7();
+      if (!transactionExisting) db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, detail.sequence, commitId);
+      const latest = db.prepare("SELECT * FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number DESC LIMIT 1").get(transactionId);
       const latestRow = latest ? dbRow<Record<string, unknown>>(latest) : undefined;
       const revisionCreated = !latestRow || !sameRevision(latestRow, detail);
-      let revisionId = latestRow ? String(latestRow.revision_id) : uuidV7();
+      let revisionId = latestRow ? blob(latestRow.revision_id) : uuidV7();
       if (revisionCreated) {
         revisionId = uuidV7();
         const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
-        db.prepare(
-          `INSERT INTO transaction_revisions(
-            revision_id, transaction_id, source_record_id, capture_id, commit_sequence, revision_number,
-            amount_coefficient, amount_scale, currency, direction, posting_status, effective_on,
-            transaction_date_time_local, time_zone, time_precision, balance_coefficient, balance_scale
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        ).run(revisionId, transactionId, sourceRecordId, captureId, commitSequence, revisionNumber,
-          detail.amount.coefficient.toString(), detail.amount.scale, input.currency, detail.direction, "posted",
-          detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second",
-          detail.balance.coefficient.toString(), detail.balance.scale);
-        db.prepare(
-          "INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_sequence) VALUES (?, ?, ?, ?, ?)",
-        ).run(uuidV7(), transactionId, revisionId, sourceRecordId, commitSequence);
-        db.prepare(
-          "INSERT INTO current_transactions(transaction_id, revision_id, commit_sequence) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_sequence = excluded.commit_sequence",
-        ).run(transactionId, revisionId, commitSequence);
+        db.prepare(`INSERT INTO transaction_revisions(
+          revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
+          direction, posting_status, effective_on, transaction_date_time_local, time_zone, time_precision, time_origin, utc_instant_utc_us
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+          revisionId, transactionId, sourceRecordId, captureId, commitId, revisionNumber, detail.amount.coefficient.toString(), detail.amount.scale,
+          input.currency, detail.direction, "posted", detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
+          "second", "source_reported", detail.utcInstantUtcUs,
+        );
+        const assertionId = uuidV7();
+        db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
+        db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, commitId);
       }
-      const assertion = db.prepare(
-        "SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?",
-      ).get(transactionId, revisionId);
+      const assertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
       if (!assertion) throw new Error("Canonical assertion was not created.");
-      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id) VALUES (?, ?)")
-        .run(String(dbRow<{ assertion_id: string }>(assertion).assertion_id), sourceRecordId);
-      transactionResults.push({
-        transactionId,
-        revisionId,
-        sourceSequence: detail.sequence,
-        direction: detail.direction,
-        amount: { coefficient: detail.amount.coefficient.toString(), scale: detail.amount.scale },
-        revisionCreated,
-      });
+      const assertionId = blob(dbRow<{ assertion_id: unknown }>(assertion).assertion_id);
+      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, commit_id) VALUES (?, ?, ?)").run(assertionId, sourceRecordId, commitId);
+      transactionResults.push({ transactionId: idToString(transactionId), revisionId: idToString(revisionId), sourceSequence: detail.sequence, direction: detail.direction, amount: { coefficient: detail.amount.coefficient.toString(), scale: detail.amount.scale }, revisionCreated });
     }
-    db.prepare(
-      `INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_sequence)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET
-         scope_start = excluded.scope_start, scope_end = excluded.scope_end,
-         cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_sequence = excluded.commit_sequence`,
-    ).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor, captureId, commitSequence);
+    db.prepare(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET scope_start = excluded.scope_start,
+      scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor, captureId, commitId);
     db.exec("COMMIT");
     inTransaction = false;
-    return { captureId, commitSequence, accountId, transactions: transactionResults };
+    return { captureId: idToString(captureId), commitSequence, accountId: idToString(accountId), transactions: transactionResults };
   } catch (error) {
     if (inTransaction) db.exec("ROLLBACK");
     throw error;
+  } finally { db.close(); }
+}
+
+const writerQueues = new Map<string, Promise<void>>();
+async function withCanonicalWriter<T>(ledgerDir: string, operation: () => T): Promise<T> {
+  const key = canonicalSqlitePath(ledgerDir);
+  const previous = writerQueues.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const turn = new Promise<void>((resolve) => { release = resolve; });
+  const queued = previous.then(() => turn);
+  writerQueues.set(key, queued);
+  await previous;
+  try {
+    for (let attempt = 0; ; attempt += 1) {
+      try { return operation(); }
+      catch (error) {
+        if (attempt >= 2 || !/busy|locked/i.test(String(error))) throw error;
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    }
   } finally {
-    db.close();
+    release();
+    if (writerQueues.get(key) === queued) writerQueues.delete(key);
   }
 }
 
-function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount {
-  return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) };
+export function commitCathayDomesticDeposit(ledgerDir: string, input: CathayDomesticDepositCaptureInput): Promise<CathayCanonicalCommitResult> {
+  const validated = validateCapture(input);
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositOnce(ledgerDir, input, validated));
 }
 
+function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }
 function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction {
   return {
-    id: String(row.transaction_id),
-    accountId: String(row.account_id),
-    accountNo: String(row.account_no),
-    sourceSequence: String(row.source_sequence),
-    amount: amountFromRow(row),
-    currency: "TWD",
-    direction: row.direction as "inflow" | "outflow",
-    postingStatus: "posted",
-    effectiveOn: String(row.effective_on),
-    transactionDateTimeLocal: String(row.transaction_date_time_local),
-    timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
-    balance: { coefficient: String(row.balance_coefficient), scale: Number(row.balance_scale) },
-    revisionId: String(row.revision_id),
-    commitSequence: Number(row.commit_sequence),
+    id: idToString(row.transaction_id), accountId: idToString(row.account_id), accountNo: String(row.account_no), sourceSequence: String(row.source_sequence),
+    amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: "posted", effectiveOn: String(row.effective_on),
+    transactionDateTimeLocal: String(row.transaction_date_time_local), timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, timePrecision: "second", timeOrigin: "source_reported",
+    utcInstantUtcUs: Number(row.utc_instant_utc_us), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence),
   };
 }
-
 function transactionRevisionFromRow(row: Record<string, unknown>): CanonicalTransactionRevision {
   const transaction = transactionFromRow(row);
-  return {
-    ...transaction,
-    id: String(row.revision_id),
-    transactionId: transaction.id,
-  };
+  return { ...transaction, id: idToString(row.revision_id), transactionId: transaction.id };
 }
 
 class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQuery {
   private readonly ledgerDir: string;
 
-  constructor(ledgerDir: string) {
-    this.ledgerDir = ledgerDir;
-  }
-
+  constructor(ledgerDir: string) { this.ledgerDir = ledgerDir; }
   async current(_request: CathayCanonicalCurrentQueryRequest): Promise<CathayCanonicalCurrentQueryResult> {
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      const accounts = (db.prepare(
-        "SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no",
-      ).all() as Record<string, unknown>[]).map((row) => ({
-        id: String(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const,
-      }));
-      const rows = db.prepare(
-        `SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence,
-          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
-          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
-          r.revision_id, r.commit_sequence
-         FROM current_transactions c
-         JOIN financial_transactions t ON t.transaction_id = c.transaction_id
-         JOIN financial_accounts a ON a.account_id = t.account_id
-         JOIN transaction_revisions r ON r.revision_id = c.revision_id
-         ORDER BY a.account_no, t.source_sequence`,
-      ).all() as Record<string, unknown>[];
-      return {
-        status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow),
-        commitSequence: rows.reduce((max, row) => Math.max(max, Number(row.commit_sequence)), 0),
-      };
-    } finally {
-      db.close();
-    }
+      const accounts = (db.prepare("SELECT account_id AS id, account_no AS accountNo, currency, account_type AS accountType FROM financial_accounts ORDER BY account_no").all() as Record<string, unknown>[]).map((row) => ({ id: idToString(row.id), accountNo: String(row.accountNo), currency: "TWD" as const, accountType: "depository" as const }));
+      const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
+        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM current_transactions current_row
+        JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
+        JOIN transaction_revisions r ON r.revision_id = current_row.revision_id JOIN canonical_commits c ON c.commit_id = current_row.commit_id
+        ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
+      return { status: "ok", kind: "current", accounts, transactions: rows.map(transactionFromRow), commitSequence: rows.reduce((max, row) => Math.max(max, Number(row.commit_sequence)), 0) };
+    } finally { db.close(); }
   }
-
   async historical(request: CathayCanonicalHistoricalQueryRequest): Promise<CathayCanonicalHistoricalQueryResult> {
-    if (request.cutoff.kind !== "both" || !/^\d+$/.test(request.cutoff.knowledgeAt)) {
-      throw new Error("Canonical historical queries require financial-time and knowledge-time cutoffs.");
-    }
+    if (request.cutoff.kind !== "both" || !/^\d{4}-\d{2}-\d{2}$/.test(request.cutoff.financialAt) || !/^\d+$/.test(request.cutoff.knowledgeAt)) throw new Error("Canonical historical queries require financial-time and knowledge-time cutoffs.");
+    requireDate(request.cutoff.financialAt, "historical financialAt");
+    const knowledgeAt = Number(request.cutoff.knowledgeAt);
+    if (!Number.isSafeInteger(knowledgeAt)) throw new Error("Canonical historical knowledgeAt is outside the supported sequence range.");
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      const rows = db.prepare(
-        `SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence,
-          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
-          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
-          r.revision_id, r.commit_sequence
-         FROM financial_transactions t
-         JOIN financial_accounts a ON a.account_id = t.account_id
-         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id
-         JOIN canonical_commits c ON c.commit_sequence = r.commit_sequence
-         WHERE r.effective_on <= ? AND c.commit_sequence <= ?
-           AND NOT EXISTS (
-             SELECT 1 FROM transaction_revisions newer
-             JOIN canonical_commits newer_commit ON newer_commit.commit_sequence = newer.commit_sequence
-             WHERE newer.transaction_id = r.transaction_id
-               AND newer.effective_on <= ?
-               AND newer_commit.commit_sequence <= ?
-               AND newer_commit.commit_sequence > c.commit_sequence
-           )
-         ORDER BY a.account_no, t.source_sequence`,
-      ).all(request.cutoff.financialAt, Number(request.cutoff.knowledgeAt), request.cutoff.financialAt, Number(request.cutoff.knowledgeAt)) as Record<string, unknown>[];
+      const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
+        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
+        JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
+        WHERE r.effective_on <= ? AND c.commit_sequence <= ? AND NOT EXISTS (
+          SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
+          WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
+        ) ORDER BY a.account_no, t.source_sequence`).all(request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
       return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map(transactionFromRow) };
-    } finally {
-      db.close();
-    }
+    } finally { db.close(); }
   }
-
   async lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult> {
-    if (request.subject.kind !== "transaction" || !request.subject.id) {
-      throw new Error("Cathay lineage queries require a transaction subject.");
-    }
+    if (request.subject.kind !== "transaction" || !request.subject.id) throw new Error("Cathay lineage queries require a transaction subject.");
+    const transactionId = idFromString(request.subject.id);
     const db = openCanonicalDatabase(this.ledgerDir, { readOnly: true });
     try {
-      const revisionRows = db.prepare(
-        `SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no,
-          r.amount_coefficient, r.amount_scale, r.currency, r.direction, r.posting_status,
-          r.effective_on, r.transaction_date_time_local, r.balance_coefficient, r.balance_scale,
-          r.revision_id, r.commit_sequence, r.source_record_id, r.capture_id,
-          sr.sequence_lexeme, sr.payload_json, sc.observed_at, sc.scope_start, sc.scope_end, sc.authority_route,
-          sa.assertion_id
-         FROM financial_transactions t
-         JOIN financial_accounts a ON a.account_id = t.account_id
-         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id
-         JOIN source_records sr ON sr.source_record_id = r.source_record_id
-         JOIN source_captures sc ON sc.capture_id = r.capture_id
-         JOIN source_assertions sa ON sa.revision_id = r.revision_id
-         WHERE t.transaction_id = ?
-         ORDER BY r.revision_number`,
-      ).all(request.subject.id) as Record<string, unknown>[];
+      const revisionRows = db.prepare(`SELECT t.transaction_id, t.account_id, t.source_sequence, a.account_no, r.amount_coefficient, r.amount_scale, r.currency,
+        r.direction, r.posting_status, r.effective_on, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence, r.source_record_id, r.capture_id, sr.sequence_lexeme, sr.payload_json,
+        sc.observed_at, sc.scope_start, sc.scope_end, sc.authority_route, sa.assertion_id FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
+        JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
+        JOIN source_records sr ON sr.source_record_id = r.source_record_id JOIN source_captures sc ON sc.capture_id = r.capture_id
+        JOIN source_assertions sa ON sa.revision_id = r.revision_id WHERE t.transaction_id = ? ORDER BY r.revision_number`).all(transactionId) as Record<string, unknown>[];
       const entries = revisionRows.map((row) => {
-        const provenance = db.prepare(
-          `SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId
-           FROM assertion_provenance p JOIN source_records sr ON sr.source_record_id = p.source_record_id
-           WHERE p.assertion_id = ? ORDER BY p.source_record_id`,
-        ).all(String(row.assertion_id)) as Record<string, unknown>[];
+        const assertionId = blob(row.assertion_id);
+        const provenance = db.prepare(`SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId FROM assertion_provenance p
+          JOIN source_records sr ON sr.source_record_id = p.source_record_id WHERE p.assertion_id = ? ORDER BY p.source_record_id`).all(assertionId) as Record<string, unknown>[];
         const revision = transactionRevisionFromRow(row);
         return {
-          transaction: { id: String(row.transaction_id), accountId: String(row.account_id), sourceSequence: String(row.source_sequence) },
+          transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },
           revision,
-          assertion: { id: String(row.assertion_id), revisionId: String(row.revision_id), commitSequence: Number(row.commit_sequence) },
-          sourceRecord: { id: String(row.source_record_id), captureId: String(row.capture_id), sequence: String(row.sequence_lexeme), payload: String(row.payload_json) },
-          capture: { id: String(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
-          provenance: provenance.map((item) => ({ sourceRecordId: String(item.sourceRecordId), captureId: String(item.captureId) })),
+          assertion: { id: idToString(row.assertion_id), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence) },
+          sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), payload: String(row.payload_json) },
+          capture: { id: idToString(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
+          provenance: provenance.map((item) => ({ sourceRecordId: idToString(item.sourceRecordId), captureId: idToString(item.captureId) })),
         } satisfies CathayCanonicalLineageEntry;
       });
       return { status: "ok", kind: "lineage", subject: request.subject, entries };
-    } finally {
-      db.close();
-    }
+    } finally { db.close(); }
   }
 }
 
-export function createCathayCanonicalFinancialQuery(ledgerDir: string): CathayCanonicalFinancialQuery {
-  return new CathayCanonicalFinancialQueryAdapter(ledgerDir);
-}
+export function createCathayCanonicalFinancialQuery(ledgerDir: string): CathayCanonicalFinancialQuery { return new CathayCanonicalFinancialQueryAdapter(ledgerDir); }

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1593,12 +1593,7 @@ function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerive
       db.prepare("INSERT INTO derived_scope_coordinates(coordinate_id, run_id, transaction_id, field_name, producer_id, origin, rule_lineage, output_state, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)").run(coordinateId, runId, transactionId, coordinate.field, input.producerId, origin, input.ruleLineage, coordinate.state, commitId);
       const existingCurrent = db.prepare(`SELECT f.origin, f.derived_assertion_id, f.user_assertion_id FROM current_transaction_fields f WHERE f.transaction_id = ? AND f.field_name = ?`).get(transactionId, coordinate.field) as Record<string, unknown> | undefined;
       const conflicting = db.prepare(`SELECT da.assertion_id, da.producer_id, da.origin, da.rule_lineage FROM derived_assertions da
-        JOIN derived_assertion_lifecycle_events e ON e.assertion_id = da.assertion_id
-        JOIN canonical_commits c ON c.commit_id = e.commit_id
         WHERE da.transaction_id = ? AND da.field_name = ? AND (da.producer_id <> ? OR da.origin <> ? OR da.rule_lineage <> ?)
-        AND e.event_kind NOT IN ('withdrawn','superseded')
-        AND NOT EXISTS (SELECT 1 FROM derived_assertion_lifecycle_events newer JOIN canonical_commits nc ON nc.commit_id = newer.commit_id
-          WHERE newer.assertion_id = e.assertion_id AND (nc.commit_sequence > c.commit_sequence OR (nc.commit_sequence = c.commit_sequence AND newer.rowid > e.rowid)))
         LIMIT 1`).get(transactionId, coordinate.field, input.producerId, origin, input.ruleLineage) as Record<string, unknown> | undefined;
       if (conflicting) throw new Error("A different derived producer or origin cannot supersede the current lineage.");
       const latest = db.prepare(`SELECT da.* FROM derived_assertions da JOIN canonical_commits c ON c.commit_id = da.commit_id

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -915,6 +915,14 @@ CREATE TABLE IF NOT EXISTS projection_generations (
   switched_commit_id BLOB REFERENCES canonical_commits(commit_id),
   UNIQUE(generation_id, status)
 );
+CREATE TABLE IF NOT EXISTS projection_generation_provenance (
+  event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
+  generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+  event_kind TEXT NOT NULL CHECK(event_kind IN ('created','validated','switched','knowledge')),
+  event_source TEXT NOT NULL CHECK(event_source IN ('migration','rebuild','routine')),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(generation_id, event_kind, event_source, commit_id)
+);
 CREATE TABLE IF NOT EXISTS active_projection_generation (
   singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
   generation_id INTEGER NOT NULL UNIQUE REFERENCES projection_generations(generation_id),
@@ -928,6 +936,16 @@ CREATE TABLE IF NOT EXISTS projection_generation_transactions (
   revision_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
   PRIMARY KEY(generation_id, transaction_id),
   UNIQUE(generation_id, revision_id)
+);
+CREATE TABLE IF NOT EXISTS projection_generation_transaction_selection (
+  generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id),
+  revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+  selection_commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  selection_kind TEXT NOT NULL CHECK(selection_kind IN ('source_lifecycle','rebuild','migration')),
+  PRIMARY KEY(generation_id, transaction_id),
+  UNIQUE(generation_id, revision_id),
+  FOREIGN KEY(generation_id, transaction_id) REFERENCES projection_generation_transactions(generation_id, transaction_id)
 );
 CREATE TABLE IF NOT EXISTS projection_generation_transaction_fields (
   generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
@@ -944,6 +962,7 @@ CREATE TABLE IF NOT EXISTS projection_generation_transaction_fields (
 );
 CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_active ON projection_generation_transactions(generation_id, transaction_id, revision_id);
 CREATE INDEX IF NOT EXISTS idx_projection_generation_transactions_revision ON projection_generation_transactions(generation_id, revision_id, projection_commit_id);
+CREATE INDEX IF NOT EXISTS idx_projection_generation_selection_commit ON projection_generation_transaction_selection(generation_id, selection_commit_id, selection_kind, transaction_id);
 CREATE INDEX IF NOT EXISTS idx_projection_generation_fields_active ON projection_generation_transaction_fields(generation_id, transaction_id, field_name, projection_commit_id);
 CREATE INDEX IF NOT EXISTS idx_projection_generations_status ON projection_generations(status, build_cutoff_commit_sequence, generation_id);
 CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_switch_insert
@@ -962,6 +981,12 @@ CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_commit_update
 BEFORE UPDATE OF generation_id, switched_commit_id ON active_projection_generation
 WHEN NEW.switched_commit_id IS NOT (SELECT switched_commit_id FROM projection_generations WHERE generation_id = NEW.generation_id)
 BEGIN SELECT RAISE(ABORT, 'active projection switch commit does not match generation'); END;
+CREATE TRIGGER IF NOT EXISTS trg_projection_generation_provenance_no_update
+BEFORE UPDATE ON projection_generation_provenance
+BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
+CREATE TRIGGER IF NOT EXISTS trg_projection_generation_provenance_no_delete
+BEFORE DELETE ON projection_generation_provenance
+BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
 CREATE TRIGGER IF NOT EXISTS trg_projection_generation_fields_integrity_insert
 BEFORE INSERT ON projection_generation_transaction_fields
 WHEN NOT EXISTS (
@@ -1526,18 +1551,39 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     const latest = db.prepare("SELECT commit_id, commit_sequence FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as { commit_id?: unknown; commit_sequence?: number } | undefined;
     const latestCommit = latest?.commit_id ? blob(latest.commit_id) : undefined;
     let latestSequence = Number(latest?.commit_sequence ?? 0);
-    const generationExists = db.prepare("SELECT 1 FROM projection_generations WHERE generation_id = 1").get();
+    const existingGeneration = db.prepare(`SELECT created_commit_id, switched_commit_id
+      FROM projection_generations WHERE generation_id = 1`).get() as { created_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
+    const generationExists = Boolean(existingGeneration);
+    // A pre-typed v7 database may already have an active generation whose
+    // switch boundary is older than the latest routine commit. Migration must
+    // preserve that immutable activation provenance; advancing the pointer to
+    // the latest commit would make the trigger reject a valid database and
+    // would silently turn a routine knowledge commit into a switch event.
+    const generationSwitchCommit = existingGeneration?.switched_commit_id
+      ? blob(existingGeneration.switched_commit_id)
+      : latestCommit;
     if (!generationExists) {
       db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id, validated_commit_id, switched_commit_id)
       VALUES (1, 'active', ?, 'canonical/projection/v1', ?, ?, ?)`).run(latestSequence, latestCommit ?? null, latestCommit ?? null, latestCommit ?? null);
       db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
         SELECT 1, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run();
+      db.prepare(`INSERT INTO projection_generation_transaction_selection(generation_id, transaction_id, revision_id, selection_commit_id, selection_kind)
+        SELECT 1, transaction_id, revision_id, projection_commit_id, 'migration' FROM current_transactions`).run();
       db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
         SELECT 1, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run();
     }
     if (injectMigrationFailure === "v6-v7-after-generation-copy") throw new Error("Injected v6-v7 migration failure after generation copy.");
+    const existingPointer = db.prepare("SELECT switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { switched_commit_id?: unknown } | undefined;
+    if (existingGeneration && existingPointer && !canonicalIdsEqual(existingPointer.switched_commit_id, generationSwitchCommit)) {
+      throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
+    }
     db.prepare(`INSERT INTO active_projection_generation(singleton_id, generation_id, switched_commit_id)
-      VALUES (1, 1, ?) ON CONFLICT(singleton_id) DO UPDATE SET generation_id = excluded.generation_id, switched_commit_id = excluded.switched_commit_id`).run(latestCommit ?? null);
+      VALUES (1, 1, ?) ON CONFLICT(singleton_id) DO UPDATE SET generation_id = excluded.generation_id, switched_commit_id = excluded.switched_commit_id`).run(generationSwitchCommit ?? null);
+    if (generationSwitchCommit) {
+      recordProjectionGenerationEventIfMissing(db, 1, "created", "migration", generationSwitchCommit);
+      recordProjectionGenerationEventIfMissing(db, 1, "validated", "migration", generationSwitchCommit);
+      recordProjectionGenerationEventIfMissing(db, 1, "switched", "migration", generationSwitchCommit);
+    }
     if (latestCommit) db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(latestCommit);
     if (injectMigrationFailure === "v6-v7-after-pointer") throw new Error("Injected v6-v7 migration failure after active pointer.");
     db.prepare("INSERT OR REPLACE INTO schema_migrations(version, applied_at_utc_us) VALUES (7, ?)").run(currentUtcMicros());
@@ -1588,6 +1634,62 @@ function canonicalIdsEqual(left: unknown, right: unknown): boolean {
   return Buffer.compare(Buffer.from(left), Buffer.from(right)) === 0;
 }
 
+type ProjectionGenerationEventKind = "created" | "validated" | "switched" | "knowledge";
+type ProjectionGenerationEventSource = "migration" | "rebuild" | "routine";
+
+function recordProjectionGenerationEvent(
+  db: DatabaseSync,
+  generationId: number,
+  eventKind: ProjectionGenerationEventKind,
+  eventSource: ProjectionGenerationEventSource,
+  commitId: CanonicalId,
+): void {
+  db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id)
+    VALUES (?, ?, ?, ?, ?)`).run(uuidV7(), generationId, eventKind, eventSource, commitId);
+}
+
+function recordProjectionGenerationEventIfMissing(
+  db: DatabaseSync,
+  generationId: number,
+  eventKind: ProjectionGenerationEventKind,
+  eventSource: ProjectionGenerationEventSource,
+  commitId: CanonicalId,
+): void {
+  if (db.prepare("SELECT 1 FROM projection_generation_provenance WHERE generation_id = ? AND event_kind = ?").get(generationId, eventKind)) return;
+  recordProjectionGenerationEvent(db, generationId, eventKind, eventSource, commitId);
+}
+
+/** Existing v7 databases predate the typed provenance tables. Backfill only
+ * from persisted generation/current rows; no synthetic canonical commit is
+ * created, and all future changes use append-only events. */
+function backfillProjectionProvenance(db: DatabaseSync): void {
+  const generations = db.prepare(`SELECT generation_id, created_commit_id, validated_commit_id, switched_commit_id
+    FROM projection_generations ORDER BY generation_id`).all() as Array<Record<string, unknown>>;
+  for (const generation of generations) {
+    const generationId = Number(generation.generation_id);
+    const created = generation.created_commit_id ? blob(generation.created_commit_id) : undefined;
+    const validated = generation.validated_commit_id ? blob(generation.validated_commit_id) : undefined;
+    const switched = generation.switched_commit_id ? blob(generation.switched_commit_id) : undefined;
+    const eventSource = (commitId: CanonicalId): ProjectionGenerationEventSource => {
+      const kind = String((db.prepare("SELECT commit_kind FROM canonical_commits WHERE commit_id = ?").get(commitId) as { commit_kind?: unknown } | undefined)?.commit_kind ?? "");
+      return kind === "projection_rebuild" ? "rebuild" : "migration";
+    };
+    const backfillPhase = (eventKind: ProjectionGenerationEventKind, commitId: CanonicalId | undefined): void => {
+      if (!commitId || db.prepare("SELECT 1 FROM projection_generation_provenance WHERE generation_id = ? AND event_kind = ?").get(generationId, eventKind)) return;
+      db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id) VALUES (?, ?, ?, ?, ?)`).run(uuidV7(), generationId, eventKind, eventSource(commitId), commitId);
+    };
+    backfillPhase("created", created);
+    backfillPhase("validated", validated);
+    backfillPhase("switched", switched);
+    const selectionCount = Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transaction_selection WHERE generation_id = ?").get(generationId) as { count?: number }).count ?? 0);
+    if (selectionCount === 0) {
+      db.prepare(`INSERT INTO projection_generation_transaction_selection(generation_id, transaction_id, revision_id, selection_commit_id, selection_kind)
+        SELECT projected.generation_id, projected.transaction_id, projected.revision_id, projected.projection_commit_id, 'migration'
+        FROM projection_generation_transactions projected WHERE projected.generation_id = ?`).run(generationId);
+    }
+  }
+}
+
 function projectionIdentityKey(row: { transaction_id?: unknown; revision_id?: unknown }): string {
   return `${blob(row.transaction_id).toString("hex")}:${blob(row.revision_id).toString("hex")}`;
 }
@@ -1595,8 +1697,14 @@ function projectionIdentityKey(row: { transaction_id?: unknown; revision_id?: un
 /** Rebuild population is intentionally allowed to omit malformed evidence;
  * this calculator derives the expected set from immutable revision/scope rows,
  * not from the Source Assertion join used by the population query. */
-function expectedGenerationTransactions(db: DatabaseSync, cutoff: number): Array<{ transaction_id?: unknown; revision_id?: unknown }> {
-  return db.prepare(`SELECT transaction_row.transaction_id, revision.revision_id
+function expectedGenerationTransactions(db: DatabaseSync, cutoff: number): Array<{ transaction_id?: unknown; revision_id?: unknown; selection_commit_id?: unknown }> {
+  return db.prepare(`SELECT transaction_row.transaction_id, revision.revision_id,
+      (SELECT transition.commit_id FROM assertions source_assertion
+        JOIN assertion_transitions transition ON transition.assertion_id = source_assertion.assertion_id
+        JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
+        WHERE source_assertion.origin = 'source' AND source_assertion.revision_id = revision.revision_id
+          AND transition_commit.commit_sequence <= ?
+        ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1) AS selection_commit_id
     FROM financial_transactions transaction_row
     JOIN transaction_revisions revision ON revision.transaction_id = transaction_row.transaction_id
     JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
@@ -1612,7 +1720,7 @@ function expectedGenerationTransactions(db: DatabaseSync, cutoff: number): Array
         JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
         WHERE source_assertion.origin = 'source' AND source_assertion.revision_id = revision.revision_id
           AND transition_commit.commit_sequence <= ?
-        ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1), 'observed') <> 'withdrawn'`).all(cutoff, cutoff, cutoff) as Array<{ transaction_id?: unknown; revision_id?: unknown }>;
+        ORDER BY transition_commit.commit_sequence DESC, transition.rowid DESC LIMIT 1), 'observed') <> 'withdrawn'`).all(cutoff, cutoff, cutoff, cutoff) as Array<{ transaction_id?: unknown; revision_id?: unknown; selection_commit_id?: unknown }>;
 }
 
 function validateGenerationTransactionIntegrity(db: DatabaseSync, generationId: number, cutoff: number): void {
@@ -1625,21 +1733,41 @@ function validateGenerationTransactionIntegrity(db: DatabaseSync, generationId: 
   if (missing.length !== 0 || extra.length !== 0 || expectedKeys.size !== actualKeys.size) {
     throw new Error(`Projection rebuild completeness mismatch: missing=${missing.length}, extra=${extra.length}.`);
   }
+  const expectedByKey = new Map(expected.map((row) => [projectionIdentityKey(row), row]));
   const rows = db.prepare(`SELECT projected.transaction_id, projected.revision_id, projected.projection_commit_id, projected.revision_commit_id,
+      selection.selection_commit_id, selection.selection_kind,
       revision.transaction_id AS revision_transaction_id, revision.commit_id AS source_revision_commit_id,
+      generation.created_commit_id AS generation_created_commit_id,
       revision_commit.commit_sequence AS revision_commit_sequence, projection_commit.commit_sequence AS projection_commit_sequence,
-      upper_commit.commit_sequence AS upper_commit_sequence
+      selection_commit.commit_sequence AS selection_commit_sequence
     FROM projection_generation_transactions projected
+    LEFT JOIN projection_generation_transaction_selection selection
+      ON selection.generation_id = projected.generation_id AND selection.transaction_id = projected.transaction_id
     JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
     JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
     JOIN canonical_commits projection_commit ON projection_commit.commit_id = projected.projection_commit_id
     JOIN projection_generations generation ON generation.generation_id = projected.generation_id
-    JOIN canonical_commits upper_commit ON upper_commit.commit_id = COALESCE(generation.switched_commit_id, generation.created_commit_id)
+    LEFT JOIN canonical_commits selection_commit ON selection_commit.commit_id = selection.selection_commit_id
     WHERE projected.generation_id = ?`).all(generationId) as Array<Record<string, unknown>>;
-  if (rows.some((row) => !canonicalIdsEqual(row.revision_transaction_id, row.transaction_id)
-    || !canonicalIdsEqual(row.revision_commit_id, row.source_revision_commit_id)
-    || Number(row.projection_commit_sequence) < Number(row.revision_commit_sequence)
-    || Number(row.projection_commit_sequence) > Number(row.upper_commit_sequence))) {
+  if (rows.some((row) => {
+    const expectedRow = expectedByKey.get(projectionIdentityKey(row));
+    const rebuildSelection = row.selection_kind === "rebuild";
+    const expectedSelection = expectedRow?.selection_commit_id;
+    const selectionMatches = row.selection_commit_id !== undefined && row.selection_commit_id !== null
+      && canonicalIdsEqual(row.selection_commit_id, row.projection_commit_id)
+      && (rebuildSelection
+        ? canonicalIdsEqual(row.selection_commit_id, row.generation_created_commit_id)
+        : row.selection_kind === "migration"
+          ? (canonicalIdsEqual(row.selection_commit_id, expectedSelection)
+            || canonicalIdsEqual(row.selection_commit_id, row.generation_created_commit_id))
+          : expectedSelection !== undefined && expectedSelection !== null && canonicalIdsEqual(row.selection_commit_id, expectedSelection));
+    return !expectedRow
+      || !canonicalIdsEqual(row.revision_transaction_id, row.transaction_id)
+      || !canonicalIdsEqual(row.revision_commit_id, row.source_revision_commit_id)
+      || !selectionMatches
+      || row.selection_commit_sequence === undefined || row.selection_commit_sequence === null
+      || Number(row.selection_commit_sequence) < Number(row.revision_commit_sequence);
+  })) {
     throw new Error("Canonical v7 projection transaction commit semantics are invalid.");
   }
 }
@@ -1681,7 +1809,9 @@ function validateGenerationFieldIntegrity(db: DatabaseSync, generationId: number
     LEFT JOIN canonical_commits revision_commit ON revision_commit.commit_id = revision.commit_id
     LEFT JOIN canonical_commits projection_commit ON projection_commit.commit_id = field.projection_commit_id
     LEFT JOIN canonical_commits projected_projection_commit ON projected_projection_commit.commit_id = projected.projection_commit_id
-    LEFT JOIN canonical_commits upper_commit ON upper_commit.commit_id = COALESCE(generation.switched_commit_id, generation.created_commit_id)
+    LEFT JOIN active_projection_generation active_pointer ON active_pointer.singleton_id = 1 AND active_pointer.generation_id = generation.generation_id
+    LEFT JOIN current_projection_state active_state ON active_state.generation = 1 AND active_pointer.generation_id IS NOT NULL
+    LEFT JOIN canonical_commits upper_commit ON upper_commit.commit_id = COALESCE(active_state.commit_id, generation.switched_commit_id, generation.created_commit_id)
     LEFT JOIN derived_import_runs run ON run.commit_id = assertion.created_commit_id AND run.producer_id = assertion.producer_id AND run.rule_lineage = assertion.rule_lineage
     LEFT JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
     WHERE field.generation_id = ?`).all(generationId) as Array<Record<string, unknown>>;
@@ -1807,6 +1937,46 @@ function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: 
   if (invalidProvenance !== 0) throw new Error("Canonical v7 selected assertion provenance coordinates are invalid.");
 }
 
+function validateProjectionGenerationProvenance(db: DatabaseSync, generationId: number): void {
+  const generation = db.prepare(`SELECT status, created_commit_id, validated_commit_id, switched_commit_id
+    FROM projection_generations WHERE generation_id = ?`).get(generationId) as { status?: string; created_commit_id?: unknown; validated_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
+  if (!generation) throw new Error("Canonical v7 projection generation provenance is missing.");
+  const events = db.prepare(`SELECT event.event_kind, event.event_source, event.commit_id, commit_row.commit_sequence
+    FROM projection_generation_provenance event JOIN canonical_commits commit_row ON commit_row.commit_id = event.commit_id
+    WHERE event.generation_id = ? ORDER BY commit_row.commit_sequence, event.rowid`).all(generationId) as Array<{ event_kind?: string; event_source?: string; commit_id?: unknown; commit_sequence?: number }>;
+  const requirePhase = (kind: ProjectionGenerationEventKind, commitId: unknown): void => {
+    if (commitId === null || commitId === undefined) return;
+    const phase = events.filter((event) => event.event_kind === kind);
+    if (phase.length !== 1 || !canonicalIdsEqual(phase[0]!.commit_id, commitId)) throw new Error(`Canonical v7 ${kind} provenance does not match generation state.`);
+  };
+  requirePhase("created", generation.created_commit_id);
+  requirePhase("validated", generation.validated_commit_id);
+  requirePhase("switched", generation.switched_commit_id);
+  if (generation.status === "active" && (generation.switched_commit_id === null || generation.switched_commit_id === undefined)) {
+    throw new Error("Canonical v7 active generation has no typed switch provenance.");
+  }
+  const activePointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
+  if (!activePointer || Number(activePointer.generation_id) !== generationId) return;
+  const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
+  const stateRows = db.prepare("SELECT generation, commit_id FROM current_projection_state").all() as Array<{ generation?: number; commit_id?: unknown }>;
+  if (commitCount === 0) {
+    if (stateRows.length !== 0 || events.length !== 0) throw new Error("Canonical v7 empty projection has unexpected provenance state.");
+    return;
+  }
+  if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1 || stateRows[0]!.commit_id === null || stateRows[0]!.commit_id === undefined) {
+    throw new Error("Canonical v7 current knowledge state is missing typed provenance.");
+  }
+  const stateCommit = blob(stateRows[0]!.commit_id);
+  const knowledgeEvents = events.filter((event) => event.event_kind === "switched" || event.event_kind === "knowledge");
+  if (!knowledgeEvents.some((event) => canonicalIdsEqual(event.commit_id, stateCommit))) {
+    throw new Error("Canonical v7 current knowledge commit has no projection provenance event.");
+  }
+  const latestKnowledge = knowledgeEvents.at(-1);
+  if (!latestKnowledge || !canonicalIdsEqual(latestKnowledge.commit_id, stateCommit)) {
+    throw new Error("Canonical v7 current knowledge state is not the latest active provenance event.");
+  }
+}
+
 /** Validate the one switch boundary used by both writer and read-only startup.
  * This is intentionally a row-level gate: SQLite FKs can prove that a pointer
  * names a row, but cannot prove that the row is the sole active generation or
@@ -1832,12 +2002,15 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
     }
     if (!canonicalIdsEqual(pointer.switched_commit_id, active.switched_commit_id)) throw new Error("Canonical v7 active projection pointer does not match its generation switch commit.");
     if (!db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id))) throw new Error("Canonical v7 active projection pointer references no commit.");
-    if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1 || !canonicalIdsEqual(stateRows[0]!.commit_id, pointer.switched_commit_id)) {
-      throw new Error("Canonical v7 active projection knowledge state does not match its switch commit.");
+    if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1
+      || stateRows[0]!.commit_id === null || stateRows[0]!.commit_id === undefined
+      || !db.prepare("SELECT 1 FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id))) {
+      throw new Error("Canonical v7 active projection knowledge state is missing or invalid.");
     }
-    const switchSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(blob(pointer.switched_commit_id)) as { commit_sequence?: number } | undefined)?.commit_sequence ?? -1);
-    if (switchSequence < Number(active.build_cutoff_commit_sequence ?? 0)) throw new Error("Canonical v7 active projection switch precedes its knowledge cutoff.");
+    const knowledgeSequence = Number((db.prepare("SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?").get(blob(stateRows[0]!.commit_id)) as { commit_sequence?: number } | undefined)?.commit_sequence ?? -1);
+    if (knowledgeSequence < Number(active.build_cutoff_commit_sequence ?? 0)) throw new Error("Canonical v7 active projection knowledge precedes its cutoff.");
   }
+  validateProjectionGenerationProvenance(db, generationId);
   validateGenerationExactAmounts(db, generationId);
   validateCathayAuthorityRoute(db, generationId);
   const activeCutoff = Number((db.prepare("SELECT build_cutoff_commit_sequence FROM projection_generations WHERE generation_id = ?").get(generationId) as { build_cutoff_commit_sequence?: number } | undefined)?.build_cutoff_commit_sequence ?? 0);
@@ -1850,6 +2023,7 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
 
 function ensureV7ProjectionSchema(db: DatabaseSync): void {
   db.exec(SCHEMA_V7_APPEND);
+  backfillProjectionProvenance(db);
   const generationId = validateActiveProjectionBoundary(db);
   const mixedRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
     WHERE rows.generation_id = ? AND (rows.revision_id NOT IN (SELECT revision_id FROM transaction_revisions)
@@ -1942,7 +2116,7 @@ function applySchemaMigration(db: DatabaseSync, options: CanonicalDatabaseOption
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
-  const requiredTables = ["capture_scopes", "capture_scope_pages", "source_assertions", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields", "projection_generations", "active_projection_generation", "projection_generation_transactions", "projection_generation_transaction_fields"];
+  const requiredTables = ["capture_scopes", "capture_scope_pages", "source_assertions", "assertion_lifecycle_events", "source_record_scopes", "current_projection_state", "assertions", "assertion_transitions", "assertion_provenance", "derived_import_runs", "derived_scope_coordinates", "derived_assertions", "derived_assertion_provenance", "derived_assertion_lifecycle_events", "user_assertions", "user_assertion_lifecycle_events", "user_assertion_provenance", "current_transaction_fields", "projection_generations", "projection_generation_provenance", "active_projection_generation", "projection_generation_transactions", "projection_generation_transaction_selection", "projection_generation_transaction_fields"];
   for (const table of requiredTables) {
     if (!relationType(db, table)) throw new Error(`Canonical schema v7 table ${table} is missing.`);
   }
@@ -1972,8 +2146,10 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     transaction_revisions: ["economic_status", "administrative_state", "semantic_rule_version"],
     current_transactions: ["projection_commit_id", "revision_commit_id"],
     projection_generations: ["generation_id", "status", "build_cutoff_commit_sequence", "rule_version", "created_commit_id", "validated_commit_id", "switched_commit_id"],
+    projection_generation_provenance: ["event_id", "generation_id", "event_kind", "event_source", "commit_id"],
     active_projection_generation: ["singleton_id", "generation_id", "switched_commit_id"],
     projection_generation_transactions: ["generation_id", "transaction_id", "revision_id", "projection_commit_id", "revision_commit_id"],
+    projection_generation_transaction_selection: ["generation_id", "transaction_id", "revision_id", "selection_commit_id", "selection_kind"],
     projection_generation_transaction_fields: ["generation_id", "transaction_id", "field_name", "value_text", "origin", "derived_assertion_id", "user_assertion_id", "projection_commit_id"],
   };
   for (const [table, columns] of Object.entries(requiredColumns)) {
@@ -1985,7 +2161,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
     "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
     "idx_derived_scope_coordinates_lineage",
-    "idx_current_transaction_fields_projection", "idx_projection_generation_transactions_active", "idx_projection_generation_transactions_revision", "idx_projection_generation_fields_active", "idx_projection_generations_status",
+    "idx_current_transaction_fields_projection", "idx_projection_generation_transactions_active", "idx_projection_generation_transactions_revision", "idx_projection_generation_selection_commit", "idx_projection_generation_fields_active", "idx_projection_generations_status",
   ];
   for (const index of requiredIndexes) {
     if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v6 index ${index} is missing.`);
@@ -2352,6 +2528,7 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, 'canonical/projection/v1', 'projection_rebuild')").run(commitId, commitSequence, recordedAtUtcUs((options.clock ?? (() => new Date().toISOString()))()));
     db.prepare(`INSERT INTO projection_generations(generation_id, status, build_cutoff_commit_sequence, rule_version, created_commit_id)
       VALUES (?, 'building', ?, 'canonical/projection/v1', ?)`).run(generation, cutoff, commitId);
+    recordProjectionGenerationEvent(db, generation, "created", "rebuild", commitId);
     rebuildFailure(options.injectFailure, ["creation", "after-generation-creation"]);
     db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
       SELECT ?, t.transaction_id, revision.revision_id, ?, revision.commit_id
@@ -2364,6 +2541,9 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
         AND COALESCE((SELECT transition.event_kind FROM assertion_transitions transition JOIN canonical_commits transition_commit ON transition_commit.commit_id = transition.commit_id
           WHERE transition.assertion_id = source_assertion.assertion_id AND transition_commit.commit_sequence <= ?
           ORDER BY transition_commit.commit_sequence DESC, transition.event_id DESC LIMIT 1), 'observed') <> 'withdrawn'`).run(generation, commitId, cutoff, cutoff, cutoff);
+    db.prepare(`INSERT INTO projection_generation_transaction_selection(generation_id, transaction_id, revision_id, selection_commit_id, selection_kind)
+      SELECT generation_id, transaction_id, revision_id, projection_commit_id, 'rebuild'
+      FROM projection_generation_transactions WHERE generation_id = ?`).run(generation);
     const insertField = db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
     const generationTransactions = db.prepare("SELECT transaction_id FROM projection_generation_transactions WHERE generation_id = ?").all(generation) as Array<Record<string, unknown>>;
@@ -2394,9 +2574,12 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     if (duplicate !== 0) throw new Error("Projection rebuild validation found duplicate transaction authority.");
     rebuildFailure(options.injectFailure, ["validation", "after-validation"]);
     db.prepare("UPDATE projection_generations SET status = 'validated', validated_commit_id = ? WHERE generation_id = ?").run(commitId, generation);
+    recordProjectionGenerationEvent(db, generation, "validated", "rebuild", commitId);
+    validateProjectionGenerationProvenance(db, generation);
     rebuildFailure(options.injectFailure, ["pre-switch"]);
     db.prepare("UPDATE projection_generations SET status = 'retired' WHERE status = 'active'").run();
     db.prepare("UPDATE projection_generations SET status = 'active', switched_commit_id = ? WHERE generation_id = ?").run(commitId, generation);
+    recordProjectionGenerationEvent(db, generation, "switched", "rebuild", commitId);
     db.prepare("UPDATE active_projection_generation SET generation_id = ?, switched_commit_id = ? WHERE singleton_id = 1").run(generation, commitId);
     db.prepare("DELETE FROM current_transactions").run();
     db.prepare(`INSERT INTO current_transactions(transaction_id, revision_id, commit_id, projection_commit_id, revision_commit_id)
@@ -2405,6 +2588,7 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     db.prepare(`INSERT INTO current_transaction_fields(transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
       SELECT transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, ? FROM projection_generation_transaction_fields WHERE generation_id = ?`).run(commitId, generation);
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
+    validateProjectionGenerationProvenance(db, generation);
     db.exec("COMMIT");
     inTransaction = false;
     return { status: "switched", previousGeneration, generation, cutoffCommitSequence: cutoff, commitSequence, transactionCount: Number((db.prepare("SELECT COUNT(*) AS count FROM projection_generation_transactions WHERE generation_id = ?").get(generation) as { count?: number }).count ?? 0), fieldCount };
@@ -2596,15 +2780,27 @@ function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommi
   const generationId = Number(pointer.generation_id);
   const generation = db.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(generationId) as { status?: string } | undefined;
   if (!generation || generation.status !== "active") throw new Error("Canonical active projection generation is not writable.");
-  db.prepare("UPDATE projection_generations SET build_cutoff_commit_sequence = (SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?), switched_commit_id = ?, validated_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
-  db.prepare("UPDATE current_transactions SET commit_id = ?, projection_commit_id = ?").run(projectionCommitId, projectionCommitId);
+  const generationState = db.prepare("SELECT created_commit_id, switched_commit_id FROM projection_generations WHERE generation_id = ?").get(generationId) as { created_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
+  if (!generationState?.switched_commit_id) {
+    db.prepare("UPDATE projection_generations SET created_commit_id = COALESCE(created_commit_id, ?), validated_commit_id = COALESCE(validated_commit_id, ?), switched_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
+    recordProjectionGenerationEvent(db, generationId, "created", "routine", projectionCommitId);
+    recordProjectionGenerationEvent(db, generationId, "validated", "routine", projectionCommitId);
+    recordProjectionGenerationEvent(db, generationId, "switched", "routine", projectionCommitId);
+    db.prepare("UPDATE active_projection_generation SET switched_commit_id = ? WHERE singleton_id = 1").run(projectionCommitId);
+  }
+  db.prepare("UPDATE projection_generations SET build_cutoff_commit_sequence = (SELECT commit_sequence FROM canonical_commits WHERE commit_id = ?) WHERE generation_id = ?").run(projectionCommitId, generationId);
   db.prepare("DELETE FROM projection_generation_transaction_fields WHERE generation_id = ?").run(generationId);
+  db.prepare("DELETE FROM projection_generation_transaction_selection WHERE generation_id = ?").run(generationId);
   db.prepare("DELETE FROM projection_generation_transactions WHERE generation_id = ?").run(generationId);
   db.prepare(`INSERT INTO projection_generation_transactions(generation_id, transaction_id, revision_id, projection_commit_id, revision_commit_id)
     SELECT ?, transaction_id, revision_id, projection_commit_id, revision_commit_id FROM current_transactions`).run(generationId);
+  db.prepare(`INSERT INTO projection_generation_transaction_selection(generation_id, transaction_id, revision_id, selection_commit_id, selection_kind)
+    SELECT ?, current_row.transaction_id, current_row.revision_id, current_row.projection_commit_id,
+      CASE WHEN current_row.projection_commit_id = generation.switched_commit_id THEN 'rebuild' ELSE 'source_lifecycle' END
+    FROM current_transactions current_row JOIN projection_generations generation ON generation.generation_id = ?`).run(generationId, generationId);
   db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
     SELECT ?, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run(generationId);
-  db.prepare("UPDATE active_projection_generation SET switched_commit_id = ? WHERE singleton_id = 1").run(projectionCommitId);
+  recordProjectionGenerationEvent(db, generationId, "knowledge", "routine", projectionCommitId);
 }
 
 function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock, runtime?: CanonicalRuntimeOptions): { runId: string; commitSequence: number; assertionIds: string[] } {
@@ -2865,12 +3061,13 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
         r.utc_instant_utc_us, r.revision_id, projection_cutoff.commit_sequence FROM projection_generation_transactions current_row
         JOIN active_projection_generation pointer ON pointer.singleton_id = 1 AND pointer.generation_id = current_row.generation_id
-        JOIN canonical_commits projection_cutoff ON projection_cutoff.commit_id = pointer.switched_commit_id
+        JOIN current_projection_state state ON state.generation = 1
+        JOIN canonical_commits projection_cutoff ON projection_cutoff.commit_id = state.commit_id
         JOIN financial_transactions t ON t.transaction_id = current_row.transaction_id JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.revision_id = current_row.revision_id
         ORDER BY a.account_no, t.source_sequence`).all() as Record<string, unknown>[];
-      const projection = db.prepare(`SELECT c.commit_sequence FROM active_projection_generation pointer
-        JOIN canonical_commits c ON c.commit_id = pointer.switched_commit_id WHERE pointer.singleton_id = 1`).get() as { commit_sequence?: number } | undefined;
+      const projection = db.prepare(`SELECT c.commit_sequence FROM current_projection_state state
+        JOIN canonical_commits c ON c.commit_id = state.commit_id WHERE state.generation = 1`).get() as { commit_sequence?: number } | undefined;
       if (!projection) throw new Error("Canonical current projection cutoff is missing.");
       const result = { status: "ok", kind: "current", accounts, transactions: rows.map((row) => transactionFromRow(addSelectedFields(db, row))), commitSequence: Number(projection.commit_sequence) } satisfies CathayCanonicalCurrentQueryResult;
       return result;

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -918,9 +918,13 @@ CREATE TABLE IF NOT EXISTS projection_generations (
 CREATE TABLE IF NOT EXISTS projection_generation_provenance (
   event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
   generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+  ordinal INTEGER NOT NULL CHECK(ordinal > 0),
+  previous_event_id BLOB CHECK(previous_event_id IS NULL OR length(previous_event_id) = 16),
   event_kind TEXT NOT NULL CHECK(event_kind IN ('created','validated','switched','knowledge')),
   event_source TEXT NOT NULL CHECK(event_source IN ('migration','rebuild','routine')),
   commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  event_digest BLOB NOT NULL CHECK(length(event_digest) = 32),
+  UNIQUE(generation_id, ordinal),
   UNIQUE(generation_id, event_kind, event_source, commit_id)
 );
 CREATE TABLE IF NOT EXISTS active_projection_generation (
@@ -1546,6 +1550,7 @@ function migrateV6ToV7(db: DatabaseSync, injectMigrationFailure?: CanonicalMigra
     db.exec("DROP TABLE canonical_commits; ALTER TABLE canonical_commits_v7 RENAME TO canonical_commits");
     db.exec("CREATE INDEX IF NOT EXISTS idx_canonical_commits_sequence ON canonical_commits(commit_sequence, commit_id)");
     db.exec(SCHEMA_V7_APPEND);
+    backfillProjectionProvenance(db);
     if (injectMigrationFailure === "v6-v7-after-generation-creation") throw new Error("Injected v6-v7 migration failure after generation creation.");
 
     const latest = db.prepare("SELECT commit_id, commit_sequence FROM canonical_commits ORDER BY commit_sequence DESC LIMIT 1").get() as { commit_id?: unknown; commit_sequence?: number } | undefined;
@@ -1637,6 +1642,97 @@ function canonicalIdsEqual(left: unknown, right: unknown): boolean {
 type ProjectionGenerationEventKind = "created" | "validated" | "switched" | "knowledge";
 type ProjectionGenerationEventSource = "migration" | "rebuild" | "routine";
 
+const PROJECTION_GENERATION_EVENT_ORDER: Record<ProjectionGenerationEventKind, number> = {
+  created: 0,
+  validated: 1,
+  switched: 2,
+  knowledge: 3,
+};
+
+function projectionGenerationEventDigest(values: {
+  generationId: number;
+  ordinal: number;
+  eventKind: ProjectionGenerationEventKind;
+  eventSource: ProjectionGenerationEventSource;
+  commitId: CanonicalId;
+  previousEventId: CanonicalId | null;
+}): Buffer {
+  const previous = values.previousEventId ? Buffer.from(values.previousEventId).toString("hex") : "";
+  const commit = Buffer.from(values.commitId).toString("hex");
+  return createHash("sha256")
+    .update(`canonical-projection-provenance/v1|${values.generationId}|${values.ordinal}|${values.eventKind}|${values.eventSource}|${commit}|${previous}`, "utf8")
+    .digest();
+}
+
+function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): void {
+  const columns = new Set((db.prepare("PRAGMA table_info(projection_generation_provenance)").all() as Array<{ name?: string }>).map((column) => String(column.name)));
+  const required = ["ordinal", "previous_event_id", "event_digest"];
+  if (!required.some((column) => !columns.has(column))) {
+    db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_ordinal ON projection_generation_provenance(generation_id, ordinal); CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_semantic ON projection_generation_provenance(generation_id, event_kind, event_source, commit_id);");
+    return;
+  }
+
+  // v7 databases created before the chain fields are upgraded in the same
+  // migration transaction. Keep the persisted event IDs, then derive a
+  // stable order and link/digest for every generation; a malformed legacy
+  // relation fails the copy and rolls the schema back atomically.
+  const legacyRows = db.prepare(`SELECT event.rowid AS row_id, event.event_id, event.generation_id,
+      event.event_kind, event.event_source, event.commit_id, commit_row.commit_sequence
+    FROM projection_generation_provenance event
+    JOIN canonical_commits commit_row ON commit_row.commit_id = event.commit_id`).all() as Array<Record<string, unknown>>;
+  const switchedByGeneration = new Map((db.prepare("SELECT generation_id, switched_commit_id FROM projection_generations").all() as Array<Record<string, unknown>>)
+    .filter((row) => row.switched_commit_id !== null && row.switched_commit_id !== undefined)
+    .map((row) => [Number(row.generation_id), blob(row.switched_commit_id)] as const));
+  // The first v7 runtime recorded the activation commit both as `switched`
+  // and as a routine `knowledge` event. It carried no additional knowledge
+  // advance; normalize that legacy duplicate while constructing the chain.
+  const legacy = legacyRows.filter((row) => row.event_kind !== "knowledge"
+    || !canonicalIdsEqual(blob(row.commit_id), switchedByGeneration.get(Number(row.generation_id))));
+  db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy");
+  db.exec(`CREATE TABLE projection_generation_provenance (
+    event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
+    generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
+    ordinal INTEGER NOT NULL CHECK(ordinal > 0),
+    previous_event_id BLOB CHECK(previous_event_id IS NULL OR length(previous_event_id) = 16),
+    event_kind TEXT NOT NULL CHECK(event_kind IN ('created','validated','switched','knowledge')),
+    event_source TEXT NOT NULL CHECK(event_source IN ('migration','rebuild','routine')),
+    commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+    event_digest BLOB NOT NULL CHECK(length(event_digest) = 32),
+    UNIQUE(generation_id, ordinal),
+    UNIQUE(generation_id, event_kind, event_source, commit_id)
+  )`);
+  const insert = db.prepare(`INSERT INTO projection_generation_provenance(
+    event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
+  const grouped = new Map<number, Array<Record<string, unknown>>>();
+  for (const row of legacy) {
+    const generationId = Number(row.generation_id);
+    const group = grouped.get(generationId) ?? [];
+    group.push(row);
+    grouped.set(generationId, group);
+  }
+  for (const rows of grouped.values()) {
+    rows.sort((left, right) => Number(left.commit_sequence) - Number(right.commit_sequence)
+      || PROJECTION_GENERATION_EVENT_ORDER[String(left.event_kind) as ProjectionGenerationEventKind] - PROJECTION_GENERATION_EVENT_ORDER[String(right.event_kind) as ProjectionGenerationEventKind]
+      || Number(left.row_id) - Number(right.row_id));
+    let previous: CanonicalId | null = null;
+    for (let index = 0; index < rows.length; index += 1) {
+      const row = rows[index]!;
+      const generationId = Number(row.generation_id);
+      const ordinal = index + 1;
+      const eventKind = String(row.event_kind) as ProjectionGenerationEventKind;
+      const eventSource = String(row.event_source) as ProjectionGenerationEventSource;
+      const commitId = blob(row.commit_id);
+      const eventId = blob(row.event_id);
+      insert.run(eventId, generationId, ordinal, previous, eventKind, eventSource, commitId,
+        projectionGenerationEventDigest({ generationId, ordinal, eventKind, eventSource, commitId, previousEventId: previous }));
+      previous = eventId;
+    }
+  }
+  db.exec("DROP TABLE projection_generation_provenance_legacy");
+  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_ordinal ON projection_generation_provenance(generation_id, ordinal); CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_semantic ON projection_generation_provenance(generation_id, event_kind, event_source, commit_id);");
+}
+
 function recordProjectionGenerationEvent(
   db: DatabaseSync,
   generationId: number,
@@ -1644,8 +1740,15 @@ function recordProjectionGenerationEvent(
   eventSource: ProjectionGenerationEventSource,
   commitId: CanonicalId,
 ): void {
-  db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, event_kind, event_source, commit_id)
-    VALUES (?, ?, ?, ?, ?)`).run(uuidV7(), generationId, eventKind, eventSource, commitId);
+  const last = db.prepare(`SELECT event_id, ordinal FROM projection_generation_provenance
+    WHERE generation_id = ? ORDER BY ordinal DESC LIMIT 1`).get(generationId) as { event_id?: unknown; ordinal?: number } | undefined;
+  const ordinal = Number(last?.ordinal ?? 0) + 1;
+  const previous = last?.event_id ? blob(last.event_id) : null;
+  const eventId = uuidV7();
+  db.prepare(`INSERT INTO projection_generation_provenance(
+    event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(eventId, generationId, ordinal, previous, eventKind, eventSource, commitId,
+    projectionGenerationEventDigest({ generationId, ordinal, eventKind, eventSource, commitId, previousEventId: previous }));
 }
 
 function recordProjectionGenerationEventIfMissing(
@@ -1663,6 +1766,7 @@ function recordProjectionGenerationEventIfMissing(
  * from persisted generation/current rows; no synthetic canonical commit is
  * created, and all future changes use append-only events. */
 function backfillProjectionProvenance(db: DatabaseSync): void {
+  ensureProjectionGenerationProvenanceSchema(db);
   const generations = db.prepare(`SELECT generation_id, created_commit_id, validated_commit_id, switched_commit_id
     FROM projection_generations ORDER BY generation_id`).all() as Array<Record<string, unknown>>;
   for (const generation of generations) {
@@ -1937,40 +2041,146 @@ function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: 
   if (invalidProvenance !== 0) throw new Error("Canonical v7 selected assertion provenance coordinates are invalid.");
 }
 
-function validateProjectionGenerationProvenance(db: DatabaseSync, generationId: number): void {
-  const generation = db.prepare(`SELECT status, created_commit_id, validated_commit_id, switched_commit_id
-    FROM projection_generations WHERE generation_id = ?`).get(generationId) as { status?: string; created_commit_id?: unknown; validated_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
+function canonicalCommitHasEvidence(db: DatabaseSync, commitKind: string, commitId: CanonicalId): boolean {
+  if (commitKind === "source_capture") return Boolean(db.prepare("SELECT 1 FROM source_captures WHERE commit_id = ? LIMIT 1").get(commitId));
+  if (commitKind === "derived_import") return Boolean(db.prepare("SELECT 1 FROM derived_import_runs WHERE commit_id = ? LIMIT 1").get(commitId));
+  if (commitKind === "user_assertion") return Boolean(db.prepare(`SELECT 1 FROM assertions
+      WHERE origin = 'user' AND created_commit_id = ?
+      UNION ALL SELECT 1 FROM assertion_transitions WHERE user_id IS NOT NULL AND commit_id = ? LIMIT 1`).get(commitId, commitId));
+  return false;
+}
+
+function validateProjectionGenerationChain(db: DatabaseSync, generationId: number): Array<{ event_kind?: string; event_source?: string; commit_id?: unknown; commit_sequence?: number }> {
+  const generation = db.prepare(`SELECT status, build_cutoff_commit_sequence, created_commit_id, validated_commit_id, switched_commit_id
+    FROM projection_generations WHERE generation_id = ?`).get(generationId) as { status?: string; build_cutoff_commit_sequence?: number; created_commit_id?: unknown; validated_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
   if (!generation) throw new Error("Canonical v7 projection generation provenance is missing.");
-  const events = db.prepare(`SELECT event.event_kind, event.event_source, event.commit_id, commit_row.commit_sequence
+  const events = db.prepare(`SELECT event.event_id, event.ordinal, event.previous_event_id, event.event_kind, event.event_source, event.commit_id, event.event_digest,
+      commit_row.commit_sequence, commit_row.commit_kind, commit_row.authority_route
     FROM projection_generation_provenance event JOIN canonical_commits commit_row ON commit_row.commit_id = event.commit_id
-    WHERE event.generation_id = ? ORDER BY commit_row.commit_sequence, event.rowid`).all(generationId) as Array<{ event_kind?: string; event_source?: string; commit_id?: unknown; commit_sequence?: number }>;
+    WHERE event.generation_id = ? ORDER BY event.ordinal`).all(generationId) as Array<Record<string, unknown>>;
+  if (events.length === 0) throw new Error("Canonical v7 projection provenance chain is missing.");
+  let previous: CanonicalId | null = null;
+  for (let index = 0; index < events.length; index += 1) {
+    const row = events[index]!;
+    const ordinal = Number(row.ordinal);
+    const eventKind = String(row.event_kind) as ProjectionGenerationEventKind;
+    const eventSource = String(row.event_source) as ProjectionGenerationEventSource;
+    const commitId = blob(row.commit_id);
+    if (!Number.isSafeInteger(ordinal) || ordinal !== index + 1 || (previous === null ? row.previous_event_id !== null : !canonicalIdsEqual(row.previous_event_id, previous))) {
+      throw new Error("Canonical v7 projection provenance chain linkage is invalid.");
+    }
+    const expectedDigest = projectionGenerationEventDigest({ generationId, ordinal, eventKind, eventSource, commitId, previousEventId: previous });
+    if (!canonicalIdsEqual(row.event_digest, expectedDigest)) throw new Error("Canonical v7 projection provenance digest is invalid.");
+    if (!Object.prototype.hasOwnProperty.call(PROJECTION_GENERATION_EVENT_ORDER, eventKind)
+      || !Object.prototype.hasOwnProperty.call({ migration: true, rebuild: true, routine: true }, eventSource)) {
+      throw new Error("Canonical v7 projection provenance phase or source is invalid.");
+    }
+    const commitKind = String(row.commit_kind);
+    const commitSequence = Number(row.commit_sequence);
+    const isRebuild = commitKind === "projection_rebuild";
+    if (eventSource === "rebuild") {
+      if (!isRebuild || eventKind === "knowledge" || row.authority_route !== "canonical/projection/v1") {
+        throw new Error("Canonical v7 rebuild provenance source is invalid.");
+      }
+    } else if (isRebuild) {
+      throw new Error("Canonical v7 projection rebuild commit has an invalid provenance source.");
+    } else if (eventKind === "knowledge" && eventSource !== "routine") {
+      throw new Error("Canonical v7 knowledge provenance must be a routine evidence event.");
+    } else if (eventSource === "routine" && !canonicalCommitHasEvidence(db, commitKind, commitId)) {
+      throw new Error("Canonical v7 routine provenance lacks canonical evidence.");
+    }
+    if (eventKind !== "knowledge" && eventKind !== "created" && eventKind !== "validated" && eventKind !== "switched") {
+      throw new Error("Canonical v7 projection provenance phase is invalid.");
+    }
+    const cutoff = Number(generation.build_cutoff_commit_sequence ?? -1);
+    if (eventKind === "knowledge" && (!Number.isSafeInteger(commitSequence) || commitSequence > cutoff)) {
+      throw new Error("Canonical v7 knowledge provenance exceeds its generation cutoff.");
+    }
+    if (eventSource !== "rebuild" && (!Number.isSafeInteger(commitSequence) || commitSequence > cutoff)) {
+      throw new Error("Canonical v7 routine provenance exceeds its generation cutoff.");
+    }
+    previous = blob(row.event_id);
+  }
+
+  const phaseEvents = events.filter((event) => event.event_kind !== "knowledge");
+  const requiredPhases = generation.status === "building" ? ["created"]
+    : generation.status === "validated" ? ["created", "validated"]
+      : ["created", "validated", "switched"];
+  if (phaseEvents.length !== requiredPhases.length || phaseEvents.some((event, index) => event.event_kind !== requiredPhases[index])
+    || events.slice(0, phaseEvents.length).some((event, index) => event !== phaseEvents[index])) {
+    throw new Error("Canonical v7 projection provenance phases are incomplete or out of order.");
+  }
+  const phaseSource = phaseEvents[0]?.event_source;
+  if (!phaseSource || phaseEvents.some((event) => event.event_source !== phaseSource)) throw new Error("Canonical v7 projection phase sources are inconsistent.");
+  const phaseCommit = phaseEvents[0]?.commit_id;
+  if (!phaseCommit || phaseEvents.some((event) => !canonicalIdsEqual(event.commit_id, phaseCommit))) throw new Error("Canonical v7 projection phase commits are inconsistent.");
   const requirePhase = (kind: ProjectionGenerationEventKind, commitId: unknown): void => {
-    if (commitId === null || commitId === undefined) return;
-    const phase = events.filter((event) => event.event_kind === kind);
-    if (phase.length !== 1 || !canonicalIdsEqual(phase[0]!.commit_id, commitId)) throw new Error(`Canonical v7 ${kind} provenance does not match generation state.`);
+    const phase = phaseEvents.find((event) => event.event_kind === kind);
+    if (commitId === null || commitId === undefined || !phase || !canonicalIdsEqual(phase.commit_id, commitId)) {
+      throw new Error(`Canonical v7 ${kind} provenance does not match generation state.`);
+    }
   };
   requirePhase("created", generation.created_commit_id);
-  requirePhase("validated", generation.validated_commit_id);
-  requirePhase("switched", generation.switched_commit_id);
-  if (generation.status === "active" && (generation.switched_commit_id === null || generation.switched_commit_id === undefined)) {
-    throw new Error("Canonical v7 active generation has no typed switch provenance.");
+  if (requiredPhases.includes("validated")) requirePhase("validated", generation.validated_commit_id);
+  if (requiredPhases.includes("switched")) requirePhase("switched", generation.switched_commit_id);
+  if (requiredPhases.length < 2 && generation.validated_commit_id !== null && generation.validated_commit_id !== undefined) throw new Error("Canonical v7 building generation is unexpectedly validated.");
+  if (requiredPhases.length < 3 && generation.switched_commit_id !== null && generation.switched_commit_id !== undefined) throw new Error("Canonical v7 generation switched before activation.");
+
+  const switched = phaseEvents.find((event) => event.event_kind === "switched");
+  const switchedSequence = Number(switched?.commit_sequence ?? -1);
+  const expectedRoutine = switched
+    ? (db.prepare(`SELECT commit_id, commit_sequence, commit_kind FROM canonical_commits
+        WHERE commit_sequence > ? AND commit_sequence <= ? AND commit_kind <> 'projection_rebuild'
+        ORDER BY commit_sequence`).all(switchedSequence, Number(generation.build_cutoff_commit_sequence ?? -1)) as Array<Record<string, unknown>>)
+      .filter((commit) => canonicalCommitHasEvidence(db, String(commit.commit_kind), blob(commit.commit_id)))
+    : [];
+  const knowledge = events.filter((event) => event.event_kind === "knowledge");
+  if (knowledge.some((event, index) => index > 0 && Number(event.commit_sequence) <= Number(knowledge[index - 1]!.commit_sequence))) {
+    throw new Error("Canonical v7 knowledge provenance ordering is invalid.");
   }
+  const expectedKeys = new Set(expectedRoutine.map((commit) => Buffer.from(blob(commit.commit_id)).toString("hex")));
+  const actualKeys = new Set(knowledge.map((event) => Buffer.from(blob(event.commit_id)).toString("hex")));
+  if (expectedKeys.size !== actualKeys.size || [...expectedKeys].some((key) => !actualKeys.has(key))) {
+    throw new Error("Canonical v7 projection knowledge event chain is incomplete.");
+  }
+  if (switched && switchedSequence <= Number(generation.build_cutoff_commit_sequence ?? -1)) {
+    const retirementSequence = generation.status === "retired"
+      ? Number((db.prepare(`SELECT MIN(commit_row.commit_sequence) AS sequence FROM projection_generations later
+          JOIN canonical_commits commit_row ON commit_row.commit_id = later.created_commit_id
+          WHERE later.generation_id > ?`).get(generationId) as { sequence?: number } | undefined)?.sequence ?? -1)
+      : Number.POSITIVE_INFINITY;
+    if (generation.status === "retired" && (!Number.isSafeInteger(retirementSequence) || retirementSequence <= switchedSequence)) {
+      throw new Error("Canonical v7 retired generation has no immutable retirement boundary.");
+    }
+    const evidenceSequences = (db.prepare("SELECT commit_id, commit_sequence, commit_kind FROM canonical_commits ORDER BY commit_sequence").all() as Array<Record<string, unknown>>)
+      .filter((commit) => canonicalCommitHasEvidence(db, String(commit.commit_kind), blob(commit.commit_id)))
+      .map((commit) => Number(commit.commit_sequence))
+      .filter((sequence) => sequence >= switchedSequence && sequence < retirementSequence);
+    const latestEvidence = evidenceSequences.at(-1);
+    if (latestEvidence !== Number(generation.build_cutoff_commit_sequence)) {
+      throw new Error("Canonical v7 generation cutoff does not terminate its provenance chain.");
+    }
+  }
+  return events as Array<{ event_kind?: string; event_source?: string; commit_id?: unknown; commit_sequence?: number }>;
+}
+
+function validateProjectionGenerationProvenance(db: DatabaseSync, generationId: number): void {
+  const generations = db.prepare("SELECT generation_id FROM projection_generations ORDER BY generation_id").all() as Array<{ generation_id?: number }>;
+  for (const generation of generations) validateProjectionGenerationChain(db, Number(generation.generation_id));
   const activePointer = db.prepare("SELECT generation_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number } | undefined;
   if (!activePointer || Number(activePointer.generation_id) !== generationId) return;
   const commitCount = Number((db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get() as { count?: number }).count ?? 0);
   const stateRows = db.prepare("SELECT generation, commit_id FROM current_projection_state").all() as Array<{ generation?: number; commit_id?: unknown }>;
+  const activeEvents = validateProjectionGenerationChain(db, generationId);
   if (commitCount === 0) {
-    if (stateRows.length !== 0 || events.length !== 0) throw new Error("Canonical v7 empty projection has unexpected provenance state.");
+    if (stateRows.length !== 0 || activeEvents.length !== 0) throw new Error("Canonical v7 empty projection has unexpected provenance state.");
     return;
   }
   if (stateRows.length !== 1 || Number(stateRows[0]!.generation) !== 1 || stateRows[0]!.commit_id === null || stateRows[0]!.commit_id === undefined) {
     throw new Error("Canonical v7 current knowledge state is missing typed provenance.");
   }
   const stateCommit = blob(stateRows[0]!.commit_id);
-  const knowledgeEvents = events.filter((event) => event.event_kind === "switched" || event.event_kind === "knowledge");
-  if (!knowledgeEvents.some((event) => canonicalIdsEqual(event.commit_id, stateCommit))) {
-    throw new Error("Canonical v7 current knowledge commit has no projection provenance event.");
-  }
+  const knowledgeEvents = activeEvents.filter((event) => event.event_kind === "switched" || event.event_kind === "knowledge");
   const latestKnowledge = knowledgeEvents.at(-1);
   if (!latestKnowledge || !canonicalIdsEqual(latestKnowledge.commit_id, stateCommit)) {
     throw new Error("Canonical v7 current knowledge state is not the latest active provenance event.");
@@ -2146,7 +2356,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     transaction_revisions: ["economic_status", "administrative_state", "semantic_rule_version"],
     current_transactions: ["projection_commit_id", "revision_commit_id"],
     projection_generations: ["generation_id", "status", "build_cutoff_commit_sequence", "rule_version", "created_commit_id", "validated_commit_id", "switched_commit_id"],
-    projection_generation_provenance: ["event_id", "generation_id", "event_kind", "event_source", "commit_id"],
+    projection_generation_provenance: ["event_id", "generation_id", "ordinal", "previous_event_id", "event_kind", "event_source", "commit_id", "event_digest"],
     active_projection_generation: ["singleton_id", "generation_id", "switched_commit_id"],
     projection_generation_transactions: ["generation_id", "transaction_id", "revision_id", "projection_commit_id", "revision_commit_id"],
     projection_generation_transaction_selection: ["generation_id", "transaction_id", "revision_id", "selection_commit_id", "selection_kind"],
@@ -2161,7 +2371,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     "idx_source_record_scopes_scope_sequence", "idx_source_record_scopes_account_capture", "idx_current_transactions_revision",
     "idx_assertions_lineage", "idx_assertion_transitions_knowledge", "idx_assertion_transitions_transaction", "idx_assertion_provenance_authority",
     "idx_derived_scope_coordinates_lineage",
-    "idx_current_transaction_fields_projection", "idx_projection_generation_transactions_active", "idx_projection_generation_transactions_revision", "idx_projection_generation_selection_commit", "idx_projection_generation_fields_active", "idx_projection_generations_status",
+    "idx_current_transaction_fields_projection", "idx_projection_generation_transactions_active", "idx_projection_generation_transactions_revision", "idx_projection_generation_selection_commit", "idx_projection_generation_provenance_ordinal", "idx_projection_generation_provenance_semantic", "idx_projection_generation_fields_active", "idx_projection_generations_status",
   ];
   for (const index of requiredIndexes) {
     if (!db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?").get(index)) throw new Error(`Canonical schema v6 index ${index} is missing.`);
@@ -2781,7 +2991,8 @@ function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommi
   const generation = db.prepare("SELECT status FROM projection_generations WHERE generation_id = ?").get(generationId) as { status?: string } | undefined;
   if (!generation || generation.status !== "active") throw new Error("Canonical active projection generation is not writable.");
   const generationState = db.prepare("SELECT created_commit_id, switched_commit_id FROM projection_generations WHERE generation_id = ?").get(generationId) as { created_commit_id?: unknown; switched_commit_id?: unknown } | undefined;
-  if (!generationState?.switched_commit_id) {
+  const initializesGeneration = !generationState?.switched_commit_id;
+  if (initializesGeneration) {
     db.prepare("UPDATE projection_generations SET created_commit_id = COALESCE(created_commit_id, ?), validated_commit_id = COALESCE(validated_commit_id, ?), switched_commit_id = ? WHERE generation_id = ?").run(projectionCommitId, projectionCommitId, projectionCommitId, generationId);
     recordProjectionGenerationEvent(db, generationId, "created", "routine", projectionCommitId);
     recordProjectionGenerationEvent(db, generationId, "validated", "routine", projectionCommitId);
@@ -2800,7 +3011,7 @@ function syncActiveProjectionFromCompatibility(db: DatabaseSync, projectionCommi
     FROM current_transactions current_row JOIN projection_generations generation ON generation.generation_id = ?`).run(generationId, generationId);
   db.prepare(`INSERT INTO projection_generation_transaction_fields(generation_id, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id)
     SELECT ?, transaction_id, field_name, value_text, origin, derived_assertion_id, user_assertion_id, projection_commit_id FROM current_transaction_fields`).run(generationId);
-  recordProjectionGenerationEvent(db, generationId, "knowledge", "routine", projectionCommitId);
+  if (!initializesGeneration) recordProjectionGenerationEvent(db, generationId, "knowledge", "routine", projectionCommitId);
 }
 
 function commitCathayDerivedImportRunOnce(ledgerDir: string, input: CathayDerivedImportRunInput, coordinates: CathayDerivedImportCoordinate[], clock: CanonicalAdmissionClock, runtime?: CanonicalRuntimeOptions): { runId: string; commitSequence: number; assertionIds: string[] } {

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -985,10 +985,10 @@ CREATE TRIGGER IF NOT EXISTS trg_active_projection_generation_commit_update
 BEFORE UPDATE OF generation_id, switched_commit_id ON active_projection_generation
 WHEN NEW.switched_commit_id IS NOT (SELECT switched_commit_id FROM projection_generations WHERE generation_id = NEW.generation_id)
 BEGIN SELECT RAISE(ABORT, 'active projection switch commit does not match generation'); END;
-CREATE TRIGGER IF NOT EXISTS trg_projection_generation_provenance_no_update
+CREATE TRIGGER IF NOT EXISTS projection_generation_events_no_update
 BEFORE UPDATE ON projection_generation_provenance
 BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
-CREATE TRIGGER IF NOT EXISTS trg_projection_generation_provenance_no_delete
+CREATE TRIGGER IF NOT EXISTS projection_generation_events_no_delete
 BEFORE DELETE ON projection_generation_provenance
 BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
 CREATE TRIGGER IF NOT EXISTS trg_projection_generation_fields_integrity_insert
@@ -1664,24 +1664,29 @@ function projectionGenerationEventDigest(values: {
     .digest();
 }
 
+const PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS = [
+  { name: "projection_generation_events_no_update", operation: "UPDATE" },
+  { name: "projection_generation_events_no_delete", operation: "DELETE" },
+] as const;
+
 function ensureProjectionGenerationProvenanceTriggers(db: DatabaseSync): void {
-  db.exec(`DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update;
-    DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete;
-    CREATE TRIGGER trg_projection_generation_provenance_no_update
-    BEFORE UPDATE ON projection_generation_provenance
-    BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;
-    CREATE TRIGGER trg_projection_generation_provenance_no_delete
-    BEFORE DELETE ON projection_generation_provenance
-    BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;`);
+  db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete");
+  for (const definition of PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS) {
+    db.exec(`DROP TRIGGER IF EXISTS ${definition.name};
+      CREATE TRIGGER ${definition.name}
+      BEFORE ${definition.operation} ON projection_generation_provenance
+      BEGIN SELECT RAISE(ABORT, 'projection generation provenance is append-only'); END;`);
+  }
 }
 
 function validateProjectionGenerationProvenanceTriggers(db: DatabaseSync): void {
   const rows = db.prepare(`SELECT name, sql FROM sqlite_master
-    WHERE type = 'trigger' AND name IN ('trg_projection_generation_provenance_no_update', 'trg_projection_generation_provenance_no_delete')`).all() as Array<{ name?: string; sql?: string }>;
-  if (rows.length !== 2
-    || rows.some((row) => !/projection_generation_provenance/i.test(String(row.sql))
-      || !/BEFORE\s+(UPDATE|DELETE)\s+ON\s+projection_generation_provenance/i.test(String(row.sql))
-      || !/append-only/i.test(String(row.sql)))) {
+    WHERE type = 'trigger' AND name IN (${PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS.map(() => "?").join(", ")})`).all(...PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS.map((definition) => definition.name)) as Array<{ name?: string; sql?: string }>;
+  const definitions = new Map(rows.map((row) => [String(row.name), String(row.sql)]));
+  const valid = definitions.size === PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS.length
+    && PROJECTION_GENERATION_APPEND_ONLY_TRIGGER_DEFINITIONS.every((definition) => definitions.get(definition.name)?.replaceAll(/\s+/g, " ").toLowerCase().includes(`create trigger ${definition.name} before ${definition.operation.toLowerCase()} on projection_generation_provenance`))
+    && [...definitions.values()].every((sql) => /raise\s*\(\s*abort\s*,\s*'projection generation provenance is append-only'\s*\)/i.test(sql));
+  if (!valid) {
     throw new Error("Canonical v7 projection provenance append-only triggers are missing or invalid.");
   }
 }
@@ -1696,22 +1701,11 @@ function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): boolean {
   }
 
   // v7 databases created before the chain fields are upgraded in the same
-  // migration transaction. Keep the persisted event IDs, then derive a
-  // stable order and link/digest for every generation; a malformed legacy
-  // relation fails the copy and rolls the schema back atomically.
-  const legacyRows = db.prepare(`SELECT event.rowid AS row_id, event.event_id, event.generation_id,
-      event.event_kind, event.event_source, event.commit_id, commit_row.commit_sequence
-    FROM projection_generation_provenance event
-    JOIN canonical_commits commit_row ON commit_row.commit_id = event.commit_id`).all() as Array<Record<string, unknown>>;
-  const switchedByGeneration = new Map((db.prepare("SELECT generation_id, switched_commit_id FROM projection_generations").all() as Array<Record<string, unknown>>)
-    .filter((row) => row.switched_commit_id !== null && row.switched_commit_id !== undefined)
-    .map((row) => [Number(row.generation_id), blob(row.switched_commit_id)] as const));
-  // The first v7 runtime recorded the activation commit both as `switched`
-  // and as a routine `knowledge` event. It carried no additional knowledge
-  // advance; normalize that legacy duplicate while constructing the chain.
-  const legacy = legacyRows.filter((row) => row.event_kind !== "knowledge"
-    || !canonicalIdsEqual(blob(row.commit_id), switchedByGeneration.get(Number(row.generation_id))));
-  db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy");
+  // migration transaction. Keep the legacy table beside the empty typed table;
+  // rebuildLegacyProjectionProvenanceChains is the single planner/copier that
+  // derives phases, ordinals, links, and digests before dropping the legacy
+  // relation. This avoids a lossy first-pass chain followed by a second copy.
+  db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update; DROP TRIGGER IF EXISTS projection_generation_events_no_delete; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; ALTER TABLE projection_generation_provenance RENAME TO projection_generation_provenance_legacy");
   db.exec(`CREATE TABLE projection_generation_provenance (
     event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16),
     generation_id INTEGER NOT NULL REFERENCES projection_generations(generation_id),
@@ -1724,37 +1718,7 @@ function ensureProjectionGenerationProvenanceSchema(db: DatabaseSync): boolean {
     UNIQUE(generation_id, ordinal),
     UNIQUE(generation_id, event_kind, event_source, commit_id)
   )`);
-  const insert = db.prepare(`INSERT INTO projection_generation_provenance(
-    event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest
-  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
-  const grouped = new Map<number, Array<Record<string, unknown>>>();
-  for (const row of legacy) {
-    const generationId = Number(row.generation_id);
-    const group = grouped.get(generationId) ?? [];
-    group.push(row);
-    grouped.set(generationId, group);
-  }
-  for (const rows of grouped.values()) {
-    rows.sort((left, right) => Number(left.commit_sequence) - Number(right.commit_sequence)
-      || PROJECTION_GENERATION_EVENT_ORDER[String(left.event_kind) as ProjectionGenerationEventKind] - PROJECTION_GENERATION_EVENT_ORDER[String(right.event_kind) as ProjectionGenerationEventKind]
-      || Number(left.row_id) - Number(right.row_id));
-    let previous: CanonicalId | null = null;
-    for (let index = 0; index < rows.length; index += 1) {
-      const row = rows[index]!;
-      const generationId = Number(row.generation_id);
-      const ordinal = index + 1;
-      const eventKind = String(row.event_kind) as ProjectionGenerationEventKind;
-      const eventSource = String(row.event_source) as ProjectionGenerationEventSource;
-      const commitId = blob(row.commit_id);
-      const eventId = blob(row.event_id);
-      insert.run(eventId, generationId, ordinal, previous, eventKind, eventSource, commitId,
-        projectionGenerationEventDigest({ generationId, ordinal, eventKind, eventSource, commitId, previousEventId: previous }));
-      previous = eventId;
-    }
-  }
-  db.exec("DROP TABLE projection_generation_provenance_legacy");
   db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_ordinal ON projection_generation_provenance(generation_id, ordinal); CREATE UNIQUE INDEX IF NOT EXISTS idx_projection_generation_provenance_semantic ON projection_generation_provenance(generation_id, event_kind, event_source, commit_id);");
-  ensureProjectionGenerationProvenanceTriggers(db);
   return true;
 }
 
@@ -1796,8 +1760,17 @@ function rebuildLegacyProjectionProvenanceChains(db: DatabaseSync): void {
   const generations = db.prepare(`SELECT generation_id, status, build_cutoff_commit_sequence,
       created_commit_id, validated_commit_id, switched_commit_id
     FROM projection_generations ORDER BY generation_id`).all() as Array<Record<string, unknown>>;
+  const sourceTable = relationType(db, "projection_generation_provenance_legacy") ? "projection_generation_provenance_legacy" : "projection_generation_provenance";
   const events = db.prepare(`SELECT rowid AS row_id, event_id, generation_id, event_kind, event_source, commit_id
-    FROM projection_generation_provenance ORDER BY generation_id, rowid`).all() as Array<Record<string, unknown>>;
+    FROM ${sourceTable} ORDER BY generation_id, rowid`).all() as Array<Record<string, unknown>>;
+  const switchedByGeneration = new Map((db.prepare("SELECT generation_id, switched_commit_id FROM projection_generations").all() as Array<Record<string, unknown>>)
+    .filter((row) => row.switched_commit_id !== null && row.switched_commit_id !== undefined)
+    .map((row) => [Number(row.generation_id), blob(row.switched_commit_id)] as const));
+  // The first v7 runtime recorded activation as both `switched` and a routine
+  // `knowledge` event. It carried no additional knowledge advance, so the
+  // single planner normalizes that legacy duplicate before copying.
+  const normalizedEvents = events.filter((row) => row.event_kind !== "knowledge"
+    || !canonicalIdsEqual(blob(row.commit_id), switchedByGeneration.get(Number(row.generation_id))));
   const commitInfo = (commitId: CanonicalId): { sequence: number; kind: string } => {
     const row = db.prepare("SELECT commit_sequence, commit_kind FROM canonical_commits WHERE commit_id = ?").get(commitId) as { commit_sequence?: number; commit_kind?: string } | undefined;
     if (!row) throw new Error("Legacy projection provenance references an unknown commit.");
@@ -1807,7 +1780,7 @@ function rebuildLegacyProjectionProvenanceChains(db: DatabaseSync): void {
   const planned = new Map<number, Array<{ eventId: CanonicalId; eventKind: ProjectionGenerationEventKind; eventSource: ProjectionGenerationEventSource; commitId: CanonicalId; sequence: number }>>();
   for (const generation of generations) {
     const generationId = Number(generation.generation_id);
-    const generationEvents = events.filter((event) => Number(event.generation_id) === generationId);
+    const generationEvents = normalizedEvents.filter((event) => Number(event.generation_id) === generationId);
     const phases = new Map<ProjectionGenerationEventKind, Record<string, unknown>>();
     for (const event of generationEvents) {
       const kind = String(event.event_kind) as ProjectionGenerationEventKind;
@@ -1877,7 +1850,7 @@ function rebuildLegacyProjectionProvenanceChains(db: DatabaseSync): void {
         : left.eventKind === "knowledge" && right.eventKind === "knowledge" ? left.sequence - right.sequence : PROJECTION_GENERATION_EVENT_ORDER[left.eventKind] - PROJECTION_GENERATION_EVENT_ORDER[right.eventKind]);
     planned.set(generationId, rows);
   }
-  db.exec("DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; DELETE FROM projection_generation_provenance");
+  db.exec("DROP TRIGGER IF EXISTS projection_generation_events_no_update; DROP TRIGGER IF EXISTS projection_generation_events_no_delete; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_update; DROP TRIGGER IF EXISTS trg_projection_generation_provenance_no_delete; DELETE FROM projection_generation_provenance");
   const insert = db.prepare(`INSERT INTO projection_generation_provenance(event_id, generation_id, ordinal, previous_event_id, event_kind, event_source, commit_id, event_digest)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
   for (const [generationId, rows] of planned) {
@@ -1890,6 +1863,7 @@ function rebuildLegacyProjectionProvenanceChains(db: DatabaseSync): void {
       previous = row.eventId;
     }
   }
+  if (sourceTable === "projection_generation_provenance_legacy") db.exec("DROP TABLE projection_generation_provenance_legacy");
   ensureProjectionGenerationProvenanceTriggers(db);
 }
 
@@ -2105,6 +2079,75 @@ function validateGenerationFieldCompleteness(db: DatabaseSync, generationId: num
   if (missing.length !== 0 || extra.length !== 0 || expectedSet.size !== actualSet.size) {
     throw new Error(`Canonical v7 projection field completeness mismatch: missing=${missing.length}, extra=${extra.length}.`);
   }
+}
+
+/** Selected assertions are only readable when their typed provenance is still
+ * present at the same Knowledge Point. This existence-aware gate deliberately
+ * starts from selected projection rows, so unrelated historical assertions do
+ * not become a false completeness requirement. */
+function validateSelectedAssertionProvenance(db: DatabaseSync, generationId: number, cutoff: number): void {
+  const invalidSource = Number((db.prepare(`SELECT COUNT(*) AS count
+    FROM projection_generation_transactions projected
+    JOIN projection_generations generation ON generation.generation_id = projected.generation_id
+    JOIN transaction_revisions revision ON revision.revision_id = projected.revision_id
+    LEFT JOIN assertions assertion ON assertion.revision_id = revision.revision_id AND assertion.origin = 'source'
+    WHERE projected.generation_id = ? AND NOT EXISTS (
+      SELECT 1 FROM assertion_provenance provenance
+      JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+      JOIN source_records source_record ON source_record.source_record_id = provenance.source_record_id
+      JOIN source_captures capture ON capture.capture_id = source_record.capture_id
+      WHERE provenance.assertion_id = assertion.assertion_id
+        AND provenance.source_record_id = revision.source_record_id
+        AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL
+        AND source_record.capture_id = revision.capture_id
+        AND provenance_commit.commit_sequence <= ?
+        AND provenance_commit.commit_kind = 'source_capture'
+        AND provenance_commit.authority_route = ?
+        AND capture.commit_id = provenance.commit_id
+        AND capture.authority_route = ? AND capture.stream = ?
+        AND capture.completeness_rule_version = ?
+    )`).get(generationId, cutoff, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) as { count?: number }).count ?? 0);
+  if (invalidSource !== 0) throw new Error("Canonical v7 selected Source assertion provenance is incomplete.");
+
+  const invalidUserFields = Number((db.prepare(`SELECT COUNT(*) AS count
+    FROM projection_generation_transaction_fields field
+    JOIN projection_generations generation ON generation.generation_id = field.generation_id
+    LEFT JOIN assertions assertion ON assertion.assertion_id = field.user_assertion_id
+    WHERE field.generation_id = ? AND field.origin = 'user' AND NOT EXISTS (
+      SELECT 1 FROM assertion_provenance provenance
+      JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+      WHERE provenance.assertion_id = assertion.assertion_id
+        AND provenance.source_record_id IS NULL AND provenance.run_id IS NULL AND provenance.coordinate_id IS NULL
+        AND provenance_commit.commit_sequence <= ?
+        AND provenance_commit.commit_kind = 'user_assertion' AND provenance_commit.authority_route = 'user/local'
+        AND (provenance.commit_id = assertion.created_commit_id OR EXISTS (
+          SELECT 1 FROM assertion_transitions transition
+          WHERE transition.assertion_id = assertion.assertion_id AND transition.user_id IS NOT NULL AND transition.commit_id = provenance.commit_id
+        ))
+    )`).get(generationId, cutoff) as { count?: number }).count ?? 0);
+  const invalidDerivedFields = Number((db.prepare(`SELECT COUNT(*) AS count
+    FROM projection_generation_transaction_fields field
+    JOIN projection_generations generation ON generation.generation_id = field.generation_id
+    LEFT JOIN assertions assertion ON assertion.assertion_id = field.derived_assertion_id
+    WHERE field.generation_id = ? AND field.origin = 'derived' AND NOT EXISTS (
+      SELECT 1 FROM assertion_provenance provenance
+      JOIN canonical_commits provenance_commit ON provenance_commit.commit_id = provenance.commit_id
+      JOIN derived_import_runs run ON run.run_id = provenance.run_id
+      JOIN derived_scope_coordinates coordinate ON coordinate.coordinate_id = provenance.coordinate_id
+      JOIN source_authority_routes registered ON registered.authority_route = run.authority_route
+      WHERE provenance.assertion_id = assertion.assertion_id
+        AND provenance.source_record_id IS NULL AND provenance.run_id IS NOT NULL AND provenance.coordinate_id IS NOT NULL
+        AND provenance_commit.commit_sequence <= ?
+        AND provenance_commit.commit_kind = 'derived_import' AND provenance_commit.authority_route = ?
+        AND run.commit_id = provenance.commit_id AND run.authority_route = ? AND run.stream = ?
+        AND run.producer_id = assertion.producer_id AND run.origin = ? AND run.rule_lineage = assertion.rule_lineage AND run.status = 'complete'
+        AND coordinate.run_id = run.run_id AND coordinate.transaction_id = assertion.transaction_id AND coordinate.field_name = assertion.field_name
+        AND coordinate.producer_id = assertion.producer_id AND coordinate.origin = ? AND coordinate.rule_lineage = assertion.rule_lineage
+        AND coordinate.output_state = 'supported'
+        AND registered.integration_namespace = ? AND registered.stream = ? AND registered.contract_version = ?
+    )`).get(generationId, cutoff, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DERIVED_ORIGIN, CATHAY_DERIVED_ORIGIN, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, CATHAY_DOMESTIC_DEPOSIT_CONTRACT_VERSION) as { count?: number }).count ?? 0);
+  const invalidFields = invalidUserFields + invalidDerivedFields;
+  if (invalidFields !== 0) throw new Error("Canonical v7 selected assertion provenance is incomplete.");
 }
 
 function validateGenerationLifecycleCoordinates(db: DatabaseSync, generationId: number): void {
@@ -2394,6 +2437,7 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
   const activeCutoff = Number((db.prepare("SELECT build_cutoff_commit_sequence FROM projection_generations WHERE generation_id = ?").get(generationId) as { build_cutoff_commit_sequence?: number } | undefined)?.build_cutoff_commit_sequence ?? 0);
   validateGenerationTransactionIntegrity(db, generationId, activeCutoff);
   validateGenerationFieldCompleteness(db, generationId, activeCutoff);
+  validateSelectedAssertionProvenance(db, generationId, activeCutoff);
   validateGenerationFieldIntegrity(db, generationId);
   validateGenerationLifecycleCoordinates(db, generationId);
   validateUserAssertionProvenanceAuthority(db);
@@ -2950,6 +2994,7 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
     if (dangling !== 0) throw new Error("Projection rebuild validation failed for references or exact arithmetic.");
     validateGenerationTransactionIntegrity(db, generation, cutoff);
     validateGenerationFieldCompleteness(db, generation, cutoff);
+    validateSelectedAssertionProvenance(db, generation, cutoff);
     validateGenerationExactAmounts(db, generation);
     validateCathayAuthorityRoute(db, generation);
     validateGenerationFieldIntegrity(db, generation);

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -8,7 +8,7 @@ export const CATHAY_DOMESTIC_DEPOSIT_STREAM = "domestic-deposit";
 export const CATHAY_DOMESTIC_DEPOSIT_AUTHORITY = "cathay/domestic-deposit/v1";
 export const CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE = "Asia/Taipei";
 export const CANONICAL_SQLITE_FILE = "canonical.sqlite";
-export const CANONICAL_SCHEMA_VERSION = 3;
+export const CANONICAL_SCHEMA_VERSION = 4;
 export const CATHAY_POSTING_MAPPING = {
   contractVersion: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   postingStatus: "posted",
@@ -43,6 +43,36 @@ export type CathayDomesticDepositCaptureInput = {
   scope: { startDate: string; endDate: string; complete?: boolean };
   syncState: { cursor?: string | null };
   observedAt: string;
+  absenceAuthority?: CathayAbsenceAuthority;
+};
+
+export type CathayAbsenceAuthority = "comparable-complete-range" | "tombstone";
+export type CathayTransportCheckpoint = {
+  kind: "transport-progress";
+  ordinal: number;
+  token: string | null;
+};
+export type CathayStagedCapturePage = {
+  accountNo: string;
+  currency: "TWD";
+  scope: { startDate: string; endDate: string };
+  pageOrdinal: number;
+  requestPageToken: string | null;
+  nextPageToken: string | null;
+  rawResponse: string;
+  contractFingerprint: string;
+  preflightFingerprint: string;
+  absenceAuthority?: CathayAbsenceAuthority;
+  transportCheckpoint?: CathayTransportCheckpoint;
+};
+export type CathayDomesticDepositSyncInput = {
+  sourceConnectionId: string;
+  identityEpoch: string;
+  authorityRoute: string;
+  stream: string;
+  syncState: { cursor?: string | null };
+  observedAt: string;
+  pages: CathayStagedCapturePage[];
 };
 
 export const CATHAY_DOMESTIC_DEPOSIT_FIXTURE: CathayDomesticDepositCaptureInput = {
@@ -253,6 +283,32 @@ type ValidatedCathayCapture = {
   completeness: typeof CATHAY_COMPLETENESS_PROOF;
   rows: ValidatedCathayRow[];
 };
+type ValidatedCathayScope = {
+  accountNo: string;
+  currency: "TWD";
+  startDate: string;
+  endDate: string;
+  absenceAuthority?: CathayAbsenceAuthority;
+  contractFingerprint: string;
+  preflightFingerprint: string;
+  pages: Array<{
+    pageOrdinal: number;
+    terminal: boolean;
+    rowCount: number;
+    responseDigest: string;
+    rows: ValidatedCathayRow[];
+  }>;
+  rows: ValidatedCathayRow[];
+};
+type ValidatedCathaySync = {
+  sourceConnectionId: string;
+  identityEpoch: string;
+  authorityRoute: string;
+  stream: string;
+  syncState: { cursor?: string | null };
+  observedAt: string;
+  scopes: ValidatedCathayScope[];
+};
 
 function cathayPostingMapping(
   statement: { [key: string]: LosslessJsonValue },
@@ -334,6 +390,81 @@ function validateCapture(input: CathayDomesticDepositCaptureInput): ValidatedCat
     } satisfies ValidatedCathayRow;
   });
   return { accountNo, startDate, endDate, posting, completeness: CATHAY_COMPLETENESS_PROOF, rows };
+}
+
+function responseDigest(rawResponse: string): string {
+  return createHash("sha256").update(rawResponse, "utf8").digest("hex");
+}
+
+function validateSyncInput(input: CathayDomesticDepositSyncInput): ValidatedCathaySync {
+  if (!input.sourceConnectionId.trim() || !input.identityEpoch.trim()) throw new Error("Source Connection and Identity Epoch are required.");
+  if (input.authorityRoute !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY || input.stream !== CATHAY_DOMESTIC_DEPOSIT_STREAM) throw new Error("Invalid Cathay sync authority route or stream.");
+  if (input.syncState.cursor !== undefined && input.syncState.cursor !== null) throw new Error("Cathay domestic deposit has no continuation cursor.");
+  parseRfc3339UtcMicros(input.observedAt, "Capture observedAt");
+  if (input.pages.length === 0) throw new Error("Cathay sync requires at least one staged page.");
+
+  const grouped = new Map<string, CathayStagedCapturePage[]>();
+  for (const page of input.pages) {
+    if (!page.accountNo.trim() || page.currency !== "TWD") throw new Error("Cathay staged page has an invalid account identity or currency.");
+    if (!Number.isInteger(page.pageOrdinal) || page.pageOrdinal < 0) throw new Error("Cathay page ordinal must be a non-negative integer.");
+    if (!page.contractFingerprint.trim() || !page.preflightFingerprint.trim()) throw new Error("Cathay page contract and preflight fingerprints are required.");
+    if (page.contractFingerprint !== CATHAY_DOMESTIC_DEPOSIT_AUTHORITY) throw new Error("Cathay page contract fingerprint is unsupported.");
+    const pages = grouped.get(page.accountNo) ?? [];
+    pages.push(page);
+    grouped.set(page.accountNo, pages);
+  }
+  const scopes: ValidatedCathayScope[] = [];
+  let contractFingerprint: string | undefined;
+  let preflightFingerprint: string | undefined;
+  for (const [accountNo, pagesForAccount] of grouped) {
+    const pages = [...pagesForAccount].sort((left, right) => left.pageOrdinal - right.pageOrdinal);
+    if (new Set(pages.map((page) => page.pageOrdinal)).size !== pages.length) throw new Error("Cathay staged pages contain duplicate ordinals.");
+    const first = pages[0]!;
+    const startDate = requireDate(first.scope.startDate, "Cathay scope.startDate");
+    const endDate = requireDate(first.scope.endDate, "Cathay scope.endDate");
+    if (startDate > endDate) throw new Error("Cathay scope startDate must not be after endDate.");
+    const pageRows: ValidatedCathayScope["pages"] = [];
+    const rows: ValidatedCathayRow[] = [];
+    const sequences = new Set<string>();
+    let expectedRequestToken: string | null = null;
+    let absenceAuthority = first.absenceAuthority;
+    for (const [index, page] of pages.entries()) {
+      if (page.pageOrdinal !== index) throw new Error("Cathay staged pages must have contiguous ordinals starting at zero.");
+      if (page.scope.startDate !== startDate || page.scope.endDate !== endDate) throw new Error("Cathay page scope drifted within one account.");
+      if (page.contractFingerprint !== first.contractFingerprint || page.preflightFingerprint !== first.preflightFingerprint) throw new Error("Cathay page contract or preflight fingerprint drifted.");
+      if (page.absenceAuthority !== absenceAuthority) throw new Error("Cathay page absence authority drifted.");
+      const requestPageToken = page.requestPageToken ?? null;
+      if (requestPageToken !== expectedRequestToken) throw new Error("Cathay page continuation token is not contiguous.");
+      const validated = validateCapture({
+        rawResponse: page.rawResponse,
+        sourceConnectionId: input.sourceConnectionId,
+        identityEpoch: input.identityEpoch,
+        accountNo,
+        currency: page.currency,
+        authorityRoute: input.authorityRoute,
+        stream: input.stream,
+        scope: { startDate, endDate },
+        syncState: { cursor: null },
+        observedAt: input.observedAt,
+      });
+      const nextPageToken = page.nextPageToken ?? null;
+      const terminal = nextPageToken === null;
+      if (!terminal && index === pages.length - 1) throw new Error("Cathay staged pages end before the terminal page.");
+      if (terminal && index !== pages.length - 1) throw new Error("Cathay staged pages contain a missing continuation page.");
+      for (const row of validated.rows) {
+        if (sequences.has(row.sequence)) throw new Error("Cathay source sequence was duplicated across pages.");
+        sequences.add(row.sequence);
+        rows.push(row);
+      }
+      pageRows.push({ pageOrdinal: page.pageOrdinal, terminal, rowCount: validated.rows.length, responseDigest: responseDigest(page.rawResponse), rows: validated.rows });
+      expectedRequestToken = nextPageToken;
+      contractFingerprint ??= page.contractFingerprint;
+      preflightFingerprint ??= page.preflightFingerprint;
+      if (contractFingerprint !== page.contractFingerprint || preflightFingerprint !== page.preflightFingerprint) throw new Error("Cathay sync contract or preflight fingerprint drifted across scopes.");
+    }
+    scopes.push({ accountNo, currency: "TWD", startDate, endDate, absenceAuthority, contractFingerprint: first.contractFingerprint, preflightFingerprint: first.preflightFingerprint, pages: pageRows, rows });
+  }
+  return { sourceConnectionId: input.sourceConnectionId, identityEpoch: input.identityEpoch, authorityRoute: input.authorityRoute, stream: input.stream, syncState: { cursor: null }, observedAt: input.observedAt, scopes };
 }
 
 type CanonicalId = Buffer;
@@ -458,6 +589,40 @@ CREATE INDEX IF NOT EXISTS idx_source_records_capture ON source_records(capture_
 CREATE INDEX IF NOT EXISTS idx_time_observations_revision ON transaction_time_observations(revision_id, role, observation_id);
 `;
 
+const SCHEMA_V4_APPEND = `
+CREATE TABLE IF NOT EXISTS capture_scopes (
+  scope_id BLOB PRIMARY KEY CHECK(length(scope_id) = 16), capture_id BLOB NOT NULL REFERENCES source_captures(capture_id),
+  source_connection_id BLOB NOT NULL REFERENCES source_connections(source_connection_id), identity_epoch_id BLOB NOT NULL REFERENCES identity_epochs(identity_epoch_id),
+  account_id BLOB NOT NULL REFERENCES financial_accounts(account_id), account_no TEXT NOT NULL, stream TEXT NOT NULL,
+  scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, completeness TEXT NOT NULL CHECK(completeness = 'complete-range'),
+  completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),
+  completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'),
+  absence_authority TEXT CHECK(absence_authority IN ('comparable-complete-range', 'tombstone')),
+  contract_fingerprint TEXT NOT NULL, preflight_fingerprint TEXT NOT NULL, page_count INTEGER NOT NULL CHECK(page_count > 0),
+  terminal INTEGER NOT NULL CHECK(terminal IN (0, 1)), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(capture_id, account_id, scope_start, scope_end)
+);
+CREATE TABLE IF NOT EXISTS capture_scope_pages (
+  scope_page_id BLOB PRIMARY KEY CHECK(length(scope_page_id) = 16), scope_id BLOB NOT NULL REFERENCES capture_scopes(scope_id),
+  page_ordinal INTEGER NOT NULL CHECK(page_ordinal >= 0), terminal INTEGER NOT NULL CHECK(terminal IN (0, 1)), row_count INTEGER NOT NULL CHECK(row_count >= 0),
+  response_digest TEXT NOT NULL, proof_kind TEXT NOT NULL CHECK(proof_kind = 'success-status-scope-count-details'),
+  contract_fingerprint TEXT NOT NULL, preflight_fingerprint TEXT NOT NULL, commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id),
+  UNIQUE(scope_id, page_ordinal)
+);
+CREATE TABLE IF NOT EXISTS assertion_lifecycle_events (
+  event_id BLOB PRIMARY KEY CHECK(length(event_id) = 16), assertion_id BLOB NOT NULL REFERENCES source_assertions(assertion_id),
+  transaction_id BLOB NOT NULL REFERENCES financial_transactions(transaction_id), revision_id BLOB NOT NULL REFERENCES transaction_revisions(revision_id),
+  capture_id BLOB NOT NULL REFERENCES source_captures(capture_id), scope_id BLOB REFERENCES capture_scopes(scope_id),
+  commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id), event_kind TEXT NOT NULL CHECK(event_kind IN ('observed', 'superseded', 'withdrawn', 'restored'))
+);
+CREATE INDEX IF NOT EXISTS idx_capture_scopes_account_time ON capture_scopes(source_connection_id, identity_epoch_id, account_id, scope_start, scope_end, commit_id);
+CREATE INDEX IF NOT EXISTS idx_capture_scope_pages_proof ON capture_scope_pages(scope_id, page_ordinal, commit_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_assertion_knowledge ON assertion_lifecycle_events(assertion_id, commit_id, event_kind, event_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_transaction_knowledge ON assertion_lifecycle_events(transaction_id, commit_id, event_kind, event_id);
+CREATE INDEX IF NOT EXISTS idx_assertion_lifecycle_scope ON assertion_lifecycle_events(scope_id, commit_id, assertion_id);
+`;
+const SCHEMA_V4 = `${SCHEMA}${SCHEMA_V4_APPEND}`;
+
 // Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
 // Keeping this target schema separate prevents an older database from being created at a
 // partially upgraded shape before its migration transaction reaches the next version.
@@ -528,6 +693,18 @@ function migrateV2ToV3(db: DatabaseSync): void {
     throw error;
   }
 }
+function migrateV3ToV4(db: DatabaseSync): void {
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec(SCHEMA_V4_APPEND);
+    db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(4, currentUtcMicros());
+    db.exec("PRAGMA user_version = 4");
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
 function applySchemaMigration(db: DatabaseSync): void {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: number };
   const version = Number(row.user_version ?? 0);
@@ -536,10 +713,16 @@ function applySchemaMigration(db: DatabaseSync): void {
   if (version === 1) {
     migrateV1ToV2(db);
     migrateV2ToV3(db);
+    migrateV3ToV4(db);
     return;
   }
   if (version === 2) {
     migrateV2ToV3(db);
+    migrateV3ToV4(db);
+    return;
+  }
+  if (version === 3) {
+    migrateV3ToV4(db);
     return;
   }
   if (version === CANONICAL_SCHEMA_VERSION) {
@@ -550,7 +733,7 @@ function applySchemaMigration(db: DatabaseSync): void {
   }
   db.exec("BEGIN IMMEDIATE");
   try {
-    db.exec(SCHEMA);
+    db.exec(SCHEMA_V4);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(CANONICAL_SCHEMA_VERSION, currentUtcMicros());
     db.exec(`PRAGMA user_version = ${CANONICAL_SCHEMA_VERSION}`);
     db.exec("COMMIT");
@@ -561,6 +744,9 @@ function applySchemaMigration(db: DatabaseSync): void {
 }
 
 function validateReadOnlyDatabase(db: DatabaseSync): void {
+  for (const table of ["capture_scopes", "capture_scope_pages", "assertion_lifecycle_events"]) {
+    if (!tableExists(db, table)) throw new Error(`Canonical schema v4 table ${table} is missing.`);
+  }
   const journalMode = String((db.prepare("PRAGMA journal_mode").get() as { journal_mode?: unknown }).journal_mode ?? "").toLowerCase();
   if (journalMode !== "wal") throw new Error("Canonical SQLite WAL journal is not available for read-only access.");
   const integrity = String((db.prepare("PRAGMA integrity_check").get() as { integrity_check?: unknown }).integrity_check ?? "");
@@ -600,9 +786,13 @@ export function openCanonicalDatabase(ledgerDir: string, options: { readOnly?: b
 }
 
 export type CanonicalAmount = { coefficient: string; scale: number };
+export type CanonicalAssertionSupportState = "supported" | "withdrawn";
+export type CanonicalEconomicStatus = "normal" | "canceled" | "refund" | "reversal";
+export type CanonicalAdministrativeState = "active" | "deleted" | "purged";
 export type CanonicalTransaction = {
   id: string; accountId: string; accountNo: string; sourceSequence: string; amount: CanonicalAmount; currency: "TWD";
   direction: "inflow" | "outflow"; postingStatus: "posted"; postingOrigin: "provider_booked_history"; postingBasis: "query-status-success-with-accounting-date"; postingRuleVersion: "cathay/domestic-deposit/v1";
+  assertionSupportState: CanonicalAssertionSupportState; economicStatus: CanonicalEconomicStatus; administrativeState: CanonicalAdministrativeState;
   displayLabel: string | null; effectiveOn: string; effectiveTimeBasis: "accounting"; effectiveTimeRuleVersion: "cathay/domestic-deposit/v1"; transactionDateTimeLocal: string;
   timeZone: typeof CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE; timePrecision: "second"; timeOrigin: "source_reported";
   utcInstantUtcUs: number; revisionId: string; commitSequence: number;
@@ -612,6 +802,12 @@ export type CathayCanonicalCurrentQueryResult = { status: "ok"; kind: "current";
 export type CathayCanonicalHistoricalQueryRequest = { kind: "historical"; cutoff: { kind: "both"; financialAt: string; knowledgeAt: string } };
 export type CathayCanonicalHistoricalQueryResult = { status: "ok"; kind: "historical"; cutoff: CathayCanonicalHistoricalQueryRequest["cutoff"]; transactions: CanonicalTransaction[] };
 export type CathayCanonicalLineageQueryRequest = { kind: "lineage"; subject: { kind: "transaction"; id: string } };
+export type CathayCanonicalLifecycleEvent = {
+  id: string;
+  kind: "observed" | "superseded" | "withdrawn" | "restored";
+  commitSequence: number;
+  scopeProof: { id: string; completeness: "complete-range"; absenceAuthority: CathayAbsenceAuthority | null; contractFingerprint: string; pageCount: number } | null;
+};
 export type CathayCanonicalLineageEntry = {
   transaction: { id: string; accountId: string; sourceSequence: string };
   revision: CanonicalTransactionRevision;
@@ -619,6 +815,7 @@ export type CathayCanonicalLineageEntry = {
   sourceRecord: { id: string; captureId: string; sequence: string; description: string | null; payload: string };
   capture: { id: string; observedAt: string; scopeStart: string; scopeEnd: string; authorityRoute: string };
   provenance: Array<{ sourceRecordId: string; captureId: string }>;
+  lifecycleEvents: CathayCanonicalLifecycleEvent[];
 };
 export type CathayCanonicalLineageQueryResult = { status: "ok"; kind: "lineage"; subject: CathayCanonicalLineageQueryRequest["subject"]; entries: CathayCanonicalLineageEntry[] };
 export type CanonicalTransactionRevision = CanonicalTransaction & { transactionId: string };
@@ -628,7 +825,8 @@ export interface CathayCanonicalFinancialQuery {
   lineage(request: CathayCanonicalLineageQueryRequest): Promise<CathayCanonicalLineageQueryResult>;
 }
 export type CathayCommitTransactionResult = { transactionId: string; revisionId: string; sourceSequence: string; direction: "inflow" | "outflow"; amount: CanonicalAmount; revisionCreated: boolean };
-export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountId: string; transactions: CathayCommitTransactionResult[] };
+export type CathayCanonicalCommitScopeResult = { scopeId: string; accountId: string; accountNo: string; transactions: CathayCommitTransactionResult[] };
+export type CathayCanonicalCommitResult = { captureId: string; commitSequence: number; accountId: string; transactions: CathayCommitTransactionResult[]; scopes: CathayCanonicalCommitScopeResult[] };
 
 function dbRow<T extends Record<string, unknown>>(value: unknown): T { return value as T; }
 function sameRevision(row: Record<string, unknown>, detail: ValidatedCathayRow): boolean {
@@ -653,10 +851,22 @@ function currentUtcMicros(): number {
 export type CanonicalAdmissionClock = () => string;
 export type CathayCanonicalCommitOptions = { clock?: CanonicalAdmissionClock };
 
-function commitCathayDomesticDepositOnce(
+type LifecycleEventKind = CathayCanonicalLifecycleEvent["kind"];
+function insertLifecycleEvent(
+  db: DatabaseSync,
+  values: { assertionId: CanonicalId; transactionId: CanonicalId; revisionId: CanonicalId; captureId: CanonicalId; scopeId: CanonicalId | null; commitId: CanonicalId; kind: LifecycleEventKind },
+): void {
+  db.prepare("INSERT INTO assertion_lifecycle_events(event_id, assertion_id, transaction_id, revision_id, capture_id, scope_id, commit_id, event_kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), values.assertionId, values.transactionId, values.revisionId, values.captureId, values.scopeId, values.commitId, values.kind);
+}
+function latestLifecycleEvent(db: DatabaseSync, assertionId: CanonicalId): LifecycleEventKind | null {
+  const row = db.prepare(`SELECT e.event_kind FROM assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+    WHERE e.assertion_id = ? ORDER BY c.commit_sequence DESC, e.event_id DESC LIMIT 1`).get(assertionId) as { event_kind?: string } | undefined;
+  return row?.event_kind as LifecycleEventKind | null;
+}
+
+function commitCathayDomesticDepositSyncOnce(
   ledgerDir: string,
-  input: CathayDomesticDepositCaptureInput,
-  validated: ValidatedCathayCapture,
+  input: ValidatedCathaySync,
   admissionClock: CanonicalAdmissionClock,
 ): CathayCanonicalCommitResult {
   const db = openCanonicalDatabase(ledgerDir);
@@ -667,69 +877,110 @@ function commitCathayDomesticDepositOnce(
     const commitId = uuidV7();
     const maxSequence = Number((db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number }).max_sequence ?? 0);
     const commitSequence = maxSequence + 1;
-    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(admissionClock()), CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, "source_capture");
-    db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(CATHAY_DOMESTIC_DEPOSIT_AUTHORITY, CATHAY_INTEGRATION_NAMESPACE, CATHAY_DOMESTIC_DEPOSIT_STREAM, "v1", commitId);
+    db.prepare("INSERT INTO canonical_commits(commit_id, commit_sequence, recorded_at_utc_us, authority_route, commit_kind) VALUES (?, ?, ?, ?, ?)").run(commitId, commitSequence, recordedAtUtcUs(admissionClock()), input.authorityRoute, "source_capture");
+    db.prepare("INSERT OR IGNORE INTO source_authority_routes(authority_route, integration_namespace, stream, contract_version, created_commit_id) VALUES (?, ?, ?, ?, ?)").run(input.authorityRoute, CATHAY_INTEGRATION_NAMESPACE, input.stream, "v1", commitId);
     const connectionExisting = db.prepare("SELECT source_connection_id FROM source_connections WHERE integration_namespace = ? AND source_connection_key = ?").get(CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId);
     const sourceConnectionId = connectionExisting ? blob(dbRow<{ source_connection_id: unknown }>(connectionExisting).source_connection_id) : uuidV7();
     if (!connectionExisting) db.prepare("INSERT INTO source_connections(source_connection_id, integration_namespace, source_connection_key, created_commit_id) VALUES (?, ?, ?, ?)").run(sourceConnectionId, CATHAY_INTEGRATION_NAMESPACE, input.sourceConnectionId, commitId);
     const epochExisting = db.prepare("SELECT identity_epoch_id FROM identity_epochs WHERE source_connection_id = ? AND epoch_key = ?").get(sourceConnectionId, input.identityEpoch);
     const identityEpochId = epochExisting ? blob(dbRow<{ identity_epoch_id: unknown }>(epochExisting).identity_epoch_id) : uuidV7();
     if (!epochExisting) db.prepare("INSERT INTO identity_epochs(identity_epoch_id, source_connection_id, epoch_key, created_commit_id) VALUES (?, ?, ?, ?)").run(identityEpochId, sourceConnectionId, input.identityEpoch, commitId);
-    const accountExisting = db.prepare("SELECT account_id, currency, account_type FROM financial_accounts WHERE source_connection_id = ? AND identity_epoch_id = ? AND stream = ? AND account_no = ?").get(sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo);
-    const accountId = accountExisting ? blob(dbRow<{ account_id: unknown }>(accountExisting).account_id) : uuidV7();
-    if (accountExisting) {
-      const account = dbRow<{ currency: string; account_type: string }>(accountExisting);
-      if (account.currency !== input.currency || account.account_type !== "depository") throw new Error("Cathay account identity has conflicting required classification.");
-    } else db.prepare("INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(accountId, sourceConnectionId, identityEpochId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.accountNo, "depository", input.currency, commitId);
-    const captureId = uuidV7();
-    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, validated.accountNo, input.observedAt, validated.startDate, validated.endDate, validated.completeness.kind, validated.completeness.basis, validated.completeness.ruleVersion, commitId);
-
-    const transactionResults: CathayCommitTransactionResult[] = [];
-    for (const detail of validated.rows) {
-      const sourceRecordId = uuidV7();
-      db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, detail.sequence, detail.description, detail.payload);
-      const transactionExisting = db.prepare("SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?").get(accountId, detail.sequence);
-      const transactionId = transactionExisting ? blob(dbRow<{ transaction_id: unknown }>(transactionExisting).transaction_id) : uuidV7();
-      if (!transactionExisting) db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, detail.sequence, commitId);
-      const latest = db.prepare("SELECT * FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number DESC LIMIT 1").get(transactionId);
-      const latestRow = latest ? dbRow<Record<string, unknown>>(latest) : undefined;
-      const revisionCreated = !latestRow || !sameRevision(latestRow, detail);
-      let revisionId = latestRow ? blob(latestRow.revision_id) : uuidV7();
-      if (revisionCreated) {
-        revisionId = uuidV7();
-        const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
-        db.prepare(`INSERT INTO transaction_revisions(
-          revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
-          direction, posting_status, posting_origin, posting_basis, posting_rule_version, description, effective_on, transaction_date_time_local,
-          time_zone, time_precision, time_origin, effective_time_basis, effective_time_rule_version, utc_instant_utc_us
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
-          revisionId, transactionId, sourceRecordId, captureId, commitId, revisionNumber, detail.amount.coefficient.toString(), detail.amount.scale,
-          input.currency, detail.direction, validated.posting.postingStatus, validated.posting.origin, validated.posting.basis, validated.posting.ruleVersion,
-          detail.description, detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE,
-          "second", "source_reported", "accounting", validated.posting.ruleVersion, detail.utcInstantUtcUs,
-        );
-        const insertObservation = db.prepare(`INSERT INTO transaction_time_observations(
-          observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
-        insertObservation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "accounting", detail.accountDate, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", detail.accountingUtcInstantUtcUs);
-        insertObservation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "occurred", detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", detail.utcInstantUtcUs);
-        const assertionId = uuidV7();
-        db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
-        db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, commitId);
-      }
-      const assertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
-      if (!assertion) throw new Error("Canonical assertion was not created.");
-      const assertionId = blob(dbRow<{ assertion_id: unknown }>(assertion).assertion_id);
-      db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, commit_id) VALUES (?, ?, ?)").run(assertionId, sourceRecordId, commitId);
-      transactionResults.push({ transactionId: idToString(transactionId), revisionId: idToString(revisionId), sourceSequence: detail.sequence, direction: detail.direction, amount: { coefficient: detail.amount.coefficient.toString(), scale: detail.amount.scale }, revisionCreated });
+    const accountIds = new Map<string, CanonicalId>();
+    for (const scope of input.scopes) {
+      const existing = db.prepare("SELECT account_id, currency, account_type FROM financial_accounts WHERE source_connection_id = ? AND identity_epoch_id = ? AND stream = ? AND account_no = ?").get(sourceConnectionId, identityEpochId, input.stream, scope.accountNo);
+      const accountId = existing ? blob(dbRow<{ account_id: unknown }>(existing).account_id) : uuidV7();
+      if (existing) {
+        const row = dbRow<{ currency: string; account_type: string }>(existing);
+        if (row.currency !== scope.currency || row.account_type !== "depository") throw new Error("Cathay account identity has conflicting required classification.");
+      } else db.prepare("INSERT INTO financial_accounts(account_id, source_connection_id, identity_epoch_id, stream, account_no, account_type, currency, created_commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(accountId, sourceConnectionId, identityEpochId, input.stream, scope.accountNo, "depository", scope.currency, commitId);
+      accountIds.set(scope.accountNo, accountId);
     }
-    db.prepare(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET scope_start = excluded.scope_start,
-      scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, CATHAY_DOMESTIC_DEPOSIT_STREAM, validated.startDate, validated.endDate, input.syncState.cursor ?? null, captureId, commitId);
+    const captureId = uuidV7();
+    const captureStart = [...input.scopes].map((scope) => scope.startDate).sort()[0]!;
+    const captureEnd = [...input.scopes].map((scope) => scope.endDate).sort().at(-1)!;
+    db.prepare("INSERT INTO source_captures(capture_id, source_connection_id, identity_epoch_id, authority_route, stream, account_no, observed_at, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(captureId, sourceConnectionId, identityEpochId, input.authorityRoute, input.stream, input.scopes.length === 1 ? input.scopes[0]!.accountNo : "multi-scope", input.observedAt, captureStart, captureEnd, CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, commitId);
+    const allTransactions: CathayCommitTransactionResult[] = [];
+    const scopeResults: CathayCanonicalCommitScopeResult[] = [];
+    for (const scope of input.scopes) {
+      const accountId = accountIds.get(scope.accountNo)!;
+      const scopeId = uuidV7();
+      db.prepare("INSERT INTO capture_scopes(scope_id, capture_id, source_connection_id, identity_epoch_id, account_id, account_no, stream, scope_start, scope_end, completeness, completeness_basis, completeness_rule_version, absence_authority, contract_fingerprint, preflight_fingerprint, page_count, terminal, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(scopeId, captureId, sourceConnectionId, identityEpochId, accountId, scope.accountNo, input.stream, scope.startDate, scope.endDate, CATHAY_COMPLETENESS_PROOF.kind, CATHAY_COMPLETENESS_PROOF.basis, CATHAY_COMPLETENESS_PROOF.ruleVersion, scope.absenceAuthority ?? null, scope.contractFingerprint, scope.preflightFingerprint, scope.pages.length, 1, commitId);
+      for (const page of scope.pages) db.prepare("INSERT INTO capture_scope_pages(scope_page_id, scope_id, page_ordinal, terminal, row_count, response_digest, proof_kind, contract_fingerprint, preflight_fingerprint, commit_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").run(uuidV7(), scopeId, page.pageOrdinal, page.terminal ? 1 : 0, page.rowCount, page.responseDigest, CATHAY_COMPLETENESS_PROOF.basis, scope.contractFingerprint, scope.preflightFingerprint, commitId);
+      const seenSequences = new Set(scope.rows.map((row) => row.sequence));
+      const scopeTransactions: CathayCommitTransactionResult[] = [];
+      for (const detail of scope.rows) {
+        const sourceRecordId = uuidV7();
+        const sourceRecordSequence = input.scopes.length === 1 ? detail.sequence : `${scope.accountNo}:${detail.sequence}`;
+        db.prepare("INSERT INTO source_records(source_record_id, capture_id, commit_id, sequence_lexeme, description, payload_json) VALUES (?, ?, ?, ?, ?, ?)").run(sourceRecordId, captureId, commitId, sourceRecordSequence, detail.description, detail.payload);
+        const existingTransaction = db.prepare("SELECT transaction_id FROM financial_transactions WHERE account_id = ? AND source_sequence = ?").get(accountId, detail.sequence);
+        const transactionId = existingTransaction ? blob(dbRow<{ transaction_id: unknown }>(existingTransaction).transaction_id) : uuidV7();
+        if (!existingTransaction) db.prepare("INSERT INTO financial_transactions(transaction_id, account_id, source_sequence, created_commit_id) VALUES (?, ?, ?, ?)").run(transactionId, accountId, detail.sequence, commitId);
+        const latest = db.prepare("SELECT * FROM transaction_revisions WHERE transaction_id = ? ORDER BY revision_number DESC LIMIT 1").get(transactionId);
+        const latestRow = latest ? dbRow<Record<string, unknown>>(latest) : undefined;
+        const revisionCreated = !latestRow || !sameRevision(latestRow, detail);
+        let revisionId = latestRow ? blob(latestRow.revision_id) : uuidV7();
+        let assertionId: CanonicalId;
+        if (revisionCreated) {
+          if (latestRow) {
+            const oldAssertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE revision_id = ?").get(blob(latestRow.revision_id));
+            if (oldAssertion) insertLifecycleEvent(db, { assertionId: blob(dbRow<{ assertion_id: unknown }>(oldAssertion).assertion_id), transactionId, revisionId: blob(latestRow.revision_id), captureId, scopeId, commitId, kind: "superseded" });
+          }
+          revisionId = uuidV7();
+          const revisionNumber = latestRow ? Number(latestRow.revision_number) + 1 : 1;
+          db.prepare(`INSERT INTO transaction_revisions(
+            revision_id, transaction_id, source_record_id, capture_id, commit_id, revision_number, amount_coefficient, amount_scale, currency,
+            direction, posting_status, posting_origin, posting_basis, posting_rule_version, description, effective_on, transaction_date_time_local,
+            time_zone, time_precision, time_origin, effective_time_basis, effective_time_rule_version, utc_instant_utc_us
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+            revisionId, transactionId, sourceRecordId, captureId, commitId, revisionNumber, detail.amount.coefficient.toString(), detail.amount.scale,
+            scope.currency, detail.direction, CATHAY_POSTING_MAPPING.postingStatus, CATHAY_POSTING_MAPPING.origin, CATHAY_POSTING_MAPPING.basis, CATHAY_POSTING_MAPPING.ruleVersion,
+            detail.description, detail.accountDate, detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", "accounting", CATHAY_POSTING_MAPPING.ruleVersion, detail.utcInstantUtcUs,
+          );
+          const observation = db.prepare("INSERT INTO transaction_time_observations(observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+          observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "accounting", detail.accountDate, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "date", "source_reported", detail.accountingUtcInstantUtcUs);
+          observation.run(uuidV7(), transactionId, revisionId, sourceRecordId, commitId, "occurred", detail.transactionDateTime, CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, "second", "source_reported", detail.utcInstantUtcUs);
+          assertionId = uuidV7();
+          db.prepare("INSERT INTO source_assertions(assertion_id, transaction_id, revision_id, source_record_id, commit_id) VALUES (?, ?, ?, ?, ?)").run(assertionId, transactionId, revisionId, sourceRecordId, commitId);
+          insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: "observed" });
+          db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, commitId);
+        } else {
+          const assertion = db.prepare("SELECT assertion_id FROM source_assertions WHERE transaction_id = ? AND revision_id = ?").get(transactionId, revisionId);
+          if (!assertion) throw new Error("Canonical assertion was not created.");
+          assertionId = blob(dbRow<{ assertion_id: unknown }>(assertion).assertion_id);
+          const wasWithdrawn = latestLifecycleEvent(db, assertionId) === "withdrawn";
+          insertLifecycleEvent(db, { assertionId, transactionId, revisionId, captureId, scopeId, commitId, kind: wasWithdrawn ? "restored" : "observed" });
+          if (wasWithdrawn) {
+            const revisionCommit = blob(dbRow<{ commit_id: unknown }>(db.prepare("SELECT commit_id FROM transaction_revisions WHERE revision_id = ?").get(revisionId)).commit_id);
+            db.prepare("INSERT INTO current_transactions(transaction_id, revision_id, commit_id) VALUES (?, ?, ?) ON CONFLICT(transaction_id) DO UPDATE SET revision_id = excluded.revision_id, commit_id = excluded.commit_id").run(transactionId, revisionId, revisionCommit);
+          }
+        }
+        db.prepare("INSERT INTO assertion_provenance(assertion_id, source_record_id, commit_id) VALUES (?, ?, ?)").run(assertionId, sourceRecordId, commitId);
+        const result = { transactionId: idToString(transactionId), revisionId: idToString(revisionId), sourceSequence: detail.sequence, direction: detail.direction, amount: { coefficient: detail.amount.coefficient.toString(), scale: detail.amount.scale }, revisionCreated } satisfies CathayCommitTransactionResult;
+        scopeTransactions.push(result);
+        allTransactions.push(result);
+      }
+      if (scope.absenceAuthority) {
+        const prior = db.prepare(`SELECT sa.assertion_id, sa.transaction_id, sa.revision_id, t.source_sequence FROM source_assertions sa
+          JOIN financial_transactions t ON t.transaction_id = sa.transaction_id JOIN transaction_revisions r ON r.revision_id = sa.revision_id
+          JOIN current_transactions current_row ON current_row.transaction_id = t.transaction_id AND current_row.revision_id = r.revision_id
+          WHERE t.account_id = ? AND r.effective_on BETWEEN ? AND ?`).all(accountId, scope.startDate, scope.endDate) as Array<Record<string, unknown>>;
+        for (const row of prior) {
+          if (seenSequences.has(String(row.source_sequence))) continue;
+          const assertionId = blob(row.assertion_id);
+          if (latestLifecycleEvent(db, assertionId) === "withdrawn") continue;
+          insertLifecycleEvent(db, { assertionId, transactionId: blob(row.transaction_id), revisionId: blob(row.revision_id), captureId, scopeId, commitId, kind: "withdrawn" });
+          db.prepare("DELETE FROM current_transactions WHERE transaction_id = ? AND revision_id = ?").run(blob(row.transaction_id), blob(row.revision_id));
+        }
+      }
+      db.prepare(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(source_connection_id, account_id, stream) DO UPDATE SET scope_start = excluded.scope_start,
+        scope_end = excluded.scope_end, cursor = excluded.cursor, last_capture_id = excluded.last_capture_id, commit_id = excluded.commit_id`).run(sourceConnectionId, accountId, input.stream, scope.startDate, scope.endDate, input.syncState.cursor ?? null, captureId, commitId);
+      scopeResults.push({ scopeId: idToString(scopeId), accountId: idToString(accountId), accountNo: scope.accountNo, transactions: scopeTransactions });
+    }
     db.prepare("INSERT INTO current_projection_state(generation, commit_id) VALUES (1, ?) ON CONFLICT(generation) DO UPDATE SET commit_id = excluded.commit_id").run(commitId);
     db.exec("COMMIT");
     inTransaction = false;
-    return { captureId: idToString(captureId), commitSequence, accountId: idToString(accountId), transactions: transactionResults };
+    return { captureId: idToString(captureId), commitSequence, accountId: idToString(accountIds.get(input.scopes[0]!.accountNo)!), transactions: allTransactions, scopes: scopeResults };
   } catch (error) {
     if (inTransaction) db.exec("ROLLBACK");
     throw error;
@@ -766,7 +1017,37 @@ export function commitCathayDomesticDeposit(
 ): Promise<CathayCanonicalCommitResult> {
   const validated = validateCapture(input);
   const admissionClock = options.clock ?? (() => new Date().toISOString());
-  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositOnce(ledgerDir, input, validated, admissionClock));
+  const sync = validateSyncInput({
+    sourceConnectionId: input.sourceConnectionId,
+    identityEpoch: input.identityEpoch,
+    authorityRoute: input.authorityRoute,
+    stream: input.stream,
+    syncState: input.syncState,
+    observedAt: input.observedAt,
+    pages: [{
+      accountNo: validated.accountNo,
+      currency: input.currency as "TWD",
+      scope: { startDate: validated.startDate, endDate: validated.endDate },
+      pageOrdinal: 0,
+      requestPageToken: null,
+      nextPageToken: null,
+      rawResponse: input.rawResponse,
+      contractFingerprint: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+      preflightFingerprint: "cathay/domestic-deposit/v1",
+      absenceAuthority: input.absenceAuthority,
+    }],
+  });
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, sync, admissionClock));
+}
+
+export function commitCathayDomesticDepositSync(
+  ledgerDir: string,
+  input: CathayDomesticDepositSyncInput,
+  options: CathayCanonicalCommitOptions = {},
+): Promise<CathayCanonicalCommitResult> {
+  const validated = validateSyncInput(input);
+  const admissionClock = options.clock ?? (() => new Date().toISOString());
+  return withCanonicalWriter(ledgerDir, () => commitCathayDomesticDepositSyncOnce(ledgerDir, validated, admissionClock));
 }
 
 function amountFromRow(row: Record<string, unknown>, prefix = ""): CanonicalAmount { return { coefficient: String(row[`${prefix}amount_coefficient`]), scale: Number(row[`${prefix}amount_scale`]) }; }
@@ -775,6 +1056,7 @@ function transactionFromRow(row: Record<string, unknown>): CanonicalTransaction 
     id: idToString(row.transaction_id), accountId: idToString(row.account_id), accountNo: String(row.account_no), sourceSequence: String(row.source_sequence),
     amount: amountFromRow(row), currency: "TWD", direction: row.direction as "inflow" | "outflow", postingStatus: row.posting_status as "posted",
     postingOrigin: row.posting_origin as "provider_booked_history", postingBasis: row.posting_basis as "query-status-success-with-accounting-date", postingRuleVersion: row.posting_rule_version as "cathay/domestic-deposit/v1",
+    assertionSupportState: row.assertion_support_state === "withdrawn" ? "withdrawn" : "supported", economicStatus: row.economic_status as CanonicalEconomicStatus ?? "normal", administrativeState: row.administrative_state as CanonicalAdministrativeState ?? "active",
     displayLabel: typeof row.description === "string" ? row.description : null, effectiveOn: String(row.effective_on), effectiveTimeBasis: row.effective_time_basis as "accounting", effectiveTimeRuleVersion: row.effective_time_rule_version as "cathay/domestic-deposit/v1",
     transactionDateTimeLocal: String(row.transaction_date_time_local), timeZone: CATHAY_DOMESTIC_DEPOSIT_TIME_ZONE, timePrecision: "second", timeOrigin: "source_reported",
     utcInstantUtcUs: Number(row.utc_instant_utc_us), revisionId: idToString(row.revision_id), commitSequence: Number(row.commit_sequence),
@@ -813,12 +1095,18 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
       const rows = db.prepare(`SELECT t.transaction_id, t.account_id, a.account_no, t.source_sequence, r.amount_coefficient, r.amount_scale, r.currency,
         r.direction, r.posting_status, r.posting_origin, r.posting_basis, r.posting_rule_version, r.description, r.effective_on, r.effective_time_basis,
         r.effective_time_rule_version, r.transaction_date_time_local, r.time_zone, r.time_precision, r.time_origin,
-        r.utc_instant_utc_us, r.revision_id, c.commit_sequence FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
+        r.utc_instant_utc_us, r.revision_id, c.commit_sequence,
+        COALESCE((SELECT CASE WHEN lifecycle.event_kind = 'withdrawn' THEN 'withdrawn' ELSE 'supported' END FROM assertion_lifecycle_events lifecycle
+          JOIN canonical_commits lifecycle_commit ON lifecycle_commit.commit_id = lifecycle.commit_id
+          WHERE lifecycle.assertion_id = sa.assertion_id AND lifecycle_commit.commit_sequence <= ?
+          ORDER BY lifecycle_commit.commit_sequence DESC, lifecycle.event_id DESC LIMIT 1), 'supported') AS assertion_support_state
+        FROM financial_transactions t JOIN financial_accounts a ON a.account_id = t.account_id
         JOIN transaction_revisions r ON r.transaction_id = t.transaction_id JOIN canonical_commits c ON c.commit_id = r.commit_id
+        JOIN source_assertions sa ON sa.revision_id = r.revision_id
         WHERE r.effective_on <= ? AND c.commit_sequence <= ? AND NOT EXISTS (
           SELECT 1 FROM transaction_revisions newer JOIN canonical_commits newer_commit ON newer_commit.commit_id = newer.commit_id
           WHERE newer.transaction_id = r.transaction_id AND newer.effective_on <= ? AND newer_commit.commit_sequence <= ? AND newer_commit.commit_sequence > c.commit_sequence
-        ) ORDER BY a.account_no, t.source_sequence`).all(request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
+        ) ORDER BY a.account_no, t.source_sequence`).all(knowledgeAt, request.cutoff.financialAt, knowledgeAt, request.cutoff.financialAt, knowledgeAt) as Record<string, unknown>[];
       return { status: "ok", kind: "historical", cutoff: request.cutoff, transactions: rows.map(transactionFromRow) };
     } finally { db.close(); }
   }
@@ -839,6 +1127,9 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
         const assertionId = blob(row.assertion_id);
         const provenance = db.prepare(`SELECT p.source_record_id AS sourceRecordId, sr.capture_id AS captureId FROM assertion_provenance p
           JOIN source_records sr ON sr.source_record_id = p.source_record_id WHERE p.assertion_id = ? ORDER BY p.source_record_id`).all(assertionId) as Record<string, unknown>[];
+        const lifecycleEvents = db.prepare(`SELECT e.event_id, e.event_kind, c.commit_sequence, cs.scope_id, cs.completeness, cs.absence_authority, cs.contract_fingerprint, cs.page_count
+          FROM assertion_lifecycle_events e JOIN canonical_commits c ON c.commit_id = e.commit_id
+          LEFT JOIN capture_scopes cs ON cs.scope_id = e.scope_id WHERE e.assertion_id = ? ORDER BY c.commit_sequence, e.event_id`).all(assertionId) as Record<string, unknown>[];
         const revision = transactionRevisionFromRow(row);
         return {
           transaction: { id: idToString(row.transaction_id), accountId: idToString(row.account_id), sourceSequence: String(row.source_sequence) },
@@ -847,6 +1138,10 @@ class CathayCanonicalFinancialQueryAdapter implements CathayCanonicalFinancialQu
           sourceRecord: { id: idToString(row.source_record_id), captureId: idToString(row.capture_id), sequence: String(row.sequence_lexeme), description: typeof row.description === "string" ? row.description : null, payload: String(row.payload_json) },
           capture: { id: idToString(row.capture_id), observedAt: String(row.observed_at), scopeStart: String(row.scope_start), scopeEnd: String(row.scope_end), authorityRoute: String(row.authority_route) },
           provenance: provenance.map((item) => ({ sourceRecordId: idToString(item.sourceRecordId), captureId: idToString(item.captureId) })),
+          lifecycleEvents: lifecycleEvents.map((event) => ({
+            id: idToString(event.event_id), kind: event.event_kind as CathayCanonicalLifecycleEvent["kind"], commitSequence: Number(event.commit_sequence),
+            scopeProof: event.scope_id ? { id: idToString(event.scope_id), completeness: "complete-range" as const, absenceAuthority: (event.absence_authority as CathayAbsenceAuthority | null) ?? null, contractFingerprint: String(event.contract_fingerprint), pageCount: Number(event.page_count) } : null,
+          })),
         } satisfies CathayCanonicalLineageEntry;
       });
       return { status: "ok", kind: "lineage", subject: request.subject, entries };

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -458,6 +458,19 @@ CREATE INDEX IF NOT EXISTS idx_source_records_capture ON source_records(capture_
 CREATE INDEX IF NOT EXISTS idx_time_observations_revision ON transaction_time_observations(revision_id, role, observation_id);
 `;
 
+// Version 2 deliberately excludes only the v3 completeness proof columns and nullable cursor.
+// Keeping this target schema separate prevents an older database from being created at a
+// partially upgraded shape before its migration transaction reaches the next version.
+const SCHEMA_V2 = SCHEMA
+  .replace(
+    "completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), completeness_basis TEXT NOT NULL CHECK(completeness_basis = 'success-status-scope-count-details'),\n  completeness_rule_version TEXT NOT NULL CHECK(completeness_rule_version = 'cathay/domestic-deposit/v1'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)",
+    "completeness TEXT NOT NULL CHECK(completeness = 'complete-range'), commit_id BLOB NOT NULL REFERENCES canonical_commits(commit_id)",
+  )
+  .replace("stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT,", "stream TEXT NOT NULL, scope_start TEXT NOT NULL, scope_end TEXT NOT NULL, cursor TEXT NOT NULL,");
+if (SCHEMA_V2.includes("completeness_basis") || SCHEMA_V2.includes("completeness_rule_version") || !SCHEMA_V2.includes("cursor TEXT NOT NULL")) {
+  throw new Error("Canonical schema v2 target definition is inconsistent with its migration contract.");
+}
+
 function tableExists(db: DatabaseSync, name: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
 }
@@ -472,7 +485,7 @@ function migrateV1ToV2(db: DatabaseSync): void {
     db.exec("ALTER TABLE transaction_revisions ADD COLUMN description TEXT");
     db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_basis TEXT NOT NULL DEFAULT 'accounting' CHECK(effective_time_basis = 'accounting')");
     db.exec("ALTER TABLE transaction_revisions ADD COLUMN effective_time_rule_version TEXT NOT NULL DEFAULT 'cathay/domestic-deposit/v1' CHECK(effective_time_rule_version = 'cathay/domestic-deposit/v1')");
-    db.exec(SCHEMA);
+    db.exec(SCHEMA_V2);
     const revisions = db.prepare("SELECT revision_id, transaction_id, source_record_id, commit_id, capture_id, effective_on, transaction_date_time_local, utc_instant_utc_us FROM transaction_revisions").all() as Array<Record<string, unknown>>;
     const insertObservation = db.prepare(`INSERT INTO transaction_time_observations(
       observation_id, transaction_id, revision_id, source_record_id, commit_id, role, local_value, time_zone, time_precision, time_origin, utc_instant_utc_us
@@ -506,7 +519,7 @@ function migrateV2ToV3(db: DatabaseSync): void {
     db.exec(`INSERT INTO source_sync_states(source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id)
       SELECT source_connection_id, account_id, stream, scope_start, scope_end, cursor, last_capture_id, commit_id FROM source_sync_states_v2`);
     db.exec("DROP TABLE source_sync_states_v2");
-    db.exec(SCHEMA);
+    db.exec(SCHEMA_V2);
     db.prepare("INSERT INTO schema_migrations(version, applied_at_utc_us) VALUES (?, ?)").run(3, currentUtcMicros());
     db.exec("PRAGMA user_version = 3");
     db.exec("COMMIT");

--- a/src/ledger/canonical/cathay-domestic-deposit.ts
+++ b/src/ledger/canonical/cathay-domestic-deposit.ts
@@ -2187,6 +2187,16 @@ function validateProjectionGenerationProvenance(db: DatabaseSync, generationId: 
   }
 }
 
+/** A building/validated-unswitched generation is only legal inside the one
+ * BEGIN IMMEDIATE rebuild transaction. Once committed, it is recovery
+ * corruption; never retire or delete it implicitly. */
+function rejectStrayProjectionGenerations(db: DatabaseSync): void {
+  const rows = db.prepare(`SELECT generation_id, status FROM projection_generations
+    WHERE status = 'building' OR (status = 'validated' AND switched_commit_id IS NULL)
+    ORDER BY generation_id`).all() as Array<{ generation_id?: number; status?: string }>;
+  if (rows.length > 0) throw new Error(`Canonical v7 recovery found a persisted ${rows[0]!.status} generation ${rows[0]!.generation_id}.`);
+}
+
 /** Validate the one switch boundary used by both writer and read-only startup.
  * This is intentionally a row-level gate: SQLite FKs can prove that a pointer
  * names a row, but cannot prove that the row is the sole active generation or
@@ -2234,6 +2244,7 @@ function validateActiveProjectionBoundary(db: DatabaseSync): number {
 function ensureV7ProjectionSchema(db: DatabaseSync): void {
   db.exec(SCHEMA_V7_APPEND);
   backfillProjectionProvenance(db);
+  rejectStrayProjectionGenerations(db);
   const generationId = validateActiveProjectionBoundary(db);
   const mixedRows = Number((db.prepare(`SELECT COUNT(*) AS count FROM projection_generation_transactions rows
     WHERE rows.generation_id = ? AND (rows.revision_id NOT IN (SELECT revision_id FROM transaction_revisions)
@@ -2436,6 +2447,7 @@ function validateReadOnlyDatabase(db: DatabaseSync): void {
     WHERE r.transaction_id = current_row.transaction_id AND r.commit_id = current_row.revision_commit_id
       AND current_row.commit_id = current_row.projection_commit_id`).get() as { count?: number }).count ?? 0);
   if (projectionRows !== currentCount) throw new Error("Canonical current projection authority is inconsistent.");
+  rejectStrayProjectionGenerations(db);
   const validatedActiveGenerationId = validateActiveProjectionBoundary(db);
   const activePointer = db.prepare("SELECT generation_id, switched_commit_id FROM active_projection_generation WHERE singleton_id = 1").get() as { generation_id?: number; switched_commit_id?: unknown } | undefined;
   if (!activePointer) throw new Error("Canonical v7 active projection pointer is missing.");
@@ -2725,6 +2737,7 @@ function rebuildCathayCanonicalProjectionOnce(ledgerDir: string, options: Canoni
   try {
     db.exec("BEGIN IMMEDIATE");
     inTransaction = true;
+    rejectStrayProjectionGenerations(db);
     const latest = db.prepare("SELECT COALESCE(MAX(commit_sequence), 0) AS max_sequence FROM canonical_commits").get() as { max_sequence?: number };
     const currentKnowledgePoint = Number(latest.max_sequence ?? 0);
     const cutoff = options.cutoff?.commitSequence ?? currentKnowledgePoint;

--- a/src/lib/assets/server/load-assets.ts
+++ b/src/lib/assets/server/load-assets.ts
@@ -1,91 +1,26 @@
-import { DEFAULT_LEDGER_DIR, openLedgerDrizzle } from "../../../ledger/db/client.ts";
-import * as schema from "../../../ledger/db/schema.ts";
+import { DEFAULT_LEDGER_DIR } from "../../../ledger/db/client.ts";
 import type { AssetsPageDto } from "../types.ts";
 import { buildDailyHistory, buildDailyHistoryByAccount } from "../../overview/server/daily-history.ts";
 import {
   buildAccountOverview,
   buildPositionsByAccount,
   buildTransactionsByAccount,
-  emptyLedgerQueryData,
-  type LedgerQueryData,
 } from "../../shared-ledger/server/accounts.ts";
-import {
-  appendUnavailableAccounts,
-  applyLedgerVisibility,
-  loadActiveLedgerSupport,
-  loadUnavailableAccountIssues,
-} from "../../data-issues/server/ledger-visibility.ts";
+import { createFinancialQuery } from "../../shared-ledger/server/financial-query.ts";
 
 export async function loadAssets(ledgerDir = DEFAULT_LEDGER_DIR): Promise<AssetsPageDto> {
-  const { db, sqlite } = openLedgerDrizzle(ledgerDir);
-  try {
-    const [
-      sourceFiles,
-      sourceRowLineage,
-      accountTransactions,
-      foreignCurrencyTransactions,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      fundHoldings,
-      fundBuyTransactions,
-      fundRedemptionTransactions,
-      fundCashDividends,
-      fundConversionTransactions,
-      brokerageHoldings,
-      brokerageTradeTransactions,
-      maicoinAccountSnapshots,
-      maicoinStatementRows,
-    ] = await Promise.all([
-      db.select().from(schema.sourceFileImports).all(),
-      db.select().from(schema.sourceRowLineage).all(),
-      db.select().from(schema.accountTransactions).all(),
-      db.select().from(schema.foreignCurrencyTransactions).all(),
-      db.select().from(schema.creditCardCaptures).all(),
-      db.select().from(schema.creditCardCaptureEntries).all(),
-      db.select().from(schema.fundHoldings).all(),
-      db.select().from(schema.fundBuyTransactions).all(),
-      db.select().from(schema.fundRedemptionTransactions).all(),
-      db.select().from(schema.fundCashDividends).all(),
-      db.select().from(schema.fundConversionTransactions).all(),
-      db.select().from(schema.brokerageHoldings).all(),
-      db.select().from(schema.brokerageTradeTransactions).all(),
-      db.select().from(schema.maicoinAccountSnapshots).all(),
-      db.select().from(schema.maicoinStatementRows).all(),
-    ]);
+  const { ledger: visibleData, unavailableAccounts } = await createFinancialQuery(ledgerDir)
+    .current({ kind: "current", product: "assets" });
+  const accounts = [
+    ...buildAccountOverview(visibleData),
+    ...unavailableAccounts,
+  ].filter((account) => account.group !== "liability");
 
-    const data: LedgerQueryData = {
-      ...emptyLedgerQueryData(),
-      sourceFiles,
-      sourceRowLineage,
-      accountTransactions,
-      foreignCurrencyTransactions,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      fundHoldings,
-      fundBuyTransactions,
-      fundRedemptionTransactions,
-      fundCashDividends,
-      fundConversionTransactions,
-      brokerageHoldings,
-      brokerageTradeTransactions,
-      maicoinAccountSnapshots,
-      maicoinStatementRows,
-    };
-    const support = loadActiveLedgerSupport(sqlite);
-    const visibleData = applyLedgerVisibility(data, support);
-    const accounts = appendUnavailableAccounts(
-      buildAccountOverview(visibleData),
-      loadUnavailableAccountIssues(sqlite, data, support),
-    ).filter((account) => account.group !== "liability");
-
-    return {
-      accounts,
-      positionsByAccount: buildPositionsByAccount(visibleData),
-      transactionsByAccount: buildTransactionsByAccount(visibleData),
-      dailyHistoryByAccount: buildDailyHistoryByAccount(visibleData),
-      dailyHistory: buildDailyHistory(visibleData),
-    };
-  } finally {
-    sqlite.close();
-  }
+  return {
+    accounts,
+    positionsByAccount: buildPositionsByAccount(visibleData),
+    transactionsByAccount: buildTransactionsByAccount(visibleData),
+    dailyHistoryByAccount: buildDailyHistoryByAccount(visibleData),
+    dailyHistory: buildDailyHistory(visibleData),
+  };
 }

--- a/src/lib/liabilities/server/load-liabilities.ts
+++ b/src/lib/liabilities/server/load-liabilities.ts
@@ -1,65 +1,22 @@
-import { DEFAULT_LEDGER_DIR, openLedgerDrizzle } from "../../../ledger/db/client.ts";
-import * as schema from "../../../ledger/db/schema.ts";
+import { DEFAULT_LEDGER_DIR } from "../../../ledger/db/client.ts";
 import type { LiabilitiesPageDto } from "../types.ts";
 import { buildDailyHistory, buildDailyHistoryByAccount } from "../../overview/server/daily-history.ts";
 import {
   buildAccountOverview,
   buildTransactionsByAccount,
-  emptyLedgerQueryData,
-  type LedgerQueryData,
 } from "../../shared-ledger/server/accounts.ts";
-import {
-  appendUnavailableAccounts,
-  applyLedgerVisibility,
-  loadActiveLedgerSupport,
-  loadUnavailableAccountIssues,
-} from "../../data-issues/server/ledger-visibility.ts";
+import { createFinancialQuery } from "../../shared-ledger/server/financial-query.ts";
 
 export async function loadLiabilities(ledgerDir = DEFAULT_LEDGER_DIR): Promise<LiabilitiesPageDto> {
-  const { db, sqlite } = openLedgerDrizzle(ledgerDir);
-  try {
-    const [
-      sourceFiles,
-      creditCardStatementLines,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      creditCardSnapshots,
-      loanTransactions,
-      maicoinAccountSnapshots,
-    ] = await Promise.all([
-      db.select().from(schema.sourceFileImports).all(),
-      db.select().from(schema.creditCardStatementLines).all(),
-      db.select().from(schema.creditCardCaptures).all(),
-      db.select().from(schema.creditCardCaptureEntries).all(),
-      db.select().from(schema.creditCardSnapshots).all(),
-      db.select().from(schema.loanTransactions).all(),
-      db.select().from(schema.maicoinAccountSnapshots).all(),
-    ]);
+  const { ledger: visibleData, unavailableAccounts } = await createFinancialQuery(ledgerDir)
+    .current({ kind: "current", product: "liabilities" });
+  const accounts = [...buildAccountOverview(visibleData), ...unavailableAccounts]
+    .filter((account) => account.group === "liability");
 
-    const data: LedgerQueryData = {
-      ...emptyLedgerQueryData(),
-      sourceFiles,
-      creditCardStatementLines,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      creditCardSnapshots,
-      loanTransactions,
-      maicoinAccountSnapshots,
-    };
-    const support = loadActiveLedgerSupport(sqlite);
-    const visibleData = applyLedgerVisibility(data, support);
-    const accounts = appendUnavailableAccounts(
-      buildAccountOverview(visibleData),
-      loadUnavailableAccountIssues(sqlite, data, support),
-    ).filter((account) => account.group === "liability");
-
-    return {
-      accounts,
-      transactionsByAccount: buildTransactionsByAccount(visibleData),
-      dailyHistoryByAccount: buildDailyHistoryByAccount(visibleData),
-      dailyHistory: buildDailyHistory(visibleData),
-    };
-  } finally {
-    sqlite.close();
-  }
+  return {
+    accounts,
+    transactionsByAccount: buildTransactionsByAccount(visibleData),
+    dailyHistoryByAccount: buildDailyHistoryByAccount(visibleData),
+    dailyHistory: buildDailyHistory(visibleData),
+  };
 }

--- a/src/lib/overview/server/load-overview.ts
+++ b/src/lib/overview/server/load-overview.ts
@@ -1,10 +1,8 @@
-import { DEFAULT_LEDGER_DIR, openLedgerDrizzle } from "../../../ledger/db/client.ts";
-import * as schema from "../../../ledger/db/schema.ts";
+import { DEFAULT_LEDGER_DIR } from "../../../ledger/db/client.ts";
 import type { OverviewPageDto } from "../types.ts";
 import {
   buildAccountOverview,
   buildRawPositions,
-  emptyLedgerQueryData,
   type LedgerQueryData,
 } from "../../shared-ledger/server/accounts.ts";
 import { buildSummaryMetrics } from "../../shared-ledger/server/summary.ts";
@@ -12,115 +10,26 @@ import { requiredExchangeRateCurrencies } from "../../../ledger/exchange-rates.t
 import { buildDailyHistory } from "./daily-history.ts";
 import { buildOverviewSankeyGraph } from "./overview-sankey.ts";
 import {
-  appendUnavailableAccounts,
-  applyLedgerVisibility,
-  loadActiveLedgerSupport,
-  loadUnavailableAccountIssues,
-} from "../../data-issues/server/ledger-visibility.ts";
+  createFinancialQuery,
+  type ExchangeRateQueryRow,
+} from "../../shared-ledger/server/financial-query.ts";
 
 export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<OverviewPageDto> {
-  const { db, sqlite } = openLedgerDrizzle(ledgerDir);
-  try {
-    const [
-      sourceFiles,
-      sourceRowLineage,
-      accountTransactions,
-      foreignCurrencyTransactions,
-      creditCardStatementLines,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      creditCardSnapshots,
-      loanTransactions,
-      fundHoldings,
-      brokerageHoldings,
-      maicoinAccountSnapshots,
-      maicoinStatementRows,
-    ] = await Promise.all([
-      db.select().from(schema.sourceFileImports).all(),
-      db.select().from(schema.sourceRowLineage).all(),
-      db.select().from(schema.accountTransactions).all(),
-      db.select().from(schema.foreignCurrencyTransactions).all(),
-      db.select().from(schema.creditCardStatementLines).all(),
-      db.select().from(schema.creditCardCaptures).all(),
-      db.select().from(schema.creditCardCaptureEntries).all(),
-      db.select().from(schema.creditCardSnapshots).all(),
-      db.select().from(schema.loanTransactions).all(),
-      db.select().from(schema.fundHoldings).all(),
-      db.select().from(schema.brokerageHoldings).all(),
-      db.select().from(schema.maicoinAccountSnapshots).all(),
-      db.select().from(schema.maicoinStatementRows).all(),
-    ]);
-
-    const data: LedgerQueryData = {
-      ...emptyLedgerQueryData(),
-      sourceFiles,
-      sourceRowLineage,
-      accountTransactions,
-      foreignCurrencyTransactions,
-      creditCardStatementLines,
-      creditCardCaptures,
-      creditCardCaptureEntries,
-      creditCardSnapshots,
-      loanTransactions,
-      fundHoldings,
-      brokerageHoldings,
-      maicoinAccountSnapshots,
-      maicoinStatementRows,
-    };
-    const support = loadActiveLedgerSupport(sqlite);
-    const visibleData = applyLedgerVisibility(data, support);
-    const accounts = appendUnavailableAccounts(
-      buildAccountOverview(visibleData),
-      loadUnavailableAccountIssues(sqlite, data, support),
-    );
+  const { ledger: visibleData, unavailableAccounts, exchangeRates } = await createFinancialQuery(ledgerDir)
+    .current({ kind: "current", product: "overview" });
+  const accounts = [...buildAccountOverview(visibleData), ...unavailableAccounts];
     const sankeyPositions = buildRawPositions(visibleData);
     const sankeyCurrencies = [...new Set(sankeyPositions.map((position) => position.currency).filter((currency) => currency !== "TWD"))];
-    const sankeyPlaceholders = sankeyCurrencies.map(() => "?").join(", ");
-    const sankeyExchangeRates: OverviewPageDto["sankeyExchangeRates"] =
-      (sankeyCurrencies.length === 0
-        ? []
-        : sqlite.prepare(`
-            SELECT rate.rate_date AS rateDate, rate.currency, rate.twd_per_unit AS twdPerUnit
-            FROM exchange_rates AS rate
-            WHERE rate.currency IN (${sankeyPlaceholders})
-              AND rate.rate_date = (
-                SELECT MAX(rate_date)
-                FROM exchange_rates AS current_rate
-                WHERE current_rate.currency = rate.currency
-              )
-            ORDER BY rate.currency
-          `).all(...sankeyCurrencies) as OverviewPageDto["sankeyExchangeRates"])
-        .map((rate) => ({ ...rate }));
+    const sankeyExchangeRates = latestExchangeRates(exchangeRates, sankeyCurrencies);
     const sankeyRates = new Map(sankeyExchangeRates.map((rate) => [rate.currency, rate.twdPerUnit]));
     const sankey = buildOverviewSankeyGraph(sankeyPositions, sankeyRates);
     const dailyHistory = buildDailyHistory(visibleData);
     const firstDate = dailyHistory[0]?.date;
     const lastDate = dailyHistory.at(-1)?.date;
     const currencies = requiredExchangeRateCurrencies(dailyHistory);
-    const placeholders = currencies.map(() => "?").join(", ");
-    const exchangeRates: OverviewPageDto["exchangeRates"] =
-      !firstDate || !lastDate || currencies.length === 0
-        ? []
-        : (sqlite.prepare(`
-            SELECT
-              rate_date AS rateDate,
-              currency,
-              twd_per_unit AS twdPerUnit
-            FROM exchange_rates AS rate
-            WHERE currency IN (${placeholders})
-              AND rate_date <= ?
-              AND (
-                rate_date >= ?
-                OR rate_date = (
-                  SELECT MAX(rate_date)
-                  FROM exchange_rates AS prior
-                  WHERE prior.currency = rate.currency
-                    AND prior.rate_date < ?
-                )
-              )
-            ORDER BY currency, rate_date
-          `).all(...currencies, lastDate, firstDate, firstDate) as OverviewPageDto["exchangeRates"])
-            .map((rate) => ({ ...rate }));
+    const historyExchangeRates = !firstDate || !lastDate || currencies.length === 0
+      ? []
+      : historicalExchangeRates(exchangeRates, currencies, firstDate, lastDate);
 
     return {
       importedAt: latestImportedAt(visibleData),
@@ -133,15 +42,12 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
         (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
         null,
       ),
-      exchangeRates,
-      latestExchangeRateDate: exchangeRates.reduce<string | null>(
+      exchangeRates: historyExchangeRates,
+      latestExchangeRateDate: historyExchangeRates.reduce<string | null>(
         (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
         null,
       ),
     };
-  } finally {
-    sqlite.close();
-  }
 }
 
 function latestImportedAt(data: LedgerQueryData) {
@@ -150,4 +56,45 @@ function latestImportedAt(data: LedgerQueryData) {
     ...data.creditCardSnapshots.map((snapshot) => snapshot.capturedAt),
     ...data.maicoinAccountSnapshots.map((snapshot) => snapshot.capturedAt),
   ].sort().at(-1) ?? null;
+}
+
+function latestExchangeRates(
+  rows: ExchangeRateQueryRow[],
+  currencies: string[],
+): OverviewPageDto["sankeyExchangeRates"] {
+  const selected = new Set(currencies);
+  const latest = new Map<string, ExchangeRateQueryRow>();
+  for (const row of rows) {
+    if (!selected.has(row.currency)) continue;
+    const previous = latest.get(row.currency);
+    if (!previous || row.rateDate > previous.rateDate) latest.set(row.currency, row);
+  }
+  return [...latest.values()]
+    .sort((left, right) => left.currency.localeCompare(right.currency))
+    .map((row) => ({ ...row }));
+}
+
+function historicalExchangeRates(
+  rows: ExchangeRateQueryRow[],
+  currencies: string[],
+  firstDate: string,
+  lastDate: string,
+): OverviewPageDto["exchangeRates"] {
+  const selected = new Set(currencies);
+  const byCurrency = new Map<string, ExchangeRateQueryRow[]>();
+  for (const row of rows) {
+    if (!selected.has(row.currency) || row.rateDate > lastDate) continue;
+    const current = byCurrency.get(row.currency) ?? [];
+    current.push(row);
+    byCurrency.set(row.currency, current);
+  }
+  return [...byCurrency.entries()]
+    .flatMap(([currency, currencyRows]) => {
+      const prior = currencyRows
+        .filter((row) => row.rateDate < firstDate)
+        .sort((left, right) => right.rateDate.localeCompare(left.rateDate))[0];
+      return currencyRows.filter((row) => row.rateDate >= firstDate).concat(prior ? [prior] : []);
+    })
+    .sort((left, right) => left.currency.localeCompare(right.currency) || left.rateDate.localeCompare(right.rateDate))
+    .map((row) => ({ ...row }));
 }

--- a/src/lib/overview/server/load-overview.ts
+++ b/src/lib/overview/server/load-overview.ts
@@ -20,7 +20,7 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
   const sankeyCurrencies = [...new Set(
     sankeyPositions.map((position) => position.currency).filter((currency) => currency !== "TWD"),
   )];
-  const sankeyExchangeRates = await query.overviewExchangeRates({
+  const { exchangeRates: sankeyExchangeRates } = await query.current({
     kind: "current",
     product: "overview",
     selection: "latest",
@@ -34,14 +34,14 @@ export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<Over
   const currencies = requiredExchangeRateCurrencies(dailyHistory);
   const historyExchangeRates = !firstDate || !lastDate || currencies.length === 0
     ? []
-    : await query.overviewExchangeRates({
+    : (await query.current({
       kind: "current",
       product: "overview",
       selection: "history",
       currencies,
       firstDate,
       lastDate,
-    });
+      })).exchangeRates;
 
   return {
     importedAt: latestImportedAt(visibleData),

--- a/src/lib/overview/server/load-overview.ts
+++ b/src/lib/overview/server/load-overview.ts
@@ -9,45 +9,57 @@ import { buildSummaryMetrics } from "../../shared-ledger/server/summary.ts";
 import { requiredExchangeRateCurrencies } from "../../../ledger/exchange-rates.ts";
 import { buildDailyHistory } from "./daily-history.ts";
 import { buildOverviewSankeyGraph } from "./overview-sankey.ts";
-import {
-  createFinancialQuery,
-  type ExchangeRateQueryRow,
-} from "../../shared-ledger/server/financial-query.ts";
+import { createFinancialQuery } from "../../shared-ledger/server/financial-query.ts";
 
 export async function loadOverview(ledgerDir = DEFAULT_LEDGER_DIR): Promise<OverviewPageDto> {
-  const { ledger: visibleData, unavailableAccounts, exchangeRates } = await createFinancialQuery(ledgerDir)
+  const query = createFinancialQuery(ledgerDir);
+  const { ledger: visibleData, unavailableAccounts } = await query
     .current({ kind: "current", product: "overview" });
   const accounts = [...buildAccountOverview(visibleData), ...unavailableAccounts];
-    const sankeyPositions = buildRawPositions(visibleData);
-    const sankeyCurrencies = [...new Set(sankeyPositions.map((position) => position.currency).filter((currency) => currency !== "TWD"))];
-    const sankeyExchangeRates = latestExchangeRates(exchangeRates, sankeyCurrencies);
-    const sankeyRates = new Map(sankeyExchangeRates.map((rate) => [rate.currency, rate.twdPerUnit]));
-    const sankey = buildOverviewSankeyGraph(sankeyPositions, sankeyRates);
-    const dailyHistory = buildDailyHistory(visibleData);
-    const firstDate = dailyHistory[0]?.date;
-    const lastDate = dailyHistory.at(-1)?.date;
-    const currencies = requiredExchangeRateCurrencies(dailyHistory);
-    const historyExchangeRates = !firstDate || !lastDate || currencies.length === 0
-      ? []
-      : historicalExchangeRates(exchangeRates, currencies, firstDate, lastDate);
+  const sankeyPositions = buildRawPositions(visibleData);
+  const sankeyCurrencies = [...new Set(
+    sankeyPositions.map((position) => position.currency).filter((currency) => currency !== "TWD"),
+  )];
+  const sankeyExchangeRates = await query.overviewExchangeRates({
+    kind: "current",
+    product: "overview",
+    selection: "latest",
+    currencies: sankeyCurrencies,
+  });
+  const sankeyRates = new Map(sankeyExchangeRates.map((rate) => [rate.currency, rate.twdPerUnit]));
+  const sankey = buildOverviewSankeyGraph(sankeyPositions, sankeyRates);
+  const dailyHistory = buildDailyHistory(visibleData);
+  const firstDate = dailyHistory[0]?.date;
+  const lastDate = dailyHistory.at(-1)?.date;
+  const currencies = requiredExchangeRateCurrencies(dailyHistory);
+  const historyExchangeRates = !firstDate || !lastDate || currencies.length === 0
+    ? []
+    : await query.overviewExchangeRates({
+      kind: "current",
+      product: "overview",
+      selection: "history",
+      currencies,
+      firstDate,
+      lastDate,
+    });
 
-    return {
-      importedAt: latestImportedAt(visibleData),
-      summary: buildSummaryMetrics(accounts),
-      dailyHistory,
-      accounts,
-      sankey,
-      sankeyExchangeRates,
-      sankeyLatestExchangeRateDate: sankeyExchangeRates.reduce<string | null>(
-        (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
-        null,
-      ),
-      exchangeRates: historyExchangeRates,
-      latestExchangeRateDate: historyExchangeRates.reduce<string | null>(
-        (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
-        null,
-      ),
-    };
+  return {
+    importedAt: latestImportedAt(visibleData),
+    summary: buildSummaryMetrics(accounts),
+    dailyHistory,
+    accounts,
+    sankey,
+    sankeyExchangeRates,
+    sankeyLatestExchangeRateDate: sankeyExchangeRates.reduce<string | null>(
+      (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
+      null,
+    ),
+    exchangeRates: historyExchangeRates,
+    latestExchangeRateDate: historyExchangeRates.reduce<string | null>(
+      (latest, rate) => !latest || rate.rateDate > latest ? rate.rateDate : latest,
+      null,
+    ),
+  };
 }
 
 function latestImportedAt(data: LedgerQueryData) {
@@ -56,45 +68,4 @@ function latestImportedAt(data: LedgerQueryData) {
     ...data.creditCardSnapshots.map((snapshot) => snapshot.capturedAt),
     ...data.maicoinAccountSnapshots.map((snapshot) => snapshot.capturedAt),
   ].sort().at(-1) ?? null;
-}
-
-function latestExchangeRates(
-  rows: ExchangeRateQueryRow[],
-  currencies: string[],
-): OverviewPageDto["sankeyExchangeRates"] {
-  const selected = new Set(currencies);
-  const latest = new Map<string, ExchangeRateQueryRow>();
-  for (const row of rows) {
-    if (!selected.has(row.currency)) continue;
-    const previous = latest.get(row.currency);
-    if (!previous || row.rateDate > previous.rateDate) latest.set(row.currency, row);
-  }
-  return [...latest.values()]
-    .sort((left, right) => left.currency.localeCompare(right.currency))
-    .map((row) => ({ ...row }));
-}
-
-function historicalExchangeRates(
-  rows: ExchangeRateQueryRow[],
-  currencies: string[],
-  firstDate: string,
-  lastDate: string,
-): OverviewPageDto["exchangeRates"] {
-  const selected = new Set(currencies);
-  const byCurrency = new Map<string, ExchangeRateQueryRow[]>();
-  for (const row of rows) {
-    if (!selected.has(row.currency) || row.rateDate > lastDate) continue;
-    const current = byCurrency.get(row.currency) ?? [];
-    current.push(row);
-    byCurrency.set(row.currency, current);
-  }
-  return [...byCurrency.entries()]
-    .flatMap(([currency, currencyRows]) => {
-      const prior = currencyRows
-        .filter((row) => row.rateDate < firstDate)
-        .sort((left, right) => right.rateDate.localeCompare(left.rateDate))[0];
-      return currencyRows.filter((row) => row.rateDate >= firstDate).concat(prior ? [prior] : []);
-    })
-    .sort((left, right) => left.currency.localeCompare(right.currency) || left.rateDate.localeCompare(right.rateDate))
-    .map((row) => ({ ...row }));
 }

--- a/src/lib/shared-ledger/server/financial-query.check.ts
+++ b/src/lib/shared-ledger/server/financial-query.check.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createFinancialQuery,
+  type FinancialQueryBoundary,
+} from "./financial-query.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const loaders = [
+  ["assets", join(here, "../../assets/server/load-assets.ts")],
+  ["overview", join(here, "../../overview/server/load-overview.ts")],
+  ["spending", join(here, "../../spending/server/store.ts")],
+  ["liabilities", join(here, "../../liabilities/server/load-liabilities.ts")],
+] as const;
+
+for (const [product, path] of loaders) {
+  const source = readFileSync(path, "utf8");
+  assert.match(source, /financial-query\.ts/);
+  const loaderSource = product === "spending"
+    ? source.slice(source.indexOf("export function loadSpending"), source.indexOf("export function updateSpending"))
+    : source;
+  assert.doesNotMatch(loaderSource, /openLedger(?:Database|Drizzle)/);
+  assert.doesNotMatch(loaderSource, /\.prepare\(/);
+  assert.doesNotMatch(loaderSource, /ledger\/db\/schema\.ts/);
+  assert.match(source, new RegExp(`product: ["']${product}["']`));
+}
+
+const boundary: FinancialQueryBoundary = createFinancialQuery();
+assert.equal(typeof boundary.current, "function");
+assert.equal(typeof boundary.historical, "function");
+assert.equal(typeof boundary.lineage, "function");
+const historical = await boundary.historical({
+  kind: "historical",
+  product: "overview",
+  financialCutoff: "2026-01-01",
+});
+assert.deepEqual(historical, {
+  status: "unsupported",
+  kind: "historical",
+  reason: "legacy-adapter-does-not-support-historical-queries",
+});
+const lineage = await boundary.lineage({
+  kind: "lineage",
+  product: "overview",
+  subject: { type: "account", id: "example" },
+});
+assert.deepEqual(lineage, {
+  status: "unsupported",
+  kind: "lineage",
+  reason: "legacy-adapter-does-not-support-lineage-queries",
+});

--- a/src/lib/shared-ledger/server/financial-query.check.ts
+++ b/src/lib/shared-ledger/server/financial-query.check.ts
@@ -35,9 +35,9 @@ for (const [product, path] of loaders) {
 
 const boundary: FinancialQueryBoundary = createFinancialQuery();
 assert.equal(typeof boundary.current, "function");
-assert.equal(typeof boundary.overviewExchangeRates, "function");
 assert.equal(typeof boundary.historical, "function");
 assert.equal(typeof boundary.lineage, "function");
+assert.equal("overviewExchangeRates" in boundary, false);
 const boundarySource = readFileSync(join(here, "financial-query.ts"), "utf8");
 assert.doesNotMatch(boundarySource, /projection:\s*unknown/);
 assert.doesNotMatch(boundarySource, /lineage:\s*unknown/);
@@ -77,6 +77,26 @@ assert.deepEqual(lineageContract, {
   kind: "lineage",
   reason: "legacy-adapter-does-not-support-lineage-queries",
 });
+
+const latestExchangeRates = await boundary.current({
+  kind: "current",
+  product: "overview",
+  selection: "latest",
+  currencies: ["USD"],
+});
+assert.equal(latestExchangeRates.product, "overview");
+assert.equal(latestExchangeRates.selection, "latest");
+
+const historicalExchangeRates = await boundary.current({
+  kind: "current",
+  product: "overview",
+  selection: "history",
+  currencies: ["USD"],
+  firstDate: "2026-01-01",
+  lastDate: "2026-01-31",
+});
+assert.equal(historicalExchangeRates.product, "overview");
+assert.equal(historicalExchangeRates.selection, "history");
 
 const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "financial-query-boundary-"));
 try {

--- a/src/lib/shared-ledger/server/financial-query.check.ts
+++ b/src/lib/shared-ledger/server/financial-query.check.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createFinancialQuery,
+  type HistoricalFinancialProjection,
+  type HistoricalFinancialQueryResult,
+  type LineageFinancialProjection,
+  type LineageFinancialQueryResult,
   type FinancialQueryBoundary,
 } from "./financial-query.ts";
+import { seedMockLedger } from "../../../ledger/seed-mock-ledger-db.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const loaders = [
@@ -29,25 +35,64 @@ for (const [product, path] of loaders) {
 
 const boundary: FinancialQueryBoundary = createFinancialQuery();
 assert.equal(typeof boundary.current, "function");
+assert.equal(typeof boundary.overviewExchangeRates, "function");
 assert.equal(typeof boundary.historical, "function");
 assert.equal(typeof boundary.lineage, "function");
-const historical = await boundary.historical({
+const boundarySource = readFileSync(join(here, "financial-query.ts"), "utf8");
+assert.doesNotMatch(boundarySource, /projection:\s*unknown/);
+assert.doesNotMatch(boundarySource, /lineage:\s*unknown/);
+for (const [reader, forbidden] of [
+  ["readCurrentAssets", /exchange_rates|loadSpendingQueryData/],
+  ["readCurrentLiabilities", /exchange_rates|loadSpendingQueryData/],
+  ["readCurrentOverview", /fundBuyTransactions|fundRedemptionTransactions|brokerageTradeTransactions|loadSpendingQueryData/],
+] as const) {
+  const start = boundarySource.indexOf(`private async ${reader}`);
+  const end = boundarySource.indexOf("\n  private ", start + 1);
+  assert.ok(start >= 0, `${reader} must be a private product reader`);
+  assert.doesNotMatch(boundarySource.slice(start, end < 0 ? undefined : end), forbidden);
+}
+
+type Assert<T extends true> = T;
+type Equal<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends
+  (<Value>() => Value extends Right ? 1 : 2) ? true : false;
+type _HistoricalProjectionHasNoLegacyPayload = Assert<Equal<HistoricalFinancialProjection<never>["projection"], never>>;
+type _LineageProjectionHasNoLegacyPayload = Assert<Equal<LineageFinancialProjection<never>["lineage"][number], never>>;
+const historicalContract: HistoricalFinancialQueryResult<never> = await boundary.historical({
   kind: "historical",
   product: "overview",
-  financialCutoff: "2026-01-01",
+  cutoff: { kind: "both", financialAt: "2026-01-01", knowledgeAt: "2026-01-02" },
 });
-assert.deepEqual(historical, {
+assert.deepEqual(historicalContract, {
   status: "unsupported",
   kind: "historical",
   reason: "legacy-adapter-does-not-support-historical-queries",
 });
-const lineage = await boundary.lineage({
+const lineageContract: LineageFinancialQueryResult<never> = await boundary.lineage({
   kind: "lineage",
   product: "overview",
-  subject: { type: "account", id: "example" },
+  subject: { kind: "account", id: "example" },
 });
-assert.deepEqual(lineage, {
+assert.deepEqual(lineageContract, {
   status: "unsupported",
   kind: "lineage",
   reason: "legacy-adapter-does-not-support-lineage-queries",
 });
+
+const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "financial-query-boundary-"));
+try {
+  seedMockLedger(ledgerDir, new Date("2026-07-11T04:00:00.000Z"));
+  const productQuery = createFinancialQuery(ledgerDir);
+  const assets = await productQuery.current({ kind: "current", product: "assets" });
+  assert.deepEqual(assets.ledger.creditCardStatementLines, []);
+  assert.deepEqual(assets.ledger.creditCardSnapshots, []);
+  assert.deepEqual(assets.ledger.loanTransactions, []);
+  const overview = await productQuery.current({ kind: "current", product: "overview" });
+  assert.deepEqual(overview.ledger.fundBuyTransactions, []);
+  assert.deepEqual(overview.ledger.brokerageTradeTransactions, []);
+  const liabilities = await productQuery.current({ kind: "current", product: "liabilities" });
+  assert.deepEqual(liabilities.ledger.maicoinStatementRows, []);
+  const spending = productQuery.current({ kind: "current", product: "spending" });
+  assert.equal(spending.product, "spending");
+} finally {
+  await rm(ledgerDir, { recursive: true, force: true });
+}

--- a/src/lib/shared-ledger/server/financial-query.ts
+++ b/src/lib/shared-ledger/server/financial-query.ts
@@ -22,34 +22,41 @@ import type { AccountRowDto } from "../types.ts";
 
 /** Products that may consume the financial query boundary. */
 export type FinancialProduct = "assets" | "overview" | "spending" | "liabilities";
+export type LedgerFinancialProduct = Exclude<FinancialProduct, "spending">;
 
-export type CurrentFinancialQueryRequest = {
+export type CurrentFinancialQueryRequest<Product extends FinancialProduct = FinancialProduct> = {
   kind: "current";
-  product: FinancialProduct;
+  product: Product;
 };
+
+export type HistoricalCutoff =
+  | { kind: "financial-time"; at: string }
+  | { kind: "knowledge-time"; at: string }
+  | { kind: "both"; financialAt: string; knowledgeAt: string };
 
 export type HistoricalFinancialQueryRequest = {
   kind: "historical";
   product: FinancialProduct;
-  financialCutoff?: string;
-  knowledgeCutoff?: string;
+  cutoff: HistoricalCutoff;
 };
 
-export type LineageFinancialQueryRequest = {
+export type LineageSubject<SubjectKind extends string = string> = {
+  kind: SubjectKind;
+  id: string;
+};
+
+export type LineageFinancialQueryRequest<SubjectKind extends string = string> = {
   kind: "lineage";
   product: FinancialProduct;
-  subject: {
-    type: string;
-    id: string;
-  };
+  subject: LineageSubject<SubjectKind>;
 };
 
-export type UnsupportedFinancialQueryResult = {
+export type UnsupportedFinancialQueryResult<Kind extends "historical" | "lineage"> = {
   status: "unsupported";
-  kind: "historical" | "lineage";
-  reason:
-    | "legacy-adapter-does-not-support-historical-queries"
-    | "legacy-adapter-does-not-support-lineage-queries";
+  kind: Kind;
+  reason: Kind extends "historical"
+    ? "legacy-adapter-does-not-support-historical-queries"
+    : "legacy-adapter-does-not-support-lineage-queries";
 };
 
 export type ExchangeRateQueryRow = {
@@ -58,10 +65,26 @@ export type ExchangeRateQueryRow = {
   twdPerUnit: number;
 };
 
+export type OverviewExchangeRateQueryRequest =
+  | {
+    kind: "current";
+    product: "overview";
+    selection: "latest";
+    currencies: string[];
+  }
+  | {
+    kind: "current";
+    product: "overview";
+    selection: "history";
+    currencies: string[];
+    firstDate: string;
+    lastDate: string;
+  };
+
 export type LegacySpendingInvoiceRow = {
   invoice_key: string;
   invoice_id: string;
-  issued_at: unknown;
+  issued_at: number | string | null;
   invoice_amount: number | null;
   seller_business_account_number: string | null;
   seller_name: string | null;
@@ -106,16 +129,14 @@ export type LegacySpendingQueryData = {
   overrides: LegacySpendingOverrideRow[];
 };
 
-export type CurrentFinancialQueryResult = {
+export type CurrentLedgerQueryResult<Product extends LedgerFinancialProduct> = {
   status: "ok";
   kind: "current";
-  product: FinancialProduct;
+  product: Product;
   /** Legacy rows after the established active-lineage visibility rules. */
   ledger: LedgerQueryData;
   unavailableAccountIssues: UnavailableAccountIssue[];
   unavailableAccounts: AccountRowDto[];
-  exchangeRates: ExchangeRateQueryRow[];
-  spending: LegacySpendingQueryData;
 };
 
 export type CurrentSpendingQueryResult = {
@@ -125,45 +146,50 @@ export type CurrentSpendingQueryResult = {
   spending: LegacySpendingQueryData;
 };
 
-export type HistoricalFinancialProjection = {
+export type CurrentFinancialQueryResult<Product extends FinancialProduct = FinancialProduct> =
+  Product extends "spending"
+    ? CurrentSpendingQueryResult
+    : Product extends LedgerFinancialProduct
+      ? CurrentLedgerQueryResult<Product>
+      : never;
+
+export type HistoricalFinancialProjection<Projection = never> = {
   status: "ok";
   kind: "historical";
   product: FinancialProduct;
-  financialCutoff: string | null;
-  knowledgeCutoff: string | null;
-  /** Canonical implementations will provide a typed projection here. */
-  projection: unknown;
+  cutoff: HistoricalCutoff;
+  projection: Projection;
 };
 
-export type HistoricalFinancialQueryResult =
-  | HistoricalFinancialProjection
-  | UnsupportedFinancialQueryResult;
+export type HistoricalFinancialQueryResult<Projection = never> =
+  | HistoricalFinancialProjection<Projection>
+  | UnsupportedFinancialQueryResult<"historical">;
 
-export type LineageFinancialProjection = {
+export type LineageFinancialProjection<Entry = never, SubjectKind extends string = string> = {
   status: "ok";
   kind: "lineage";
   product: FinancialProduct;
-  subject: LineageFinancialQueryRequest["subject"];
-  /** Canonical implementations will provide typed assertion lineage here. */
-  lineage: unknown;
+  subject: LineageSubject<SubjectKind>;
+  lineage: readonly Entry[];
 };
 
-export type LineageFinancialQueryResult =
-  | LineageFinancialProjection
-  | UnsupportedFinancialQueryResult;
+export type LineageFinancialQueryResult<Entry = never, SubjectKind extends string = string> =
+  | LineageFinancialProjection<Entry, SubjectKind>
+  | UnsupportedFinancialQueryResult<"lineage">;
 
 export interface FinancialQueryBoundary {
-  current(request: CurrentFinancialQueryRequest & { product: "spending" }): CurrentSpendingQueryResult;
-  current(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult>;
-  /** Synchronous current seam retained for the existing synchronous spending API. */
-  currentSpending(request: CurrentFinancialQueryRequest): CurrentSpendingQueryResult;
-  historical(request: HistoricalFinancialQueryRequest): Promise<HistoricalFinancialQueryResult>;
-  lineage(request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult>;
+  current(request: CurrentFinancialQueryRequest<"spending">): CurrentSpendingQueryResult;
+  current<Product extends LedgerFinancialProduct>(
+    request: CurrentFinancialQueryRequest<Product>,
+  ): Promise<CurrentLedgerQueryResult<Product>>;
+  overviewExchangeRates(request: OverviewExchangeRateQueryRequest): Promise<ExchangeRateQueryRow[]>;
+  historical(request: HistoricalFinancialQueryRequest): Promise<HistoricalFinancialQueryResult<never>>;
+  lineage(request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult<never>>;
 }
 
 /**
  * Creates the product read boundary. The default implementation is deliberately
- * a legacy adapter; it preserves the current ledger behavior while leaving the
+ * a legacy adapter; it preserves current ledger behavior while leaving the
  * Current/Historical/Lineage contract seam ready for a canonical store.
  */
 export function createFinancialQuery(ledgerDir = DEFAULT_LEDGER_DIR): FinancialQueryBoundary {
@@ -177,30 +203,93 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
     this.ledgerDir = ledgerDir;
   }
 
-  current(request: CurrentFinancialQueryRequest & { product: "spending" }): CurrentSpendingQueryResult;
-  current(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult>;
+  current(request: CurrentFinancialQueryRequest<"spending">): CurrentSpendingQueryResult;
+  current<Product extends LedgerFinancialProduct>(
+    request: CurrentFinancialQueryRequest<Product>,
+  ): Promise<CurrentLedgerQueryResult<Product>>;
   current(
     request: CurrentFinancialQueryRequest,
-  ): Promise<CurrentFinancialQueryResult> | CurrentSpendingQueryResult {
-    if (request.product === "spending") return this.currentSpending(request);
-    return this.currentAsync(request);
+  ): CurrentSpendingQueryResult | Promise<CurrentLedgerQueryResult<LedgerFinancialProduct>> {
+    if (request.product === "spending") return this.readCurrentSpending();
+    if (request.product === "assets") return this.readCurrentAssets();
+    if (request.product === "overview") return this.readCurrentOverview();
+    return this.readCurrentLiabilities();
   }
 
-  private async currentAsync(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult> {
+  async overviewExchangeRates(request: OverviewExchangeRateQueryRequest): Promise<ExchangeRateQueryRow[]> {
+    if (request.currencies.length === 0) return [];
+    const sqlite = openLedgerDatabase(this.ledgerDir);
+    try {
+      const placeholders = request.currencies.map(() => "?").join(", ");
+      if (request.selection === "latest") {
+        return (sqlite.prepare(`
+          SELECT rate.rate_date AS rateDate, rate.currency, rate.twd_per_unit AS twdPerUnit
+          FROM exchange_rates AS rate
+          WHERE rate.currency IN (${placeholders})
+            AND rate.rate_date = (
+              SELECT MAX(rate_date)
+              FROM exchange_rates AS current_rate
+              WHERE current_rate.currency = rate.currency
+            )
+          ORDER BY rate.currency
+        `).all(...request.currencies) as ExchangeRateQueryRow[]).map((rate) => ({ ...rate }));
+      }
+      return (sqlite.prepare(`
+        SELECT
+          rate_date AS rateDate,
+          currency,
+          twd_per_unit AS twdPerUnit
+        FROM exchange_rates AS rate
+        WHERE currency IN (${placeholders})
+          AND rate_date <= ?
+          AND (
+            rate_date >= ?
+            OR rate_date = (
+              SELECT MAX(rate_date)
+              FROM exchange_rates AS prior
+              WHERE prior.currency = rate.currency
+                AND prior.rate_date < ?
+            )
+          )
+        ORDER BY currency, rate_date
+      `).all(...request.currencies, request.lastDate, request.firstDate, request.firstDate) as ExchangeRateQueryRow[])
+        .map((rate) => ({ ...rate }));
+    } finally {
+      sqlite.close();
+    }
+  }
+
+  async historical(
+    _request: HistoricalFinancialQueryRequest,
+  ): Promise<HistoricalFinancialQueryResult<never>> {
+    return {
+      status: "unsupported",
+      kind: "historical",
+      reason: "legacy-adapter-does-not-support-historical-queries",
+    };
+  }
+
+  async lineage(
+    _request: LineageFinancialQueryRequest,
+  ): Promise<LineageFinancialQueryResult<never>> {
+    return {
+      status: "unsupported",
+      kind: "lineage",
+      reason: "legacy-adapter-does-not-support-lineage-queries",
+    };
+  }
+
+  private async readCurrentAssets(): Promise<CurrentLedgerQueryResult<"assets">> {
     const { db, sqlite } = openLedgerDrizzle(this.ledgerDir);
     try {
-      const rawData: LedgerQueryData = {
+      const data: LedgerQueryData = {
         ...emptyLedgerQueryData(),
-        importRuns: await db.select().from(schema.importRuns).all(),
         sourceFiles: await db.select().from(schema.sourceFileImports).all(),
         sourceRowLineage: await db.select().from(schema.sourceRowLineage).all(),
         accountTransactions: await db.select().from(schema.accountTransactions).all(),
         foreignCurrencyTransactions: await db.select().from(schema.foreignCurrencyTransactions).all(),
-        creditCardStatementLines: await db.select().from(schema.creditCardStatementLines).all(),
         creditCardCaptures: await db.select().from(schema.creditCardCaptures).all(),
         creditCardCaptureEntries: await db.select().from(schema.creditCardCaptureEntries).all(),
-        creditCardSnapshots: await db.select().from(schema.creditCardSnapshots).all(),
-        loanTransactions: await db.select().from(schema.loanTransactions).all(),
         fundHoldings: await db.select().from(schema.fundHoldings).all(),
         fundBuyTransactions: await db.select().from(schema.fundBuyTransactions).all(),
         fundRedemptionTransactions: await db.select().from(schema.fundRedemptionTransactions).all(),
@@ -211,32 +300,57 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
         maicoinAccountSnapshots: await db.select().from(schema.maicoinAccountSnapshots).all(),
         maicoinStatementRows: await db.select().from(schema.maicoinStatementRows).all(),
       };
-      const productData = ledgerDataForProduct(rawData, request.product);
-      const support = loadActiveLedgerSupport(sqlite);
-      const unavailableAccountIssues = loadUnavailableAccountIssues(sqlite, productData, support);
-      return {
-        status: "ok",
-        kind: "current",
-        product: request.product,
-        ledger: applyLedgerVisibility(productData, support),
-        unavailableAccountIssues,
-        unavailableAccounts: unavailableAccountIssues.map(unavailableAccountFromIssue),
-        exchangeRates: (await db.select().from(schema.exchangeRates).all()).map((rate) => ({
-          rateDate: rate.rateDate,
-          currency: rate.currency,
-          twdPerUnit: rate.twdPerUnit,
-        })),
-        spending: loadSpendingQueryData(sqlite),
-      };
+      return currentLedgerResult(sqlite, "assets", data);
     } finally {
       sqlite.close();
     }
   }
 
-  currentSpending(request: CurrentFinancialQueryRequest): CurrentSpendingQueryResult {
-    if (request.product !== "spending") {
-      throw new Error(`Synchronous current query is only available for spending: ${request.product}`);
+  private async readCurrentOverview(): Promise<CurrentLedgerQueryResult<"overview">> {
+    const { db, sqlite } = openLedgerDrizzle(this.ledgerDir);
+    try {
+      const data: LedgerQueryData = {
+        ...emptyLedgerQueryData(),
+        sourceFiles: await db.select().from(schema.sourceFileImports).all(),
+        sourceRowLineage: await db.select().from(schema.sourceRowLineage).all(),
+        accountTransactions: await db.select().from(schema.accountTransactions).all(),
+        foreignCurrencyTransactions: await db.select().from(schema.foreignCurrencyTransactions).all(),
+        creditCardStatementLines: await db.select().from(schema.creditCardStatementLines).all(),
+        creditCardCaptures: await db.select().from(schema.creditCardCaptures).all(),
+        creditCardCaptureEntries: await db.select().from(schema.creditCardCaptureEntries).all(),
+        creditCardSnapshots: await db.select().from(schema.creditCardSnapshots).all(),
+        loanTransactions: await db.select().from(schema.loanTransactions).all(),
+        fundHoldings: await db.select().from(schema.fundHoldings).all(),
+        brokerageHoldings: await db.select().from(schema.brokerageHoldings).all(),
+        maicoinAccountSnapshots: await db.select().from(schema.maicoinAccountSnapshots).all(),
+        maicoinStatementRows: await db.select().from(schema.maicoinStatementRows).all(),
+      };
+      return currentLedgerResult(sqlite, "overview", data);
+    } finally {
+      sqlite.close();
     }
+  }
+
+  private async readCurrentLiabilities(): Promise<CurrentLedgerQueryResult<"liabilities">> {
+    const { db, sqlite } = openLedgerDrizzle(this.ledgerDir);
+    try {
+      const data: LedgerQueryData = {
+        ...emptyLedgerQueryData(),
+        sourceFiles: await db.select().from(schema.sourceFileImports).all(),
+        creditCardStatementLines: await db.select().from(schema.creditCardStatementLines).all(),
+        creditCardCaptures: await db.select().from(schema.creditCardCaptures).all(),
+        creditCardCaptureEntries: await db.select().from(schema.creditCardCaptureEntries).all(),
+        creditCardSnapshots: await db.select().from(schema.creditCardSnapshots).all(),
+        loanTransactions: await db.select().from(schema.loanTransactions).all(),
+        maicoinAccountSnapshots: await db.select().from(schema.maicoinAccountSnapshots).all(),
+      };
+      return currentLedgerResult(sqlite, "liabilities", data);
+    } finally {
+      sqlite.close();
+    }
+  }
+
+  private readCurrentSpending(): CurrentSpendingQueryResult {
     const sqlite = openLedgerDatabase(this.ledgerDir);
     try {
       return {
@@ -249,59 +363,23 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
       sqlite.close();
     }
   }
-
-  async historical(
-    _request: HistoricalFinancialQueryRequest,
-  ): Promise<HistoricalFinancialQueryResult> {
-    return {
-      status: "unsupported",
-      kind: "historical",
-      reason: "legacy-adapter-does-not-support-historical-queries",
-    };
-  }
-
-  async lineage(_request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult> {
-    return {
-      status: "unsupported",
-      kind: "lineage",
-      reason: "legacy-adapter-does-not-support-lineage-queries",
-    };
-  }
 }
 
-function ledgerDataForProduct(data: LedgerQueryData, product: FinancialProduct): LedgerQueryData {
-  const scoped = emptyLedgerQueryData();
-  scoped.sourceFiles = data.sourceFiles;
-  scoped.sourceRowLineage = data.sourceRowLineage;
-  if (product === "assets" || product === "overview") {
-    scoped.accountTransactions = data.accountTransactions;
-    scoped.foreignCurrencyTransactions = data.foreignCurrencyTransactions;
-  }
-  if (product === "overview" || product === "liabilities") {
-    scoped.creditCardStatementLines = data.creditCardStatementLines;
-    scoped.creditCardSnapshots = data.creditCardSnapshots;
-    scoped.loanTransactions = data.loanTransactions;
-  }
-  if (product === "assets" || product === "overview" || product === "liabilities") {
-    scoped.creditCardCaptures = data.creditCardCaptures;
-    scoped.creditCardCaptureEntries = data.creditCardCaptureEntries;
-    scoped.maicoinAccountSnapshots = data.maicoinAccountSnapshots;
-  }
-  if (product === "assets" || product === "overview") {
-    scoped.maicoinStatementRows = data.maicoinStatementRows;
-  }
-  if (product === "assets" || product === "overview") {
-    scoped.fundHoldings = data.fundHoldings;
-    scoped.brokerageHoldings = data.brokerageHoldings;
-  }
-  if (product === "assets") {
-    scoped.fundBuyTransactions = data.fundBuyTransactions;
-    scoped.fundRedemptionTransactions = data.fundRedemptionTransactions;
-    scoped.fundCashDividends = data.fundCashDividends;
-    scoped.fundConversionTransactions = data.fundConversionTransactions;
-    scoped.brokerageTradeTransactions = data.brokerageTradeTransactions;
-  }
-  return scoped;
+function currentLedgerResult<Product extends LedgerFinancialProduct>(
+  sqlite: ReturnType<typeof openLedgerDrizzle>["sqlite"],
+  product: Product,
+  data: LedgerQueryData,
+): CurrentLedgerQueryResult<Product> {
+  const support = loadActiveLedgerSupport(sqlite);
+  const unavailableAccountIssues = loadUnavailableAccountIssues(sqlite, data, support);
+  return {
+    status: "ok",
+    kind: "current",
+    product,
+    ledger: applyLedgerVisibility(data, support),
+    unavailableAccountIssues,
+    unavailableAccounts: unavailableAccountIssues.map(unavailableAccountFromIssue),
+  };
 }
 
 function loadSpendingQueryData(db: ReturnType<typeof openLedgerDrizzle>["sqlite"]): LegacySpendingQueryData {

--- a/src/lib/shared-ledger/server/financial-query.ts
+++ b/src/lib/shared-ledger/server/financial-query.ts
@@ -24,10 +24,36 @@ import type { AccountRowDto } from "../types.ts";
 export type FinancialProduct = "assets" | "overview" | "spending" | "liabilities";
 export type LedgerFinancialProduct = Exclude<FinancialProduct, "spending">;
 
-export type CurrentFinancialQueryRequest<Product extends FinancialProduct = FinancialProduct> = {
+export type CurrentOverviewLedgerQueryRequest = {
   kind: "current";
-  product: Product;
+  product: "overview";
 };
+
+export type CurrentOverviewExchangeRateQueryRequest =
+  | {
+    kind: "current";
+    product: "overview";
+    selection: "latest";
+    currencies: string[];
+  }
+  | {
+    kind: "current";
+    product: "overview";
+    selection: "history";
+    currencies: string[];
+    firstDate: string;
+    lastDate: string;
+  };
+
+type CurrentRequestByProduct = {
+  assets: { kind: "current"; product: "assets" };
+  overview: CurrentOverviewLedgerQueryRequest | CurrentOverviewExchangeRateQueryRequest;
+  spending: { kind: "current"; product: "spending" };
+  liabilities: { kind: "current"; product: "liabilities" };
+};
+
+export type CurrentFinancialQueryRequest<Product extends FinancialProduct = FinancialProduct> =
+  CurrentRequestByProduct[Product];
 
 export type HistoricalCutoff =
   | { kind: "financial-time"; at: string }
@@ -64,22 +90,6 @@ export type ExchangeRateQueryRow = {
   currency: string;
   twdPerUnit: number;
 };
-
-export type OverviewExchangeRateQueryRequest =
-  | {
-    kind: "current";
-    product: "overview";
-    selection: "latest";
-    currencies: string[];
-  }
-  | {
-    kind: "current";
-    product: "overview";
-    selection: "history";
-    currencies: string[];
-    firstDate: string;
-    lastDate: string;
-  };
 
 export type LegacySpendingInvoiceRow = {
   invoice_key: string;
@@ -146,10 +156,20 @@ export type CurrentSpendingQueryResult = {
   spending: LegacySpendingQueryData;
 };
 
+export type CurrentOverviewExchangeRateQueryResult = {
+  status: "ok";
+  kind: "current";
+  product: "overview";
+  selection: "latest" | "history";
+  exchangeRates: ExchangeRateQueryRow[];
+};
+
 export type CurrentFinancialQueryResult<Product extends FinancialProduct = FinancialProduct> =
   Product extends "spending"
     ? CurrentSpendingQueryResult
-    : Product extends LedgerFinancialProduct
+    : Product extends "overview"
+      ? CurrentLedgerQueryResult<"overview"> | CurrentOverviewExchangeRateQueryResult
+      : Product extends LedgerFinancialProduct
       ? CurrentLedgerQueryResult<Product>
       : never;
 
@@ -179,10 +199,11 @@ export type LineageFinancialQueryResult<Entry = never, SubjectKind extends strin
 
 export interface FinancialQueryBoundary {
   current(request: CurrentFinancialQueryRequest<"spending">): CurrentSpendingQueryResult;
+  current(request: CurrentOverviewLedgerQueryRequest): Promise<CurrentLedgerQueryResult<"overview">>;
+  current(request: CurrentOverviewExchangeRateQueryRequest): Promise<CurrentOverviewExchangeRateQueryResult>;
   current<Product extends LedgerFinancialProduct>(
-    request: CurrentFinancialQueryRequest<Product>,
+    request: CurrentFinancialQueryRequest<Product> & { product: Exclude<Product, "overview"> },
   ): Promise<CurrentLedgerQueryResult<Product>>;
-  overviewExchangeRates(request: OverviewExchangeRateQueryRequest): Promise<ExchangeRateQueryRow[]>;
   historical(request: HistoricalFinancialQueryRequest): Promise<HistoricalFinancialQueryResult<never>>;
   lineage(request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult<never>>;
 }
@@ -204,25 +225,41 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
   }
 
   current(request: CurrentFinancialQueryRequest<"spending">): CurrentSpendingQueryResult;
+  current(request: CurrentOverviewLedgerQueryRequest): Promise<CurrentLedgerQueryResult<"overview">>;
+  current(request: CurrentOverviewExchangeRateQueryRequest): Promise<CurrentOverviewExchangeRateQueryResult>;
   current<Product extends LedgerFinancialProduct>(
     request: CurrentFinancialQueryRequest<Product>,
   ): Promise<CurrentLedgerQueryResult<Product>>;
   current(
     request: CurrentFinancialQueryRequest,
-  ): CurrentSpendingQueryResult | Promise<CurrentLedgerQueryResult<LedgerFinancialProduct>> {
+  ): CurrentSpendingQueryResult
+    | Promise<CurrentLedgerQueryResult<LedgerFinancialProduct> | CurrentOverviewExchangeRateQueryResult> {
     if (request.product === "spending") return this.readCurrentSpending();
+    if (request.product === "overview" && "selection" in request) {
+      return this.readCurrentOverviewExchangeRates(request);
+    }
     if (request.product === "assets") return this.readCurrentAssets();
     if (request.product === "overview") return this.readCurrentOverview();
     return this.readCurrentLiabilities();
   }
 
-  async overviewExchangeRates(request: OverviewExchangeRateQueryRequest): Promise<ExchangeRateQueryRow[]> {
-    if (request.currencies.length === 0) return [];
+  private async readCurrentOverviewExchangeRates(
+    request: CurrentOverviewExchangeRateQueryRequest,
+  ): Promise<CurrentOverviewExchangeRateQueryResult> {
+    if (request.currencies.length === 0) {
+      return {
+        status: "ok",
+        kind: "current",
+        product: "overview",
+        selection: request.selection,
+        exchangeRates: [],
+      };
+    }
     const sqlite = openLedgerDatabase(this.ledgerDir);
     try {
       const placeholders = request.currencies.map(() => "?").join(", ");
       if (request.selection === "latest") {
-        return (sqlite.prepare(`
+        const exchangeRates = (sqlite.prepare(`
           SELECT rate.rate_date AS rateDate, rate.currency, rate.twd_per_unit AS twdPerUnit
           FROM exchange_rates AS rate
           WHERE rate.currency IN (${placeholders})
@@ -233,8 +270,9 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
             )
           ORDER BY rate.currency
         `).all(...request.currencies) as ExchangeRateQueryRow[]).map((rate) => ({ ...rate }));
+        return { status: "ok", kind: "current", product: "overview", selection: "latest", exchangeRates };
       }
-      return (sqlite.prepare(`
+      const exchangeRates = (sqlite.prepare(`
         SELECT
           rate_date AS rateDate,
           currency,
@@ -254,6 +292,7 @@ class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
         ORDER BY currency, rate_date
       `).all(...request.currencies, request.lastDate, request.firstDate, request.firstDate) as ExchangeRateQueryRow[])
         .map((rate) => ({ ...rate }));
+      return { status: "ok", kind: "current", product: "overview", selection: "history", exchangeRates };
     } finally {
       sqlite.close();
     }

--- a/src/lib/shared-ledger/server/financial-query.ts
+++ b/src/lib/shared-ledger/server/financial-query.ts
@@ -19,6 +19,21 @@ import {
   type UnavailableAccountIssue,
 } from "./accounts.ts";
 import type { AccountRowDto } from "../types.ts";
+import {
+  createCathayCanonicalFinancialQuery as createCathayCanonicalQuery,
+  type CathayCanonicalFinancialQuery,
+} from "../../../ledger/canonical/cathay-domestic-deposit.ts";
+
+export type {
+  CanonicalAmount,
+  CathayCanonicalCommitResult,
+  CathayCanonicalCurrentQueryRequest,
+  CathayCanonicalCurrentQueryResult,
+  CathayCanonicalHistoricalQueryRequest,
+  CathayCanonicalHistoricalQueryResult,
+  CathayCanonicalLineageQueryRequest,
+  CathayCanonicalLineageQueryResult,
+} from "../../../ledger/canonical/cathay-domestic-deposit.ts";
 
 /** Products that may consume the financial query boundary. */
 export type FinancialProduct = "assets" | "overview" | "spending" | "liabilities";
@@ -215,6 +230,15 @@ export interface FinancialQueryBoundary {
  */
 export function createFinancialQuery(ledgerDir = DEFAULT_LEDGER_DIR): FinancialQueryBoundary {
   return new LegacyFinancialQueryAdapter(ledgerDir);
+}
+
+/** Canonical adapter factory kept alongside the phase-1 legacy boundary. */
+export type CanonicalFinancialQueryBoundary = CathayCanonicalFinancialQuery;
+
+export function createCathayCanonicalFinancialQuery(
+  ledgerDir = DEFAULT_LEDGER_DIR,
+): CanonicalFinancialQueryBoundary {
+  return createCathayCanonicalQuery(ledgerDir);
 }
 
 class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {

--- a/src/lib/shared-ledger/server/financial-query.ts
+++ b/src/lib/shared-ledger/server/financial-query.ts
@@ -1,0 +1,356 @@
+import {
+  DEFAULT_LEDGER_DIR,
+  openLedgerDatabase,
+  openLedgerDrizzle,
+} from "../../../ledger/db/client.ts";
+import * as schema from "../../../ledger/db/schema.ts";
+import type { SpendingCategory } from "../../spending/categories.ts";
+import type { SpendingReason, SpendingState } from "../../spending/model.ts";
+import {
+  activeImportSql,
+  applyLedgerVisibility,
+  loadActiveLedgerSupport,
+  loadUnavailableAccountIssues,
+} from "../../data-issues/server/ledger-visibility.ts";
+import {
+  emptyLedgerQueryData,
+  unavailableAccountFromIssue,
+  type LedgerQueryData,
+  type UnavailableAccountIssue,
+} from "./accounts.ts";
+import type { AccountRowDto } from "../types.ts";
+
+/** Products that may consume the financial query boundary. */
+export type FinancialProduct = "assets" | "overview" | "spending" | "liabilities";
+
+export type CurrentFinancialQueryRequest = {
+  kind: "current";
+  product: FinancialProduct;
+};
+
+export type HistoricalFinancialQueryRequest = {
+  kind: "historical";
+  product: FinancialProduct;
+  financialCutoff?: string;
+  knowledgeCutoff?: string;
+};
+
+export type LineageFinancialQueryRequest = {
+  kind: "lineage";
+  product: FinancialProduct;
+  subject: {
+    type: string;
+    id: string;
+  };
+};
+
+export type UnsupportedFinancialQueryResult = {
+  status: "unsupported";
+  kind: "historical" | "lineage";
+  reason:
+    | "legacy-adapter-does-not-support-historical-queries"
+    | "legacy-adapter-does-not-support-lineage-queries";
+};
+
+export type ExchangeRateQueryRow = {
+  rateDate: string;
+  currency: string;
+  twdPerUnit: number;
+};
+
+export type LegacySpendingInvoiceRow = {
+  invoice_key: string;
+  invoice_id: string;
+  issued_at: unknown;
+  invoice_amount: number | null;
+  seller_business_account_number: string | null;
+  seller_name: string | null;
+  seller_addr: string | null;
+  item_key: string | null;
+  item_sequence_number: number | null;
+  item_quantity: number | null;
+  item_unit_price: number | null;
+  item_paid_amount: number | null;
+  item_product_name: string | null;
+  category: SpendingCategory | null;
+};
+
+export type LegacySpendingAccountRow = {
+  statement_row_id: string;
+  bank: string;
+  account_number: string | null;
+  currency: string;
+  date: string;
+  transaction_time: string | null;
+  description: string | null;
+  note: string | null;
+  withdrawal_amount: number | null;
+  deposit_amount: number | null;
+};
+
+export type LegacySpendingCardPaymentRow = { date: string; twd_amount: number };
+
+export type LegacySpendingOverrideRow = {
+  statement_row_id: string;
+  state: SpendingState;
+  category: SpendingCategory | null;
+  automatic_state: SpendingState;
+  automatic_reason: SpendingReason | null;
+  updated_at: string;
+};
+
+export type LegacySpendingQueryData = {
+  invoices: LegacySpendingInvoiceRow[];
+  accountTransactions: LegacySpendingAccountRow[];
+  cardPayments: LegacySpendingCardPaymentRow[];
+  overrides: LegacySpendingOverrideRow[];
+};
+
+export type CurrentFinancialQueryResult = {
+  status: "ok";
+  kind: "current";
+  product: FinancialProduct;
+  /** Legacy rows after the established active-lineage visibility rules. */
+  ledger: LedgerQueryData;
+  unavailableAccountIssues: UnavailableAccountIssue[];
+  unavailableAccounts: AccountRowDto[];
+  exchangeRates: ExchangeRateQueryRow[];
+  spending: LegacySpendingQueryData;
+};
+
+export type CurrentSpendingQueryResult = {
+  status: "ok";
+  kind: "current";
+  product: "spending";
+  spending: LegacySpendingQueryData;
+};
+
+export type HistoricalFinancialProjection = {
+  status: "ok";
+  kind: "historical";
+  product: FinancialProduct;
+  financialCutoff: string | null;
+  knowledgeCutoff: string | null;
+  /** Canonical implementations will provide a typed projection here. */
+  projection: unknown;
+};
+
+export type HistoricalFinancialQueryResult =
+  | HistoricalFinancialProjection
+  | UnsupportedFinancialQueryResult;
+
+export type LineageFinancialProjection = {
+  status: "ok";
+  kind: "lineage";
+  product: FinancialProduct;
+  subject: LineageFinancialQueryRequest["subject"];
+  /** Canonical implementations will provide typed assertion lineage here. */
+  lineage: unknown;
+};
+
+export type LineageFinancialQueryResult =
+  | LineageFinancialProjection
+  | UnsupportedFinancialQueryResult;
+
+export interface FinancialQueryBoundary {
+  current(request: CurrentFinancialQueryRequest & { product: "spending" }): CurrentSpendingQueryResult;
+  current(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult>;
+  /** Synchronous current seam retained for the existing synchronous spending API. */
+  currentSpending(request: CurrentFinancialQueryRequest): CurrentSpendingQueryResult;
+  historical(request: HistoricalFinancialQueryRequest): Promise<HistoricalFinancialQueryResult>;
+  lineage(request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult>;
+}
+
+/**
+ * Creates the product read boundary. The default implementation is deliberately
+ * a legacy adapter; it preserves the current ledger behavior while leaving the
+ * Current/Historical/Lineage contract seam ready for a canonical store.
+ */
+export function createFinancialQuery(ledgerDir = DEFAULT_LEDGER_DIR): FinancialQueryBoundary {
+  return new LegacyFinancialQueryAdapter(ledgerDir);
+}
+
+class LegacyFinancialQueryAdapter implements FinancialQueryBoundary {
+  private readonly ledgerDir: string;
+
+  constructor(ledgerDir: string) {
+    this.ledgerDir = ledgerDir;
+  }
+
+  current(request: CurrentFinancialQueryRequest & { product: "spending" }): CurrentSpendingQueryResult;
+  current(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult>;
+  current(
+    request: CurrentFinancialQueryRequest,
+  ): Promise<CurrentFinancialQueryResult> | CurrentSpendingQueryResult {
+    if (request.product === "spending") return this.currentSpending(request);
+    return this.currentAsync(request);
+  }
+
+  private async currentAsync(request: CurrentFinancialQueryRequest): Promise<CurrentFinancialQueryResult> {
+    const { db, sqlite } = openLedgerDrizzle(this.ledgerDir);
+    try {
+      const rawData: LedgerQueryData = {
+        ...emptyLedgerQueryData(),
+        importRuns: await db.select().from(schema.importRuns).all(),
+        sourceFiles: await db.select().from(schema.sourceFileImports).all(),
+        sourceRowLineage: await db.select().from(schema.sourceRowLineage).all(),
+        accountTransactions: await db.select().from(schema.accountTransactions).all(),
+        foreignCurrencyTransactions: await db.select().from(schema.foreignCurrencyTransactions).all(),
+        creditCardStatementLines: await db.select().from(schema.creditCardStatementLines).all(),
+        creditCardCaptures: await db.select().from(schema.creditCardCaptures).all(),
+        creditCardCaptureEntries: await db.select().from(schema.creditCardCaptureEntries).all(),
+        creditCardSnapshots: await db.select().from(schema.creditCardSnapshots).all(),
+        loanTransactions: await db.select().from(schema.loanTransactions).all(),
+        fundHoldings: await db.select().from(schema.fundHoldings).all(),
+        fundBuyTransactions: await db.select().from(schema.fundBuyTransactions).all(),
+        fundRedemptionTransactions: await db.select().from(schema.fundRedemptionTransactions).all(),
+        fundCashDividends: await db.select().from(schema.fundCashDividends).all(),
+        fundConversionTransactions: await db.select().from(schema.fundConversionTransactions).all(),
+        brokerageHoldings: await db.select().from(schema.brokerageHoldings).all(),
+        brokerageTradeTransactions: await db.select().from(schema.brokerageTradeTransactions).all(),
+        maicoinAccountSnapshots: await db.select().from(schema.maicoinAccountSnapshots).all(),
+        maicoinStatementRows: await db.select().from(schema.maicoinStatementRows).all(),
+      };
+      const productData = ledgerDataForProduct(rawData, request.product);
+      const support = loadActiveLedgerSupport(sqlite);
+      const unavailableAccountIssues = loadUnavailableAccountIssues(sqlite, productData, support);
+      return {
+        status: "ok",
+        kind: "current",
+        product: request.product,
+        ledger: applyLedgerVisibility(productData, support),
+        unavailableAccountIssues,
+        unavailableAccounts: unavailableAccountIssues.map(unavailableAccountFromIssue),
+        exchangeRates: (await db.select().from(schema.exchangeRates).all()).map((rate) => ({
+          rateDate: rate.rateDate,
+          currency: rate.currency,
+          twdPerUnit: rate.twdPerUnit,
+        })),
+        spending: loadSpendingQueryData(sqlite),
+      };
+    } finally {
+      sqlite.close();
+    }
+  }
+
+  currentSpending(request: CurrentFinancialQueryRequest): CurrentSpendingQueryResult {
+    if (request.product !== "spending") {
+      throw new Error(`Synchronous current query is only available for spending: ${request.product}`);
+    }
+    const sqlite = openLedgerDatabase(this.ledgerDir);
+    try {
+      return {
+        status: "ok",
+        kind: "current",
+        product: "spending",
+        spending: loadSpendingQueryData(sqlite),
+      };
+    } finally {
+      sqlite.close();
+    }
+  }
+
+  async historical(
+    _request: HistoricalFinancialQueryRequest,
+  ): Promise<HistoricalFinancialQueryResult> {
+    return {
+      status: "unsupported",
+      kind: "historical",
+      reason: "legacy-adapter-does-not-support-historical-queries",
+    };
+  }
+
+  async lineage(_request: LineageFinancialQueryRequest): Promise<LineageFinancialQueryResult> {
+    return {
+      status: "unsupported",
+      kind: "lineage",
+      reason: "legacy-adapter-does-not-support-lineage-queries",
+    };
+  }
+}
+
+function ledgerDataForProduct(data: LedgerQueryData, product: FinancialProduct): LedgerQueryData {
+  const scoped = emptyLedgerQueryData();
+  scoped.sourceFiles = data.sourceFiles;
+  scoped.sourceRowLineage = data.sourceRowLineage;
+  if (product === "assets" || product === "overview") {
+    scoped.accountTransactions = data.accountTransactions;
+    scoped.foreignCurrencyTransactions = data.foreignCurrencyTransactions;
+  }
+  if (product === "overview" || product === "liabilities") {
+    scoped.creditCardStatementLines = data.creditCardStatementLines;
+    scoped.creditCardSnapshots = data.creditCardSnapshots;
+    scoped.loanTransactions = data.loanTransactions;
+  }
+  if (product === "assets" || product === "overview" || product === "liabilities") {
+    scoped.creditCardCaptures = data.creditCardCaptures;
+    scoped.creditCardCaptureEntries = data.creditCardCaptureEntries;
+    scoped.maicoinAccountSnapshots = data.maicoinAccountSnapshots;
+  }
+  if (product === "assets" || product === "overview") {
+    scoped.maicoinStatementRows = data.maicoinStatementRows;
+  }
+  if (product === "assets" || product === "overview") {
+    scoped.fundHoldings = data.fundHoldings;
+    scoped.brokerageHoldings = data.brokerageHoldings;
+  }
+  if (product === "assets") {
+    scoped.fundBuyTransactions = data.fundBuyTransactions;
+    scoped.fundRedemptionTransactions = data.fundRedemptionTransactions;
+    scoped.fundCashDividends = data.fundCashDividends;
+    scoped.fundConversionTransactions = data.fundConversionTransactions;
+    scoped.brokerageTradeTransactions = data.brokerageTradeTransactions;
+  }
+  return scoped;
+}
+
+function loadSpendingQueryData(db: ReturnType<typeof openLedgerDrizzle>["sqlite"]): LegacySpendingQueryData {
+  const invoices = db.prepare(`
+    SELECT
+      personal_invoices.invoice_key,
+      personal_invoices.invoice_id,
+      personal_invoices.issued_at,
+      personal_invoices.amount AS invoice_amount,
+      personal_invoices.seller_business_account_number,
+      personal_invoices.seller_name,
+      personal_invoices.seller_addr,
+      items.item_key,
+      items.item_sequence_number,
+      items.item_quantity,
+      items.item_unit_price,
+      items.item_paid_amount,
+      items.item_product_name,
+      items.category
+    FROM personal_invoices
+    LEFT JOIN personal_invoice_items AS items
+      ON items.invoice_key = personal_invoices.invoice_key
+      AND ${activeImportSql("personal_invoice_items", "items")}
+    WHERE personal_invoices.status = ?
+      AND ${activeImportSql("personal_invoices")}
+    ORDER BY personal_invoices.issued_at, personal_invoices.invoice_key,
+      items.item_sequence_number, items.item_key
+  `).all("confirmed") as LegacySpendingInvoiceRow[];
+  const accountTransactions = db.prepare(`
+    SELECT statement_row_id, bank, account_number, currency,
+      COALESCE(transaction_date, accounting_date) AS date,
+      transaction_time, description, note, withdrawal_amount, deposit_amount
+    FROM account_transactions
+    WHERE (withdrawal_amount > 0 OR deposit_amount > 0)
+      AND COALESCE(transaction_date, accounting_date) IS NOT NULL
+      AND ${activeImportSql("account_transactions")}
+    ORDER BY date, statement_row_id
+  `).all() as LegacySpendingAccountRow[];
+  const cardPayments = db.prepare(`
+    SELECT COALESCE(consume_date, posting_date) AS date, twd_amount
+    FROM credit_card_statement_lines
+    WHERE twd_amount < 0
+      AND COALESCE(consume_date, posting_date) IS NOT NULL
+      AND ${activeImportSql("credit_card_statement_lines")}
+  `).all() as LegacySpendingCardPaymentRow[];
+  const overrides = db.prepare(`
+    SELECT statement_row_id, state, category, automatic_state,
+      automatic_reason, updated_at
+    FROM spending_transaction_overrides
+  `).all() as LegacySpendingOverrideRow[];
+  return { invoices, accountTransactions, cardPayments, overrides };
+}

--- a/src/lib/spending/server/store.ts
+++ b/src/lib/spending/server/store.ts
@@ -11,49 +11,14 @@ import type {
 } from "../model.ts";
 import { buildSpendingModel, SPENDING_REASONS } from "../model.ts";
 import { activeImportSql } from "../../data-issues/server/ledger-visibility.ts";
+import {
+  createFinancialQuery,
+  type LegacySpendingAccountRow,
+  type LegacySpendingCardPaymentRow,
+  type LegacySpendingOverrideRow,
+} from "../../shared-ledger/server/financial-query.ts";
 
 export { activeImportSql };
-
-type SpendingRow = {
-  invoice_key: string;
-  invoice_id: string;
-  issued_at: unknown;
-  invoice_amount: number | null;
-  seller_business_account_number: string | null;
-  seller_name: string | null;
-  seller_addr: string | null;
-  item_key: string | null;
-  item_sequence_number: number | null;
-  item_quantity: number | null;
-  item_unit_price: number | null;
-  item_paid_amount: number | null;
-  item_product_name: string | null;
-  category: SpendingCategory | null;
-};
-
-type AccountRow = {
-  statement_row_id: string;
-  bank: string;
-  account_number: string | null;
-  currency: string;
-  date: string;
-  transaction_time: string | null;
-  description: string | null;
-  note: string | null;
-  withdrawal_amount: number | null;
-  deposit_amount: number | null;
-};
-
-type CardPaymentRow = { date: string; twd_amount: number };
-
-type OverrideRow = {
-  statement_row_id: string;
-  state: SpendingState;
-  category: SpendingCategory | null;
-  automatic_state: SpendingState;
-  automatic_reason: SpendingReason | null;
-  updated_at: string;
-};
 
 const SPENDING_STATES = new Set<SpendingState>(["included", "excluded", "pending"]);
 const SPENDING_REASON_SET = new Set<SpendingReason>(SPENDING_REASONS);
@@ -77,56 +42,15 @@ export function loadSpending(
   ledgerDir = DEFAULT_LEDGER_DIR,
   { selectedMonth, selectedCategory }: SpendingLoadInput = {},
 ): SpendingModel {
-  const db = openLedgerDatabase(ledgerDir);
-  try {
-    const rows = db.prepare(`
-      SELECT
-        personal_invoices.invoice_key,
-        personal_invoices.invoice_id,
-        personal_invoices.issued_at,
-        personal_invoices.amount AS invoice_amount,
-        personal_invoices.seller_business_account_number,
-        personal_invoices.seller_name,
-        personal_invoices.seller_addr,
-        items.item_key,
-        items.item_sequence_number,
-        items.item_quantity,
-        items.item_unit_price,
-        items.item_paid_amount,
-        items.item_product_name,
-        items.category
-      FROM personal_invoices
-      LEFT JOIN personal_invoice_items AS items
-        ON items.invoice_key = personal_invoices.invoice_key
-        AND ${activeImportSql("personal_invoice_items", "items")}
-      WHERE personal_invoices.status = ?
-        AND ${activeImportSql("personal_invoices")}
-      ORDER BY personal_invoices.issued_at, personal_invoices.invoice_key,
-        items.item_sequence_number, items.item_key
-    `).all("confirmed") as SpendingRow[];
-    const accountRows = db.prepare(`
-      SELECT statement_row_id, bank, account_number, currency,
-        COALESCE(transaction_date, accounting_date) AS date,
-        transaction_time, description, note, withdrawal_amount, deposit_amount
-      FROM account_transactions
-      WHERE (withdrawal_amount > 0 OR deposit_amount > 0)
-        AND COALESCE(transaction_date, accounting_date) IS NOT NULL
-        AND ${activeImportSql("account_transactions")}
-      ORDER BY date, statement_row_id
-    `).all() as AccountRow[];
-    const cardPaymentRows = db.prepare(`
-      SELECT COALESCE(consume_date, posting_date) AS date, twd_amount
-      FROM credit_card_statement_lines
-      WHERE twd_amount < 0
-        AND COALESCE(consume_date, posting_date) IS NOT NULL
-        AND ${activeImportSql("credit_card_statement_lines")}
-    `).all() as CardPaymentRow[];
-    const overrideRows = db.prepare(`
-      SELECT statement_row_id, state, category, automatic_state,
-        automatic_reason, updated_at
-      FROM spending_transaction_overrides
-    `).all() as OverrideRow[];
-
+  const { spending } = createFinancialQuery(ledgerDir).current({
+    kind: "current",
+    product: "spending",
+  });
+  {
+    const rows = spending.invoices;
+    const accountRows = spending.accountTransactions;
+    const cardPaymentRows = spending.cardPayments;
+    const overrideRows = spending.overrides;
     const invoices: SpendingInvoiceDto[] = [];
     const invoicesByKey = new Map<string, SpendingInvoiceDto>();
     for (const row of rows) {
@@ -163,7 +87,7 @@ export function loadSpending(
         });
       }
     }
-    const accountTransaction = (row: AccountRow, amount: number): SpendingAccountTransactionInput => ({
+    const accountTransaction = (row: LegacySpendingAccountRow, amount: number): SpendingAccountTransactionInput => ({
       statementRowId: row.statement_row_id,
       bank: row.bank,
       accountNumber: row.account_number,
@@ -180,11 +104,11 @@ export function loadSpending(
     const counterpartDeposits = accountRows
       .filter((row) => Number(row.deposit_amount) > 0)
       .map((row) => accountTransaction(row, Number(row.deposit_amount)));
-    const cardPayments: SpendingCardPaymentInput[] = cardPaymentRows.map((row) => ({
+    const cardPayments: SpendingCardPaymentInput[] = cardPaymentRows.map((row: LegacySpendingCardPaymentRow) => ({
       date: row.date,
       amount: Math.abs(Number(row.twd_amount)),
     }));
-    const overrides: SpendingOverrideDto[] = overrideRows.map((row) => ({
+    const overrides: SpendingOverrideDto[] = overrideRows.map((row: LegacySpendingOverrideRow) => ({
       statementRowId: row.statement_row_id,
       state: row.state,
       category: row.category,
@@ -201,8 +125,6 @@ export function loadSpending(
       selectedMonth,
       selectedCategory,
     });
-  } finally {
-    db.close();
   }
 }
 

--- a/src/workflows/cathay-statements-canonical.check.ts
+++ b/src/workflows/cathay-statements-canonical.check.ts
@@ -72,6 +72,34 @@ try {
   });
   assert.equal(lineage.entries.length, 1);
 
+  const multiDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-workflow-canonical-multi-"));
+  try {
+    const secondAccount = "SYNTHETIC-ACCOUNT-002";
+    const secondRaw = CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace("SYNTHETIC-ACCOUNT-001", secondAccount);
+    const multiClient: CathayDomesticStatementsClient = {
+      fetchDomesticAccounts: async () => [
+        { accountNo: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, currency: "TWD", branchName: "Synthetic branch 1" },
+        { accountNo: secondAccount, currency: "TWD", branchName: "Synthetic branch 2" },
+      ],
+      fetchTransferDetailsRaw: async (_session, accountNo) => accountNo === secondAccount ? secondRaw : CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse,
+    };
+    const multiOutput = await downloadCathayStatements(page, "one_year", [], session, {
+      ...options,
+      canonicalLedgerDir: multiDir,
+      writeStatementFiles: async (account, _range, statement) => ({
+        accountId: account.accountNo, account: account.accountNo, queryPeriods: [], branchName: account.branchName ?? "", baseName: "multi", csvFilename: "multi.csv", csvPath: "multi.csv", csvBytes: 0, jsonFilename: "multi.json", jsonPath: "multi.json", jsonBytes: 0, rowCount: statement.details?.length ?? 0,
+      }),
+    }, multiClient);
+    assert.equal(multiOutput.length, 2);
+    const multiDb = openCanonicalDatabase(multiDir, { readOnly: true });
+    try {
+      assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, 1);
+      assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 1);
+      assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM capture_scopes").get()?.count, 2);
+      assert.equal(multiDb.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 2);
+    } finally { multiDb.close(); }
+  } finally { await rm(multiDir, { recursive: true, force: true }); }
+
   const failingDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-workflow-canonical-fail-"));
   try {
     let legacyWriterCalls = 0;
@@ -101,6 +129,36 @@ try {
   } finally {
     await rm(failingDir, { recursive: true, force: true });
   }
+
+  const failingMultiDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-workflow-canonical-fail-multi-"));
+  try {
+    let multiWriterCalls = 0;
+    const secondAccount = "SYNTHETIC-ACCOUNT-002";
+    const failingMultiClient: CathayDomesticStatementsClient = {
+      fetchDomesticAccounts: async () => [
+        { accountNo: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo, currency: "TWD" },
+        { accountNo: secondAccount, currency: "TWD" },
+      ],
+      fetchTransferDetailsRaw: async (_session, accountNo) => accountNo === secondAccount
+        ? CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"returnCode":"0000"', '"returnCode":"000"')
+        : CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse,
+    };
+    await assert.rejects(
+      () => downloadCathayStatements(page, "one_year", [], session, {
+        ...options,
+        canonicalLedgerDir: failingMultiDir,
+        writeStatementFiles: async (...args) => { multiWriterCalls += 1; return options.writeStatementFiles!(...args); },
+      }, failingMultiClient),
+      /returnCode was not 0000/,
+    );
+    assert.equal(multiWriterCalls, 0);
+    const db = openCanonicalDatabase(failingMultiDir);
+    try {
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM canonical_commits").get()?.count, 0);
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 0);
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 0);
+    } finally { db.close(); }
+  } finally { await rm(failingMultiDir, { recursive: true, force: true }); }
 } finally {
   await rm(ledgerDir, { recursive: true, force: true });
 }

--- a/src/workflows/cathay-statements-canonical.check.ts
+++ b/src/workflows/cathay-statements-canonical.check.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  CATHAY_DOMESTIC_DEPOSIT_FIXTURE,
+  createCathayCanonicalFinancialQuery,
+  openCanonicalDatabase,
+} from "../ledger/canonical/cathay-domestic-deposit.ts";
+import {
+  downloadCathayStatements,
+  type CathayDomesticStatementsClient,
+  type CathayDomesticWorkflowOptions,
+} from "./cathay-statements.ts";
+
+const ledgerDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-workflow-canonical-"));
+const page = {
+  goto: async () => undefined,
+  waitForLoadState: async () => undefined,
+} as never;
+const downloads = [] as Array<{ rowCount: number; account: string }>;
+const client: CathayDomesticStatementsClient = {
+  fetchDomesticAccounts: async () => [{
+    accountNo: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo,
+    currency: "TWD",
+    branchName: "Synthetic branch",
+  }],
+  fetchTransferDetailsRaw: async () => CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse,
+};
+const options: CathayDomesticWorkflowOptions = {
+  canonicalLedgerDir: ledgerDir,
+  sourceConnectionId: "workflow-synthetic-connection",
+  identityEpoch: "workflow-synthetic-epoch",
+  scope: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.scope,
+  syncState: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.syncState,
+  observedAt: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.observedAt,
+  writeStatementFiles: async (account, _dateRange, statement) => {
+    downloads.push({ rowCount: statement.details?.length ?? 0, account: account.accountNo });
+    return {
+      accountId: account.accountNo,
+      account: account.accountNo,
+      queryPeriods: [],
+      branchName: account.branchName ?? "",
+      baseName: "synthetic",
+      csvFilename: "synthetic.csv",
+      csvPath: "synthetic.csv",
+      csvBytes: 0,
+      jsonFilename: "synthetic.json",
+      jsonPath: "synthetic.json",
+      jsonBytes: 0,
+      rowCount: statement.details?.length ?? 0,
+    };
+  },
+};
+const session = { jwtToken: "synthetic-token", customerId: "synthetic-customer", idType: "synthetic" };
+
+try {
+  const output = await downloadCathayStatements(page, "one_year", [], session, options, client);
+  assert.equal(output.length, 1);
+  assert.deepEqual(downloads, [{ rowCount: 3, account: CATHAY_DOMESTIC_DEPOSIT_FIXTURE.accountNo }]);
+
+  const query = createCathayCanonicalFinancialQuery(ledgerDir);
+  const current = await query.current({ kind: "current" });
+  assert.equal(current.transactions.length, 3);
+  const historical = await query.historical({
+    kind: "historical",
+    cutoff: { kind: "both", financialAt: "2026-12-31", knowledgeAt: String(current.commitSequence) },
+  });
+  assert.equal(historical.transactions.length, 3);
+  const lineage = await query.lineage({
+    kind: "lineage",
+    subject: { kind: "transaction", id: current.transactions[0]!.id },
+  });
+  assert.equal(lineage.entries.length, 1);
+
+  const failingDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "cathay-workflow-canonical-fail-"));
+  try {
+    let legacyWriterCalls = 0;
+    const failingClient: CathayDomesticStatementsClient = {
+      ...client,
+      fetchTransferDetailsRaw: async () => CATHAY_DOMESTIC_DEPOSIT_FIXTURE.rawResponse.replace('"returnCode":"0000"', '"returnCode":"000"'),
+    };
+    await assert.rejects(
+      () => downloadCathayStatements(page, "one_year", [], session, {
+        ...options,
+        canonicalLedgerDir: failingDir,
+        writeStatementFiles: async (...args) => {
+          legacyWriterCalls += 1;
+          return options.writeStatementFiles!(...args);
+        },
+      }, failingClient),
+      /returnCode was not 0000/,
+    );
+    assert.equal(legacyWriterCalls, 0);
+    const db = openCanonicalDatabase(failingDir);
+    try {
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM source_captures").get()?.count, 0);
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM source_sync_states").get()?.count, 0);
+    } finally {
+      db.close();
+    }
+  } finally {
+    await rm(failingDir, { recursive: true, force: true });
+  }
+} finally {
+  await rm(ledgerDir, { recursive: true, force: true });
+}

--- a/src/workflows/cathay-statements.ts
+++ b/src/workflows/cathay-statements.ts
@@ -6,6 +6,12 @@ import type { Locator, Page } from "playwright";
 import { z } from "zod";
 import { navigateToCathayLoginForm } from "./cathay-login.ts";
 import { emitHumanAssistanceStage } from "./human-assistance.ts";
+import { DEFAULT_LEDGER_DIR } from "../ledger/db/client.ts";
+import {
+  CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+  CATHAY_DOMESTIC_DEPOSIT_STREAM,
+  commitCathayDomesticDeposit,
+} from "../ledger/canonical/cathay-domestic-deposit.ts";
 
 const DOMESTIC_STATEMENTS_URL =
   "https://www.cathaybk.com.tw/OnlineBanking/AcctInq/B0103_TxnDtlInq";
@@ -110,6 +116,31 @@ export type CathayStatementDownload = {
   rowCount: number;
 };
 
+export type CathayDomesticStatementsClient = {
+  fetchDomesticAccounts(session: CathaySession, filters: string[]): Promise<CathayAccount[]>;
+  fetchTransferDetailsRaw(
+    session: CathaySession,
+    accountNo: string,
+    dateRange: CathayDateRange,
+  ): Promise<string>;
+};
+
+export type CathayDomesticWorkflowOptions = {
+  /** Application-owned canonical store path; defaults to the existing LEDGER_DIR convention. */
+  canonicalLedgerDir?: string;
+  /** Sanitized operational source scope, never a credential or user identity. */
+  sourceConnectionId?: string;
+  identityEpoch?: string;
+  scope?: { startDate: string; endDate: string; complete?: boolean };
+  syncState?: { cursor: string };
+  observedAt?: string;
+  writeStatementFiles?: (
+    account: CathayAccount,
+    dateRange: CathayDateRange,
+    statement: CathayTransferResult,
+  ) => Promise<CathayStatementDownload>;
+};
+
 export type CathaySession = {
   jwtToken: string;
   customerId: string;
@@ -125,7 +156,7 @@ type CathayApiResponse<T> = {
   returnDesc?: string;
 };
 
-type CathayAccount = {
+export type CathayAccount = {
   currency?: string;
   accountNo: string;
   branchName?: string;
@@ -152,7 +183,7 @@ type CathayTransferDetail = {
   memo?: string;
 };
 
-type CathayTransferResult = {
+export type CathayTransferResult = {
   queryStatus?: string;
   accountNumber?: string;
   count?: number;
@@ -685,12 +716,7 @@ export class CathayApiClient {
     dateRange: z.infer<typeof dateRangeSchema>,
   ): Promise<CathayTransferResult> {
     const raw = await this.fetchTransferDetailsRaw(session, accountNo, dateRange);
-    const response = JSON.parse(raw) as CathayApiResponse<CathayTransferResult>;
-    const result = response.content?.datas?.[0];
-    if (!result) {
-      throw new Error(`Cathay returned no statement data for ${maskAccountLabel(accountNo)}.`);
-    }
-    return result;
+    return parseCathayTransferResponse(raw, accountNo);
   }
 
   /** Preserve the provider response lexemes for canonical admission before JSON numeric coercion. */
@@ -760,6 +786,15 @@ export class CathayApiClient {
 
     return raw;
   }
+}
+
+function parseCathayTransferResponse(raw: string, accountNo: string): CathayTransferResult {
+  const response = JSON.parse(raw) as CathayApiResponse<CathayTransferResult>;
+  const result = response.content?.datas?.[0];
+  if (!result) {
+    throw new Error(`Cathay returned no statement data for ${maskAccountLabel(accountNo)}.`);
+  }
+  return result;
 }
 
 export async function createCathaySession(page: Page): Promise<CathaySession> {
@@ -833,24 +868,56 @@ export async function downloadCathayStatements(
   dateRange: CathayDateRange,
   accountFilters: string[],
   cathaySession?: CathaySession,
+  options: CathayDomesticWorkflowOptions = {},
+  client: CathayDomesticStatementsClient = new CathayApiClient(page),
 ): Promise<CathayStatementDownload[]> {
-  const apiClient = new CathayApiClient(page);
-  const session = cathaySession ?? (await apiClient.createSession());
-  const accounts = await apiClient.fetchDomesticAccounts(
+  const session = cathaySession ?? (await new CathayApiClient(page).createSession());
+  const accounts = await client.fetchDomesticAccounts(
     session,
     accountFilters,
   );
 
   await openDomesticStatementsPage(page);
 
+  const canonicalLedgerDir = options.canonicalLedgerDir
+    ?? process.env.OCTOPUSBEAK_CANONICAL_LEDGER_DIR
+    ?? process.env.LEDGER_DIR
+    ?? DEFAULT_LEDGER_DIR;
+  const sourceConnectionId = options.sourceConnectionId
+    ?? process.env.CATHAY_SOURCE_CONNECTION_REF
+    ?? "cathay-default-source";
+  const identityEpoch = options.identityEpoch
+    ?? process.env.CATHAY_IDENTITY_EPOCH
+    ?? "cathay-domestic-deposit-v1";
+  const bounds = dateRangeBounds(dateRange);
+  const scope = {
+    startDate: options.scope?.startDate ?? bounds.startDate,
+    endDate: options.scope?.endDate ?? bounds.endDate,
+    complete: options.scope?.complete ?? true,
+  };
+  const writeFiles = options.writeStatementFiles ?? writeStatementFiles;
+  const observedAt = options.observedAt ?? new Date().toISOString();
   const downloads: CathayStatementDownload[] = [];
   for (const account of accounts) {
-    const statement = await apiClient.fetchTransferDetails(
+    const rawResponse = await client.fetchTransferDetailsRaw(
       session,
       account.accountNo,
       dateRange,
     );
-    downloads.push(await writeStatementFiles(account, dateRange, statement));
+    const statement = parseCathayTransferResponse(rawResponse, account.accountNo);
+    commitCathayDomesticDeposit(canonicalLedgerDir, {
+      rawResponse,
+      sourceConnectionId,
+      identityEpoch,
+      accountNo: account.accountNo,
+      currency: account.currency ?? "TWD",
+      authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+      stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
+      scope,
+      syncState: options.syncState ?? { cursor: scope.endDate },
+      observedAt,
+    });
+    downloads.push(await writeFiles(account, dateRange, statement));
   }
 
   return downloads;

--- a/src/workflows/cathay-statements.ts
+++ b/src/workflows/cathay-statements.ts
@@ -10,7 +10,8 @@ import { DEFAULT_LEDGER_DIR } from "../ledger/db/client.ts";
 import {
   CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
   CATHAY_DOMESTIC_DEPOSIT_STREAM,
-  commitCathayDomesticDeposit,
+  commitCathayDomesticDepositSync,
+  type CathayStagedCapturePage,
 } from "../ledger/canonical/cathay-domestic-deposit.ts";
 
 const DOMESTIC_STATEMENTS_URL =
@@ -896,7 +897,8 @@ export async function downloadCathayStatements(
   };
   const writeFiles = options.writeStatementFiles ?? writeStatementFiles;
   const observedAt = options.observedAt ?? new Date().toISOString();
-  const downloads: CathayStatementDownload[] = [];
+  const stagedPages: CathayStagedCapturePage[] = [];
+  const stagedStatements: Array<{ account: CathayAccount; statement: CathayTransferResult }> = [];
   for (const account of accounts) {
     const rawResponse = await client.fetchTransferDetailsRaw(
       session,
@@ -904,20 +906,33 @@ export async function downloadCathayStatements(
       dateRange,
     );
     const statement = parseCathayTransferResponse(rawResponse, account.accountNo);
-    await commitCathayDomesticDeposit(canonicalLedgerDir, {
-      rawResponse,
-      sourceConnectionId,
-      identityEpoch,
+    stagedStatements.push({ account, statement });
+    stagedPages.push({
       accountNo: account.accountNo,
-      currency: account.currency ?? "TWD",
-      authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
-      stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
+      currency: (account.currency ?? "TWD") as "TWD",
       scope,
-      syncState: options.syncState ?? { cursor: null },
-      observedAt,
+      pageOrdinal: 0,
+      requestPageToken: null,
+      nextPageToken: null,
+      rawResponse,
+      contractFingerprint: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+      preflightFingerprint: "cathay/domestic-deposit/collection-v1",
+      absenceAuthority: "comparable-complete-range",
     });
-    downloads.push(await writeFiles(account, dateRange, statement));
   }
+
+  if (stagedPages.length === 0) return [];
+  await commitCathayDomesticDepositSync(canonicalLedgerDir, {
+    sourceConnectionId,
+    identityEpoch,
+    authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
+    stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
+    syncState: options.syncState ?? { cursor: null },
+    observedAt,
+    pages: stagedPages,
+  });
+  const downloads: CathayStatementDownload[] = [];
+  for (const { account, statement } of stagedStatements) downloads.push(await writeFiles(account, dateRange, statement));
 
   return downloads;
 }

--- a/src/workflows/cathay-statements.ts
+++ b/src/workflows/cathay-statements.ts
@@ -131,8 +131,8 @@ export type CathayDomesticWorkflowOptions = {
   /** Sanitized operational source scope, never a credential or user identity. */
   sourceConnectionId?: string;
   identityEpoch?: string;
-  scope?: { startDate: string; endDate: string; complete?: boolean };
-  syncState?: { cursor: string };
+  scope?: { startDate: string; endDate: string };
+  syncState?: { cursor?: string | null };
   observedAt?: string;
   writeStatementFiles?: (
     account: CathayAccount,
@@ -893,7 +893,6 @@ export async function downloadCathayStatements(
   const scope = {
     startDate: options.scope?.startDate ?? bounds.startDate,
     endDate: options.scope?.endDate ?? bounds.endDate,
-    complete: options.scope?.complete ?? true,
   };
   const writeFiles = options.writeStatementFiles ?? writeStatementFiles;
   const observedAt = options.observedAt ?? new Date().toISOString();
@@ -914,7 +913,7 @@ export async function downloadCathayStatements(
       authorityRoute: CATHAY_DOMESTIC_DEPOSIT_AUTHORITY,
       stream: CATHAY_DOMESTIC_DEPOSIT_STREAM,
       scope,
-      syncState: options.syncState ?? { cursor: scope.endDate },
+      syncState: options.syncState ?? { cursor: null },
       observedAt,
     });
     downloads.push(await writeFiles(account, dateRange, statement));

--- a/src/workflows/cathay-statements.ts
+++ b/src/workflows/cathay-statements.ts
@@ -905,7 +905,7 @@ export async function downloadCathayStatements(
       dateRange,
     );
     const statement = parseCathayTransferResponse(rawResponse, account.accountNo);
-    commitCathayDomesticDeposit(canonicalLedgerDir, {
+    await commitCathayDomesticDeposit(canonicalLedgerDir, {
       rawResponse,
       sourceConnectionId,
       identityEpoch,

--- a/src/workflows/cathay-statements.ts
+++ b/src/workflows/cathay-statements.ts
@@ -591,8 +591,12 @@ function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-class CathayApiClient {
-  constructor(private page: Page) {}
+export class CathayApiClient {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
 
   async createSession(): Promise<CathaySession> {
     const result = (await this.page.evaluate(async () => {
@@ -680,8 +684,23 @@ class CathayApiClient {
     accountNo: string,
     dateRange: z.infer<typeof dateRangeSchema>,
   ): Promise<CathayTransferResult> {
+    const raw = await this.fetchTransferDetailsRaw(session, accountNo, dateRange);
+    const response = JSON.parse(raw) as CathayApiResponse<CathayTransferResult>;
+    const result = response.content?.datas?.[0];
+    if (!result) {
+      throw new Error(`Cathay returned no statement data for ${maskAccountLabel(accountNo)}.`);
+    }
+    return result;
+  }
+
+  /** Preserve the provider response lexemes for canonical admission before JSON numeric coercion. */
+  async fetchTransferDetailsRaw(
+    session: CathaySession,
+    accountNo: string,
+    dateRange: z.infer<typeof dateRangeSchema>,
+  ): Promise<string> {
     const bounds = dateRangeBounds(dateRange);
-    const response = await this.apiPost<CathayTransferResult>(
+    return await this.apiPostRaw(
       "/OnlineBankingApi/ClientBank/Api/ClientBank/B_ACCT_Q_TransferDetail",
       session,
       {
@@ -698,11 +717,6 @@ class CathayApiClient {
         },
       },
     );
-    const result = response.content?.datas?.[0];
-    if (!result) {
-      throw new Error(`Cathay returned no statement data for ${maskAccountLabel(accountNo)}.`);
-    }
-    return result;
   }
 
   private async apiPost<T>(
@@ -710,7 +724,16 @@ class CathayApiClient {
     session: Pick<CathaySession, "jwtToken">,
     body: unknown,
   ): Promise<CathayApiResponse<T>> {
-    const result = (await this.page.evaluate(
+    const raw = await this.apiPostRaw(path, session, body);
+    return JSON.parse(raw) as CathayApiResponse<T>;
+  }
+
+  private async apiPostRaw(
+    path: string,
+    session: Pick<CathaySession, "jwtToken">,
+    body: unknown,
+  ): Promise<string> {
+    const raw = await this.page.evaluate(
       async ({ path, token, body }) => {
         const response = await fetch(path, {
           method: "POST",
@@ -723,10 +746,11 @@ class CathayApiClient {
           body: JSON.stringify(body),
         });
         if (!response.ok) throw new Error(`${response.status} for ${path}`);
-        return await response.json();
+        return await response.text();
       },
       { path, token: session.jwtToken, body },
-    )) as CathayApiResponse<T>;
+    );
+    const result = JSON.parse(raw) as CathayApiResponse<unknown>;
 
     if (!result.success) {
       throw new Error(
@@ -734,7 +758,7 @@ class CathayApiClient {
       );
     }
 
-    return result;
+    return raw;
   }
 }
 


### PR DESCRIPTION
This pull request introduces a significant refactor of the server-side ledger data loading logic to use a new `createFinancialQuery` abstraction, replacing direct database access and manual query composition in the assets, liabilities, and overview modules. This change centralizes and standardizes data loading, improves maintainability, and paves the way for future extensibility. Additionally, new runtime utilities for SQLite configuration and robust busy handling are added, and a comprehensive type and runtime check suite for the financial query boundary is introduced.

**Refactor: Use Financial Query Abstraction for Data Loading**
- Migrated `loadAssets`, `loadLiabilities`, and `loadOverview` to use `createFinancialQuery` for all data loading, removing direct usage of `openLedgerDrizzle`, schema imports, and manual SQL queries. This centralizes logic and ensures consistent visibility and unavailable account handling. [[1]](diffhunk://#diff-438f574a2d1f9c3c9e9042f1c05e861c57782a574efdb4c7c1209fbe10f8bc81L1-R17) [[2]](diffhunk://#diff-1f5b1b6fdf2a5315bb9f1df76450d5280cebb2655ccdea4066503383264232a0L1-L64) [[3]](diffhunk://#diff-fbf980ee9411d76566d14a651607faa7d62eaa0fdbb1d20eb56b5bcb559e407dL1-R44)
- Updated exchange rate loading in `loadOverview` to use the financial query boundary, supporting both latest and historical rates, and removed direct SQL queries. [[1]](diffhunk://#diff-fbf980ee9411d76566d14a651607faa7d62eaa0fdbb1d20eb56b5bcb559e407dL1-R44) [[2]](diffhunk://#diff-fbf980ee9411d76566d14a651607faa7d62eaa0fdbb1d20eb56b5bcb559e407dL136-L144)

**Infrastructure: SQLite Runtime Utilities**
- Added `src/ledger/canonical/canonical-runtime.ts` with functions to configure SQLite PRAGMAs, verify runtime invariants, and serialize writer operations with robust busy-retry logic. Introduced `CanonicalBusyRetryExhaustedError` for error reporting.

**Testing & Type Safety: Financial Query Boundary Checks**
- Introduced `financial-query.check.ts`, a comprehensive test file that asserts all loader modules use the new abstraction, verifies type contracts, and ensures legacy adapters do not leak into the new boundary. It seeds a mock ledger for integration-style checks.

**Cleanup: Remove Legacy Code**
- Removed obsolete code for manual data loading, unavailable account handling, and direct SQLite connection management from affected modules. [[1]](diffhunk://#diff-438f574a2d1f9c3c9e9042f1c05e861c57782a574efdb4c7c1209fbe10f8bc81L1-R17) [[2]](diffhunk://#diff-1f5b1b6fdf2a5315bb9f1df76450d5280cebb2655ccdea4066503383264232a0L1-L64) [[3]](diffhunk://#diff-fbf980ee9411d76566d14a651607faa7d62eaa0fdbb1d20eb56b5bcb559e407dL1-R44) [[4]](diffhunk://#diff-438f574a2d1f9c3c9e9042f1c05e861c57782a574efdb4c7c1209fbe10f8bc81L88-L90) [[5]](diffhunk://#diff-fbf980ee9411d76566d14a651607faa7d62eaa0fdbb1d20eb56b5bcb559e407dL136-L144)

**Summary:**  
These changes modernize the data loading layer, improve reliability, and set the stage for future enhancements to the ledger system.## Summary

- Add canonical runtime and Cathay domestic deposit validation.
- Introduce shared financial query checks and server-side asset, liability, and overview loaders.
- Update spending storage and Cathay statement workflows to use the canonical flow.

## Testing

- Added and updated `.check.ts` coverage for canonical runtime, Cathay deposits, financial queries, and statement workflows.
- Not run (not requested).